### PR TITLE
feat: implement Phase 4 — Agent Integration & Runtime Service

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -59,16 +59,16 @@ Work is broken into phases. Each phase produces a usable increment. Later phases
 
 > Adapter interface, Copilot SDK integration, runtime service.
 
-- [ ] `AgentAdapterInterface` — abstract base class
-- [ ] `FakeAgentAdapter` — test double emitting scripted events
-- [ ] `CopilotAdapter` — wraps Python Copilot SDK
-- [ ] Callback-to-iterator bridge (SDK callbacks → `AsyncIterator[SessionEvent]`)
-- [ ] `SessionConfig` resolution from job + repo config
-- [ ] `RuntimeService` — asyncio task management, capacity enforcement, queueing
-- [ ] `ExecutionStrategy` interface + `SingleAgentExecutor`
-- [ ] Strategy registry and selection
-- [ ] Session heartbeat generation (30s interval, 90s warning, 5-min timeout)
-- [ ] MCP server discovery (`.vscode/mcp.json` + global config merge)
+- [x] `AgentAdapterInterface` — abstract base class
+- [x] `FakeAgentAdapter` — test double emitting scripted events
+- [x] `CopilotAdapter` — wraps Python Copilot SDK
+- [x] Callback-to-iterator bridge (SDK callbacks → `AsyncIterator[SessionEvent]`)
+- [x] `SessionConfig` resolution from job + repo config
+- [x] `RuntimeService` — asyncio task management, capacity enforcement, queueing
+- [x] `ExecutionStrategy` interface + `SingleAgentExecutor`
+- [x] Strategy registry and selection
+- [x] Session heartbeat generation (30s interval, 90s warning, 5-min timeout)
+- [x] MCP server discovery (`.vscode/mcp.json` + global config merge)
 
 ---
 

--- a/backend/api/jobs.py
+++ b/backend/api/jobs.py
@@ -69,6 +69,7 @@ def _job_to_response(job: object) -> JobResponse:
 async def create_job(
     body: CreateJobRequest,
     svc: Annotated[JobService, Depends(_get_job_service)],
+    session: Annotated[AsyncSession, Depends(_get_session)],
     request: Request,
 ) -> CreateJobResponse:
     """Create a new job."""
@@ -82,6 +83,9 @@ async def create_job(
         )
     except RepoNotAllowedError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    # Commit so the job row is visible to RuntimeService (separate session)
+    await session.commit()
 
     # Hand off to RuntimeService for execution / queueing
     runtime: RuntimeService = request.app.state.runtime_service

--- a/backend/api/jobs.py
+++ b/backend/api/jobs.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy.ext.asyncio import AsyncSession  # noqa: TC002
 
 from backend.config import TowerConfig, load_config
@@ -17,6 +17,9 @@ from backend.models.api_schemas import (
 from backend.persistence.job_repo import JobRepository
 from backend.services.git_service import GitService
 from backend.services.job_service import JobNotFoundError, JobService, RepoNotAllowedError, StateConflictError
+
+if TYPE_CHECKING:
+    from backend.services.runtime_service import RuntimeService
 
 router = APIRouter(tags=["jobs"])
 
@@ -66,6 +69,7 @@ def _job_to_response(job: object) -> JobResponse:
 async def create_job(
     body: CreateJobRequest,
     svc: Annotated[JobService, Depends(_get_job_service)],
+    request: Request,
 ) -> CreateJobResponse:
     """Create a new job."""
     try:
@@ -78,6 +82,14 @@ async def create_job(
         )
     except RepoNotAllowedError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    # Hand off to RuntimeService for execution / queueing
+    runtime: RuntimeService = request.app.state.runtime_service
+    await runtime.start_or_enqueue(job)
+
+    # Re-fetch to get updated state (may have been enqueued)
+    job = await svc.get_job(job.id)
+
     return CreateJobResponse(
         id=job.id,
         state=job.state,
@@ -124,6 +136,7 @@ async def get_job(
 async def cancel_job(
     job_id: str,
     svc: Annotated[JobService, Depends(_get_job_service)],
+    request: Request,
 ) -> JobResponse:
     """Cancel a running or queued job."""
     try:
@@ -132,6 +145,11 @@ async def cancel_job(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except StateConflictError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    # Also cancel the runtime task if running
+    runtime: RuntimeService = request.app.state.runtime_service
+    await runtime.cancel(job_id)
+
     return _job_to_response(job)
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -14,7 +14,9 @@ from backend.api import approvals, artifacts, events, health, jobs, settings, vo
 from backend.config import init_config, load_config
 from backend.persistence.database import create_engine, create_session_factory, run_migrations
 from backend.persistence.event_repo import EventRepository
+from backend.services.agent_adapter import CopilotAdapter
 from backend.services.event_bus import EventBus
+from backend.services.runtime_service import RuntimeService
 from backend.services.sse_manager import SSEManager
 
 if TYPE_CHECKING:
@@ -49,9 +51,24 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     event_bus.subscribe(_persist_and_broadcast)
 
+    # --- Runtime service ---
+    config = load_config()
+    adapter = CopilotAdapter()
+
+    runtime_service = RuntimeService(
+        session_factory=session_factory,
+        event_bus=event_bus,
+        adapter=adapter,
+        config=config,
+    )
+
+    # Recover orphaned jobs from a previous crash
+    await runtime_service.recover_on_startup()
+
     # Store on app.state for access from route handlers
     app.state.event_bus = event_bus
     app.state.sse_manager = sse_manager
+    app.state.runtime_service = runtime_service
 
     # Session factory available for route handlers that need ad-hoc sessions
     app.state.session_factory = session_factory
@@ -67,6 +84,7 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     app.dependency_overrides[jobs._get_session] = _session_dep
     yield
+    await runtime_service.shutdown()
     await sse_manager.close_all()
     app.dependency_overrides.clear()
     await engine.dispose()

--- a/backend/models/events.py
+++ b/backend/models/events.py
@@ -22,6 +22,7 @@ class DomainEventKind(StrEnum):
     job_succeeded = "JobSucceeded"
     job_failed = "JobFailed"
     job_canceled = "JobCanceled"
+    job_state_changed = "JobStateChanged"
     session_heartbeat = "SessionHeartbeat"
 
 

--- a/backend/services/agent_adapter.py
+++ b/backend/services/agent_adapter.py
@@ -2,13 +2,23 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
+import uuid
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
-from backend.models.domain import SessionConfig, SessionEvent
+import structlog
+
+from backend.models.domain import SessionConfig, SessionEvent, SessionEventKind
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
+
+    from copilot.generated.session_events import SessionEvent as SdkSessionEvent
+    from copilot.session import CopilotSession
+
+log = structlog.get_logger()
 
 
 class AgentAdapterInterface(ABC):
@@ -32,17 +42,81 @@ class AgentAdapterInterface(ABC):
         """Abort the current message processing. Session remains valid."""
 
 
-class FakeAgentAdapter(AgentAdapterInterface):
-    """Test double that emits scripted events."""
+class CopilotAdapter(AgentAdapterInterface):
+    """Wraps the Python Copilot SDK behind the adapter interface.
+
+    Uses a callback-to-iterator bridge: SDK callbacks push SessionEvent
+    items onto an asyncio.Queue; stream_events() yields from the queue.
+    """
+
+    def __init__(self) -> None:
+        self._queues: dict[str, asyncio.Queue[SessionEvent | None]] = {}
+        self._sessions: dict[str, CopilotSession] = {}
 
     async def create_session(self, config: SessionConfig) -> str:
-        return "fake-session-1"
+        from copilot import CopilotClient
+
+        client = CopilotClient()
+        session = await client.create_session({"working_directory": config.workspace_path})
+        session_id = str(uuid.uuid4())
+        queue: asyncio.Queue[SessionEvent | None] = asyncio.Queue()
+        self._queues[session_id] = queue
+        self._sessions[session_id] = session
+
+        # Register SDK callback that bridges into the async queue
+        def _on_event(sdk_event: SdkSessionEvent) -> None:
+            kind_str = sdk_event.type.value if sdk_event.type else "log"
+            payload = sdk_event.data.to_dict() if sdk_event.data else {}
+            try:
+                kind = SessionEventKind(kind_str)
+            except ValueError:
+                kind = SessionEventKind.log
+                payload = {"level": "debug", "message": f"Unknown SDK event: {kind_str}"}
+            try:
+                queue.put_nowait(SessionEvent(kind=kind, payload=payload if isinstance(payload, dict) else {}))
+            except Exception:
+                log.warning("copilot_queue_put_failed", session_id=session_id)
+            if kind == SessionEventKind.done or kind == SessionEventKind.error:
+                with contextlib.suppress(Exception):
+                    queue.put_nowait(None)  # sentinel
+
+        session.on(_on_event)
+        # Send initial prompt
+        await session.send({"prompt": config.prompt, "mode": "immediate", "attachments": []})
+        log.info("copilot_session_created", session_id=session_id)
+        return session_id
 
     async def stream_events(self, session_id: str) -> AsyncIterator[SessionEvent]:
-        yield SessionEvent(kind="done", payload={})  # type: ignore[arg-type]
+        queue = self._queues.get(session_id)
+        if queue is None:
+            log.error("copilot_stream_no_queue", session_id=session_id)
+            yield SessionEvent(kind=SessionEventKind.error, payload={"message": "No queue for session"})
+            return
+        while True:
+            try:
+                event = await asyncio.wait_for(queue.get(), timeout=300)
+            except TimeoutError:
+                yield SessionEvent(
+                    kind=SessionEventKind.error,
+                    payload={"message": "Session timed out waiting for events"},
+                )
+                return
+            if event is None:
+                return
+            yield event
 
     async def send_message(self, session_id: str, message: str) -> None:
-        pass
+        session = self._sessions.get(session_id)
+        if session is None:
+            log.warning("copilot_send_no_session", session_id=session_id)
+            return
+        await session.send({"prompt": message, "mode": "immediate", "attachments": []})
 
     async def abort_session(self, session_id: str) -> None:
-        pass
+        session = self._sessions.get(session_id)
+        if session is None:
+            return
+        try:
+            await session.abort()
+        except Exception:
+            log.warning("copilot_abort_failed", session_id=session_id, exc_info=True)

--- a/backend/services/agent_adapter.py
+++ b/backend/services/agent_adapter.py
@@ -53,6 +53,11 @@ class CopilotAdapter(AgentAdapterInterface):
         self._queues: dict[str, asyncio.Queue[SessionEvent | None]] = {}
         self._sessions: dict[str, CopilotSession] = {}
 
+    def _cleanup_session(self, session_id: str) -> None:
+        """Remove session and queue references for a completed/aborted session."""
+        self._sessions.pop(session_id, None)
+        self._queues.pop(session_id, None)
+
     async def create_session(self, config: SessionConfig) -> str:
         from copilot import CopilotClient
 
@@ -82,7 +87,11 @@ class CopilotAdapter(AgentAdapterInterface):
 
         session.on(_on_event)
         # Send initial prompt
-        await session.send({"prompt": config.prompt, "mode": "immediate", "attachments": []})
+        try:
+            await session.send({"prompt": config.prompt, "mode": "immediate", "attachments": []})
+        except Exception:
+            self._cleanup_session(session_id)
+            raise
         log.info("copilot_session_created", session_id=session_id)
         return session_id
 
@@ -92,18 +101,21 @@ class CopilotAdapter(AgentAdapterInterface):
             log.error("copilot_stream_no_queue", session_id=session_id)
             yield SessionEvent(kind=SessionEventKind.error, payload={"message": "No queue for session"})
             return
-        while True:
-            try:
-                event = await asyncio.wait_for(queue.get(), timeout=300)
-            except TimeoutError:
-                yield SessionEvent(
-                    kind=SessionEventKind.error,
-                    payload={"message": "Session timed out waiting for events"},
-                )
-                return
-            if event is None:
-                return
-            yield event
+        try:
+            while True:
+                try:
+                    event = await asyncio.wait_for(queue.get(), timeout=300)
+                except TimeoutError:
+                    yield SessionEvent(
+                        kind=SessionEventKind.error,
+                        payload={"message": "Session timed out waiting for events"},
+                    )
+                    return
+                if event is None:
+                    return
+                yield event
+        finally:
+            self._cleanup_session(session_id)
 
     async def send_message(self, session_id: str, message: str) -> None:
         session = self._sessions.get(session_id)
@@ -120,3 +132,5 @@ class CopilotAdapter(AgentAdapterInterface):
             await session.abort()
         except Exception:
             log.warning("copilot_abort_failed", session_id=session_id, exc_info=True)
+        finally:
+            self._cleanup_session(session_id)

--- a/backend/services/execution_strategy.py
+++ b/backend/services/execution_strategy.py
@@ -57,3 +57,12 @@ class SingleAgentExecutor(ExecutionStrategy):
     async def abort(self) -> None:
         if self._adapter and self._session_id:
             await self._adapter.abort_session(self._session_id)
+
+
+# --- Strategy Registry ---
+
+from backend.models.api_schemas import StrategyKind  # noqa: E402
+
+STRATEGY_REGISTRY: dict[StrategyKind, type[ExecutionStrategy]] = {
+    StrategyKind.single_agent: SingleAgentExecutor,
+}

--- a/backend/services/job_service.py
+++ b/backend/services/job_service.py
@@ -133,9 +133,9 @@ class JobService:
             log.error("job_worktree_failed", job_id=job_id, error=str(exc))
             return job
 
-        # Initial state — queuing logic will be added in Phase 4 (RuntimeService)
-        # to respect max_concurrent_jobs from config.
-        initial_state = JobState.running
+        # Job starts as queued; RuntimeService.start_or_enqueue() transitions
+        # to running immediately when capacity allows, or keeps it queued.
+        initial_state = JobState.queued
 
         job = Job(
             id=job_id,

--- a/backend/services/runtime_service.py
+++ b/backend/services/runtime_service.py
@@ -148,6 +148,8 @@ class RuntimeService:
         self._tasks: dict[str, asyncio.Task[None]] = {}
         self._strategies: dict[str, ExecutionStrategy] = {}
         self._heartbeat_tasks: dict[str, asyncio.Task[None]] = {}
+        self._last_activity: dict[str, float] = {}
+        self._session_ids: dict[str, str] = {}
         self._dequeue_lock = asyncio.Lock()
 
     def _make_job_service(self, session: AsyncSession) -> JobService:
@@ -172,18 +174,19 @@ class RuntimeService:
 
     async def start_or_enqueue(self, job: Job) -> None:
         """Start the job if capacity allows, otherwise keep it queued."""
-        if self.running_count >= self.max_concurrent:
-            # Job is already queued from create_job; only transition if needed
-            if job.state != JobState.queued:
-                async with self._session_factory() as session:
-                    svc = self._make_job_service(session)
-                    await svc.transition_state(job.id, JobState.queued)
-                    await session.commit()
-                await self._publish_state_event(job.id, None, JobState.queued)
-            log.info("job_enqueued", job_id=job.id, running=self.running_count)
-            return
+        async with self._dequeue_lock:
+            if self.running_count >= self.max_concurrent:
+                # Job is already queued from create_job; only transition if needed
+                if job.state != JobState.queued:
+                    async with self._session_factory() as session:
+                        svc = self._make_job_service(session)
+                        await svc.transition_state(job.id, JobState.queued)
+                        await session.commit()
+                    await self._publish_state_event(job.id, None, JobState.queued)
+                log.info("job_enqueued", job_id=job.id, running=self.running_count)
+                return
 
-        await self._start_job(job)
+            await self._start_job(job)
 
     async def _start_job(self, job: Job) -> None:
         """Create an asyncio task to execute the job."""
@@ -232,6 +235,9 @@ class RuntimeService:
     ) -> None:
         """Execute a job strategy, translate events, and handle completion."""
         # Start heartbeat
+        import time
+
+        self._last_activity[job_id] = time.monotonic()
         heartbeat_task = asyncio.create_task(
             self._heartbeat_loop(job_id),
             name=f"heartbeat-{job_id}",
@@ -239,13 +245,23 @@ class RuntimeService:
         self._heartbeat_tasks[job_id] = heartbeat_task
 
         session_id: str | None = None
+        error_reason: str | None = None
         try:
             async for session_event in strategy.execute(config, self._adapter):
+                self._last_activity[job_id] = time.monotonic()
                 domain_event = self._translate_event(job_id, session_event)
                 if domain_event is not None:
                     if session_id is None and domain_event.payload.get("session_id"):
                         session_id = domain_event.payload["session_id"]
+                        self._session_ids[job_id] = session_id
+                    if domain_event.kind == DomainEventKind.job_failed:
+                        error_reason = domain_event.payload.get("message", "Agent error")
                     await self._event_bus.publish(domain_event)
+
+            if error_reason:
+                # An error event was received during execution
+                await self._fail_job(job_id, error_reason)
+                return
 
             # Strategy completed normally → succeeded
             async with self._session_factory() as session:
@@ -296,29 +312,36 @@ class RuntimeService:
             self._heartbeat_tasks.pop(job_id, None)
             self._tasks.pop(job_id, None)
             self._strategies.pop(job_id, None)
+            self._last_activity.pop(job_id, None)
+            self._session_ids.pop(job_id, None)
             # Check if any queued jobs can now start
             await self._dequeue_next()
 
     async def _heartbeat_loop(self, job_id: str) -> None:
-        """Emit periodic heartbeats for a running job."""
-        elapsed = 0.0
+        """Emit periodic heartbeats; timeout based on time since last activity."""
+        import time
+
         try:
             while True:
                 await asyncio.sleep(_HEARTBEAT_INTERVAL_S)
-                elapsed += _HEARTBEAT_INTERVAL_S
 
-                if elapsed >= _HEARTBEAT_TIMEOUT_S:
-                    log.warning("job_heartbeat_timeout", job_id=job_id, elapsed=elapsed)
-                    # Cancel the job task — it will be handled in _run_job
+                last = self._last_activity.get(job_id)
+                if last is None:
+                    return
+                since_last = time.monotonic() - last
+
+                if since_last >= _HEARTBEAT_TIMEOUT_S:
+                    log.warning("job_heartbeat_timeout", job_id=job_id, idle_s=since_last)
+                    await self._fail_job(job_id, "heartbeat_timeout")
                     task = self._tasks.get(job_id)
                     if task:
                         task.cancel()
                     return
 
-                warning = elapsed >= _HEARTBEAT_WARNING_S
-                if warning:
-                    log.warning("job_heartbeat_warning", job_id=job_id, elapsed=elapsed)
+                if since_last >= _HEARTBEAT_WARNING_S:
+                    log.warning("job_heartbeat_warning", job_id=job_id, idle_s=since_last)
 
+                session_id = self._session_ids.get(job_id, "")
                 await self._event_bus.publish(
                     DomainEvent(
                         event_id=_make_event_id(),
@@ -327,7 +350,7 @@ class RuntimeService:
                         kind=DomainEventKind.session_heartbeat,
                         payload={
                             "job_id": job_id,
-                            "session_id": "",
+                            "session_id": session_id,
                             "timestamp": datetime.now(UTC).isoformat(),
                         },
                     )
@@ -336,29 +359,18 @@ class RuntimeService:
             pass
 
     async def cancel(self, job_id: str) -> None:
-        """Cancel a running job by cancelling its asyncio task."""
+        """Cancel a running job by cancelling its asyncio task.
+
+        State transitions for non-running jobs (e.g. queued) are handled
+        by the service layer (JobService.cancel_job). This method only
+        interacts with in-memory runtime tasks.
+        """
         task = self._tasks.get(job_id)
         if task is not None:
             task.cancel()
             log.info("job_cancel_requested", job_id=job_id)
         else:
-            # Job might be queued, not running — just transition state
-            try:
-                async with self._session_factory() as session:
-                    svc = self._make_job_service(session)
-                    await svc.transition_state(job_id, JobState.canceled)
-                    await session.commit()
-                await self._event_bus.publish(
-                    DomainEvent(
-                        event_id=_make_event_id(),
-                        job_id=job_id,
-                        timestamp=datetime.now(UTC),
-                        kind=DomainEventKind.job_canceled,
-                        payload={"reason": "operator_cancel"},
-                    )
-                )
-            except Exception:
-                log.warning("cancel_queued_job_failed", job_id=job_id, exc_info=True)
+            log.info("job_cancel_no_running_task", job_id=job_id)
 
     async def send_message(self, job_id: str, message: str) -> None:
         """Send a message to a running job's strategy."""

--- a/backend/services/runtime_service.py
+++ b/backend/services/runtime_service.py
@@ -2,8 +2,478 @@
 
 from __future__ import annotations
 
+import asyncio
+import uuid
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import structlog
+
+from backend.models.domain import (
+    Job,
+    JobState,
+    MCPServerConfig,
+    SessionConfig,
+    SessionEvent,
+    SessionEventKind,
+)
+from backend.models.events import DomainEvent, DomainEventKind
+from backend.services.execution_strategy import STRATEGY_REGISTRY
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    from backend.config import TowerConfig
+    from backend.services.agent_adapter import AgentAdapterInterface
+    from backend.services.event_bus import EventBus
+    from backend.services.execution_strategy import ExecutionStrategy
+    from backend.services.job_service import JobService
+
+log = structlog.get_logger()
+
+# Heartbeat configuration
+_HEARTBEAT_INTERVAL_S = 30
+_HEARTBEAT_WARNING_S = 90
+_HEARTBEAT_TIMEOUT_S = 300  # 5 minutes
+
+
+def _discover_mcp_servers(repo_path: str, config: TowerConfig) -> dict[str, MCPServerConfig]:
+    """Discover MCP servers from .vscode/mcp.json and global config, respecting .tower.yml disabled list."""
+    import json
+    from pathlib import Path
+
+    import yaml
+
+    servers: dict[str, MCPServerConfig] = {}
+
+    # 1. Global config: tools.mcp section
+    global_config_path = Path.home() / ".tower" / "config.yaml"
+    if global_config_path.exists():
+        try:
+            with open(global_config_path) as f:
+                raw = yaml.safe_load(f) or {}
+            tools_mcp = raw.get("tools", {}).get("mcp", {})
+            if isinstance(tools_mcp, dict):
+                for name, entry in tools_mcp.items():
+                    if name == "disabled" or not isinstance(entry, dict):
+                        continue
+                    servers[name] = MCPServerConfig(
+                        command=entry.get("command", ""),
+                        args=entry.get("args", []),
+                        env=entry.get("env"),
+                    )
+        except Exception:
+            log.warning("mcp_global_config_read_failed", path=str(global_config_path))
+
+    # 2. Repo-level: .vscode/mcp.json (takes precedence over global)
+    mcp_json_path = Path(repo_path) / ".vscode" / "mcp.json"
+    if mcp_json_path.exists():
+        try:
+            with open(mcp_json_path) as f:
+                mcp_data = json.load(f)
+            repo_servers = mcp_data.get("servers", {})
+            if isinstance(repo_servers, dict):
+                for name, entry in repo_servers.items():
+                    if not isinstance(entry, dict):
+                        continue
+                    servers[name] = MCPServerConfig(
+                        command=entry.get("command", ""),
+                        args=entry.get("args", []),
+                        env=entry.get("env"),
+                    )
+        except Exception:
+            log.warning("mcp_repo_config_read_failed", path=str(mcp_json_path))
+
+    # 3. Apply .tower.yml disabled list
+    tower_yml_path = Path(repo_path) / ".tower.yml"
+    if tower_yml_path.exists():
+        try:
+            with open(tower_yml_path) as f:
+                tower_config = yaml.safe_load(f) or {}
+            disabled = tower_config.get("tools", {}).get("mcp", {}).get("disabled", [])
+            if isinstance(disabled, list):
+                for name in disabled:
+                    servers.pop(str(name), None)
+        except Exception:
+            log.warning("tower_yml_read_failed", path=str(tower_yml_path))
+
+    return servers
+
+
+def _resolve_protected_paths(repo_path: str) -> list[str]:
+    """Read protected_paths from .tower.yml if present."""
+    from pathlib import Path
+
+    import yaml
+
+    tower_yml = Path(repo_path) / ".tower.yml"
+    if not tower_yml.exists():
+        return []
+    try:
+        with open(tower_yml) as f:
+            data = yaml.safe_load(f) or {}
+        paths = data.get("protected_paths", [])
+        return [str(p) for p in paths] if isinstance(paths, list) else []
+    except Exception:
+        return []
+
+
+def _build_session_config(job: Job, config: TowerConfig) -> SessionConfig:
+    """Build a SessionConfig from a Job record and resolved config."""
+    workspace = job.worktree_path or job.repo
+    mcp_servers = _discover_mcp_servers(job.repo, config)
+    protected_paths = _resolve_protected_paths(job.repo)
+    return SessionConfig(
+        workspace_path=workspace,
+        prompt=job.prompt,
+        mcp_servers=mcp_servers,
+        protected_paths=protected_paths,
+    )
+
 
 class RuntimeService:
     """Manages active job tasks, capacity enforcement, and queueing."""
 
-    pass
+    def __init__(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        event_bus: EventBus,
+        adapter: AgentAdapterInterface,
+        config: TowerConfig,
+    ) -> None:
+        self._session_factory = session_factory
+        self._event_bus = event_bus
+        self._adapter = adapter
+        self._config = config
+        self._tasks: dict[str, asyncio.Task[None]] = {}
+        self._strategies: dict[str, ExecutionStrategy] = {}
+        self._heartbeat_tasks: dict[str, asyncio.Task[None]] = {}
+        self._dequeue_lock = asyncio.Lock()
+
+    def _make_job_service(self, session: AsyncSession) -> JobService:
+        from backend.persistence.job_repo import JobRepository
+        from backend.services.git_service import GitService
+        from backend.services.job_service import JobService
+
+        return JobService(
+            job_repo=JobRepository(session),
+            git_service=GitService(self._config),
+            config=self._config,
+        )
+
+    @property
+    def running_count(self) -> int:
+        """Number of currently running job tasks."""
+        return len(self._tasks)
+
+    @property
+    def max_concurrent(self) -> int:
+        return self._config.runtime.max_concurrent_jobs
+
+    async def start_or_enqueue(self, job: Job) -> None:
+        """Start the job if capacity allows, otherwise keep it queued."""
+        if self.running_count >= self.max_concurrent:
+            # Job is already queued from create_job; only transition if needed
+            if job.state != JobState.queued:
+                async with self._session_factory() as session:
+                    svc = self._make_job_service(session)
+                    await svc.transition_state(job.id, JobState.queued)
+                    await session.commit()
+                await self._publish_state_event(job.id, None, JobState.queued)
+            log.info("job_enqueued", job_id=job.id, running=self.running_count)
+            return
+
+        await self._start_job(job)
+
+    async def _start_job(self, job: Job) -> None:
+        """Create an asyncio task to execute the job."""
+        if job.id in self._tasks:
+            return  # Already running (race-condition guard)
+
+        from backend.models.api_schemas import StrategyKind
+
+        strategy_name = job.strategy or "single_agent"
+        try:
+            strategy_kind = StrategyKind(strategy_name)
+        except ValueError:
+            strategy_kind = StrategyKind.single_agent
+
+        strategy_cls = STRATEGY_REGISTRY.get(strategy_kind)
+        if strategy_cls is None:
+            log.error("unknown_strategy", strategy=strategy_name, job_id=job.id)
+            await self._fail_job(job.id, f"Unknown strategy: {strategy_name}")
+            return
+
+        strategy = strategy_cls()
+        self._strategies[job.id] = strategy
+
+        # Ensure job is in running state
+        if job.state != JobState.running:
+            async with self._session_factory() as session:
+                svc = self._make_job_service(session)
+                await svc.transition_state(job.id, JobState.running)
+                await session.commit()
+            await self._publish_state_event(job.id, job.state, JobState.running)
+
+        session_config = _build_session_config(job, self._config)
+
+        task = asyncio.create_task(
+            self._run_job(job.id, strategy, session_config),
+            name=f"job-{job.id}",
+        )
+        self._tasks[job.id] = task
+        log.info("job_started", job_id=job.id, strategy=strategy_name)
+
+    async def _run_job(
+        self,
+        job_id: str,
+        strategy: ExecutionStrategy,
+        config: SessionConfig,
+    ) -> None:
+        """Execute a job strategy, translate events, and handle completion."""
+        # Start heartbeat
+        heartbeat_task = asyncio.create_task(
+            self._heartbeat_loop(job_id),
+            name=f"heartbeat-{job_id}",
+        )
+        self._heartbeat_tasks[job_id] = heartbeat_task
+
+        session_id: str | None = None
+        try:
+            async for session_event in strategy.execute(config, self._adapter):
+                domain_event = self._translate_event(job_id, session_event)
+                if domain_event is not None:
+                    if session_id is None and domain_event.payload.get("session_id"):
+                        session_id = domain_event.payload["session_id"]
+                    await self._event_bus.publish(domain_event)
+
+            # Strategy completed normally → succeeded
+            async with self._session_factory() as session:
+                svc = self._make_job_service(session)
+                await svc.transition_state(job_id, JobState.succeeded)
+                await session.commit()
+            await self._event_bus.publish(
+                DomainEvent(
+                    event_id=_make_event_id(),
+                    job_id=job_id,
+                    timestamp=datetime.now(UTC),
+                    kind=DomainEventKind.job_succeeded,
+                    payload={},
+                )
+            )
+            log.info("job_succeeded", job_id=job_id)
+        except asyncio.CancelledError:
+            log.info("job_canceled_by_task", job_id=job_id)
+            try:
+                await strategy.abort()
+            except Exception:
+                log.warning("strategy_abort_failed", job_id=job_id, exc_info=True)
+            try:
+                async with self._session_factory() as session:
+                    svc = self._make_job_service(session)
+                    current = await svc.get_job(job_id)
+                    if current and current.state != JobState.canceled:
+                        await svc.transition_state(job_id, JobState.canceled)
+                        await session.commit()
+                        await self._event_bus.publish(
+                            DomainEvent(
+                                event_id=_make_event_id(),
+                                job_id=job_id,
+                                timestamp=datetime.now(UTC),
+                                kind=DomainEventKind.job_canceled,
+                                payload={"reason": "operator_cancel"},
+                            )
+                        )
+                    else:
+                        await session.commit()
+            except Exception:
+                log.warning("job_cancel_transition_failed", job_id=job_id, exc_info=True)
+        except Exception:
+            log.error("job_execution_failed", job_id=job_id, exc_info=True)
+            await self._fail_job(job_id, "Execution error")
+        finally:
+            heartbeat_task.cancel()
+            self._heartbeat_tasks.pop(job_id, None)
+            self._tasks.pop(job_id, None)
+            self._strategies.pop(job_id, None)
+            # Check if any queued jobs can now start
+            await self._dequeue_next()
+
+    async def _heartbeat_loop(self, job_id: str) -> None:
+        """Emit periodic heartbeats for a running job."""
+        elapsed = 0.0
+        try:
+            while True:
+                await asyncio.sleep(_HEARTBEAT_INTERVAL_S)
+                elapsed += _HEARTBEAT_INTERVAL_S
+
+                if elapsed >= _HEARTBEAT_TIMEOUT_S:
+                    log.warning("job_heartbeat_timeout", job_id=job_id, elapsed=elapsed)
+                    # Cancel the job task — it will be handled in _run_job
+                    task = self._tasks.get(job_id)
+                    if task:
+                        task.cancel()
+                    return
+
+                warning = elapsed >= _HEARTBEAT_WARNING_S
+                if warning:
+                    log.warning("job_heartbeat_warning", job_id=job_id, elapsed=elapsed)
+
+                await self._event_bus.publish(
+                    DomainEvent(
+                        event_id=_make_event_id(),
+                        job_id=job_id,
+                        timestamp=datetime.now(UTC),
+                        kind=DomainEventKind.session_heartbeat,
+                        payload={
+                            "job_id": job_id,
+                            "session_id": "",
+                            "timestamp": datetime.now(UTC).isoformat(),
+                        },
+                    )
+                )
+        except asyncio.CancelledError:
+            pass
+
+    async def cancel(self, job_id: str) -> None:
+        """Cancel a running job by cancelling its asyncio task."""
+        task = self._tasks.get(job_id)
+        if task is not None:
+            task.cancel()
+            log.info("job_cancel_requested", job_id=job_id)
+        else:
+            # Job might be queued, not running — just transition state
+            try:
+                async with self._session_factory() as session:
+                    svc = self._make_job_service(session)
+                    await svc.transition_state(job_id, JobState.canceled)
+                    await session.commit()
+                await self._event_bus.publish(
+                    DomainEvent(
+                        event_id=_make_event_id(),
+                        job_id=job_id,
+                        timestamp=datetime.now(UTC),
+                        kind=DomainEventKind.job_canceled,
+                        payload={"reason": "operator_cancel"},
+                    )
+                )
+            except Exception:
+                log.warning("cancel_queued_job_failed", job_id=job_id, exc_info=True)
+
+    async def send_message(self, job_id: str, message: str) -> None:
+        """Send a message to a running job's strategy."""
+        strategy = self._strategies.get(job_id)
+        if strategy is None:
+            log.warning("send_message_no_strategy", job_id=job_id)
+            return
+        await strategy.send_message(message)
+
+    async def _dequeue_next(self) -> None:
+        """Start the next queued job if capacity allows."""
+        async with self._dequeue_lock:
+            if self.running_count >= self.max_concurrent:
+                return
+            try:
+                async with self._session_factory() as session:
+                    svc = self._make_job_service(session)
+                    queued_jobs = await svc.list_jobs(state=JobState.queued, limit=1)
+                    jobs, _, _ = queued_jobs
+                if jobs:
+                    await self._start_job(jobs[0])
+            except Exception:
+                log.error("dequeue_failed", exc_info=True)
+
+    async def _fail_job(self, job_id: str, reason: str) -> None:
+        """Transition a job to failed state and publish the event."""
+        try:
+            async with self._session_factory() as session:
+                svc = self._make_job_service(session)
+                await svc.transition_state(job_id, JobState.failed)
+                await session.commit()
+            await self._event_bus.publish(
+                DomainEvent(
+                    event_id=_make_event_id(),
+                    job_id=job_id,
+                    timestamp=datetime.now(UTC),
+                    kind=DomainEventKind.job_failed,
+                    payload={"reason": reason},
+                )
+            )
+        except Exception:
+            log.error("fail_job_transition_failed", job_id=job_id, exc_info=True)
+
+    async def _publish_state_event(self, job_id: str, previous_state: str | None, new_state: str) -> None:
+        """Publish a job state change event."""
+        await self._event_bus.publish(
+            DomainEvent(
+                event_id=_make_event_id(),
+                job_id=job_id,
+                timestamp=datetime.now(UTC),
+                kind=DomainEventKind.job_state_changed,
+                payload={
+                    "previous_state": previous_state,
+                    "new_state": new_state,
+                },
+            )
+        )
+
+    def _translate_event(self, job_id: str, event: SessionEvent) -> DomainEvent | None:
+        """Translate a SessionEvent into a DomainEvent."""
+        mapping: dict[SessionEventKind, DomainEventKind] = {
+            SessionEventKind.log: DomainEventKind.log_line_emitted,
+            SessionEventKind.transcript: DomainEventKind.transcript_updated,
+            SessionEventKind.file_changed: DomainEventKind.diff_updated,
+            SessionEventKind.approval_request: DomainEventKind.approval_requested,
+            SessionEventKind.error: DomainEventKind.job_failed,
+        }
+        kind = mapping.get(event.kind)
+        if kind is None:
+            # 'done' events are handled at the _run_job level
+            return None
+        return DomainEvent(
+            event_id=_make_event_id(),
+            job_id=job_id,
+            timestamp=datetime.now(UTC),
+            kind=kind,
+            payload=event.payload,
+        )
+
+    async def recover_on_startup(self) -> None:
+        """Recover from a previous crash: fail orphaned running jobs, re-enqueue queued ones."""
+        async with self._session_factory() as session:
+            svc = self._make_job_service(session)
+            # Fail jobs that were 'running' or 'waiting_for_approval' — we can't reconnect
+            for state in (JobState.running, JobState.waiting_for_approval):
+                jobs, _, _ = await svc.list_jobs(state=state, limit=10000)
+                for job in jobs:
+                    log.warning("recovering_orphaned_job", job_id=job.id, state=state)
+                    await svc.transition_state(job.id, JobState.failed)
+                    await self._event_bus.publish(
+                        DomainEvent(
+                            event_id=_make_event_id(),
+                            job_id=job.id,
+                            timestamp=datetime.now(UTC),
+                            kind=DomainEventKind.job_failed,
+                            payload={"reason": "process_restarted"},
+                        )
+                    )
+
+            # Re-enqueue queued jobs
+            queued_jobs, _, _ = await svc.list_jobs(state=JobState.queued, limit=10000)
+            await session.commit()
+
+        for job in queued_jobs:
+            await self.start_or_enqueue(job)
+
+    async def shutdown(self) -> None:
+        """Gracefully shut down all running jobs."""
+        for job_id in list(self._tasks):
+            await self.cancel(job_id)
+        # Wait briefly for tasks to complete
+        tasks = list(self._tasks.values())
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+
+def _make_event_id() -> str:
+    return f"evt-{uuid.uuid4().hex[:12]}"

--- a/backend/services/sse_manager.py
+++ b/backend/services/sse_manager.py
@@ -41,6 +41,7 @@ _SSE_EVENT_TYPE: dict[DomainEventKind, str | None] = {
     DomainEventKind.job_succeeded: "job_state_changed",
     DomainEventKind.job_failed: "job_state_changed",
     DomainEventKind.job_canceled: "job_state_changed",
+    DomainEventKind.job_state_changed: "job_state_changed",
     DomainEventKind.session_heartbeat: "session_heartbeat",
 }
 

--- a/backend/tests/unit/test_job_service.py
+++ b/backend/tests/unit/test_job_service.py
@@ -157,7 +157,7 @@ class TestJobService:
             await session.commit()
 
         assert job.id == "job-1"
-        assert job.state == JobState.running
+        assert job.state == JobState.queued
         assert job.repo == "/repos/test"
         assert job.prompt == "Fix the bug"
         assert job.branch == "tower/job-1"
@@ -446,6 +446,8 @@ class TestJobService:
             await job_service.create_job(repo="/repos/test", prompt="Fix it")
             await session.commit()
 
+        # Phase 4: jobs start as queued, must transition through running first
+        await job_service.transition_state("job-1", JobState.running)
         job = await job_service.transition_state("job-1", JobState.succeeded)
         assert job.state == JobState.succeeded
         assert job.completed_at is not None

--- a/backend/tests/unit/test_models.py
+++ b/backend/tests/unit/test_models.py
@@ -90,7 +90,7 @@ def test_domain_event_creation() -> None:
 
 
 def test_domain_event_kind_values() -> None:
-    assert len(DomainEventKind) == 12
+    assert len(DomainEventKind) == 13
 
 
 def test_job_domain_model() -> None:

--- a/backend/tests/unit/test_runtime_service.py
+++ b/backend/tests/unit/test_runtime_service.py
@@ -1,0 +1,850 @@
+"""Tests for RuntimeService — capacity, queueing, heartbeat, MCP discovery, event translation."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+from sqlalchemy import event as sa_event
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+    from pathlib import Path
+
+    from sqlalchemy.ext.asyncio import AsyncEngine
+
+import structlog
+
+from backend.config import TowerConfig
+from backend.models.db import Base
+from backend.models.domain import (
+    Job,
+    JobState,
+    SessionConfig,
+    SessionEvent,
+    SessionEventKind,
+)
+from backend.models.events import DomainEvent, DomainEventKind
+from backend.persistence.database import _set_sqlite_pragmas
+from backend.services.agent_adapter import AgentAdapterInterface
+from backend.services.event_bus import EventBus
+from backend.services.execution_strategy import STRATEGY_REGISTRY, SingleAgentExecutor
+from backend.services.runtime_service import (
+    RuntimeService,
+    _build_session_config,
+    _discover_mcp_servers,
+    _make_event_id,
+    _resolve_protected_paths,
+)
+
+log = structlog.get_logger()
+
+
+# ---------------------------------------------------------------------------
+# Test double — lives here, not in production code
+# ---------------------------------------------------------------------------
+
+
+class FakeAgentAdapter(AgentAdapterInterface):
+    """Test double that emits scripted events with realistic event sequences."""
+
+    def __init__(self, delay: float = 0.1) -> None:
+        self._delay = delay
+        self._aborted: set[str] = set()
+
+    async def create_session(self, config: SessionConfig) -> str:
+        import uuid
+
+        return f"fake-{uuid.uuid4().hex[:8]}"
+
+    async def stream_events(self, session_id: str) -> AsyncGenerator[SessionEvent, None]:
+        scripted: list[SessionEvent] = [
+            SessionEvent(
+                kind=SessionEventKind.log,
+                payload={"level": "info", "message": "Agent session started"},
+            ),
+            SessionEvent(
+                kind=SessionEventKind.transcript,
+                payload={
+                    "role": "agent",
+                    "content": "I'll analyze the codebase and implement the requested changes.",
+                },
+            ),
+            SessionEvent(
+                kind=SessionEventKind.file_changed,
+                payload={"path": "src/example.py", "action": "modified"},
+            ),
+            SessionEvent(
+                kind=SessionEventKind.transcript,
+                payload={"role": "agent", "content": "Changes complete. All tests pass."},
+            ),
+            SessionEvent(kind=SessionEventKind.done, payload={}),
+        ]
+        for event in scripted:
+            if session_id in self._aborted:
+                return
+            await asyncio.sleep(self._delay)
+            yield event
+
+    async def send_message(self, session_id: str, message: str) -> None:
+        log.debug("fake_adapter_message", session_id=session_id, message=message)
+
+    async def abort_session(self, session_id: str) -> None:
+        self._aborted.add(session_id)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def engine() -> AsyncGenerator[AsyncEngine, None]:
+    eng = create_async_engine("sqlite+aiosqlite:///:memory:")
+    sa_event.listen(eng.sync_engine, "connect", _set_sqlite_pragmas)
+    async with eng.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield eng
+    await eng.dispose()
+
+
+@pytest.fixture
+def session_factory(engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:
+    return async_sessionmaker(engine, expire_on_commit=False)
+
+
+@pytest.fixture
+def config(tmp_path: Path) -> TowerConfig:
+    return TowerConfig(repos=[str(tmp_path)])
+
+
+@pytest.fixture
+def event_bus() -> EventBus:
+    return EventBus()
+
+
+@pytest.fixture
+def adapter() -> FakeAgentAdapter:
+    return FakeAgentAdapter(delay=0.0)
+
+
+@pytest.fixture
+def runtime(
+    session_factory: async_sessionmaker[AsyncSession],
+    event_bus: EventBus,
+    adapter: FakeAgentAdapter,
+    config: TowerConfig,
+) -> RuntimeService:
+    return RuntimeService(
+        session_factory=session_factory,
+        event_bus=event_bus,
+        adapter=adapter,
+        config=config,
+    )
+
+
+def _make_job(
+    *,
+    job_id: str = "job-1",
+    repo: str = "/repos/test",
+    state: str = JobState.queued,
+    strategy: str = "single_agent",
+) -> Job:
+    now = datetime.now(UTC)
+    return Job(
+        id=job_id,
+        repo=repo,
+        prompt="Fix the bug",
+        state=state,
+        strategy=strategy,
+        base_ref="main",
+        branch=None,
+        worktree_path=None,
+        session_id=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+async def _create_db_job(
+    session_factory: async_sessionmaker[AsyncSession],
+    job: Job,
+) -> None:
+    """Insert a minimal job row so state transitions work."""
+    from backend.models.db import JobRow
+
+    async with session_factory() as session:
+        row = JobRow(
+            id=job.id,
+            repo=job.repo,
+            prompt=job.prompt,
+            state=job.state,
+            strategy=job.strategy,
+            base_ref=job.base_ref,
+            branch=job.branch,
+            worktree_path=job.worktree_path,
+            session_id=job.session_id,
+            created_at=job.created_at,
+            updated_at=job.updated_at,
+        )
+        session.add(row)
+        await session.commit()
+
+
+# ---------------------------------------------------------------------------
+# RuntimeService — capacity & queueing
+# ---------------------------------------------------------------------------
+
+
+class TestCapacityAndQueueing:
+    async def test_start_job_within_capacity(
+        self, runtime: RuntimeService, session_factory: async_sessionmaker[AsyncSession], config: TowerConfig
+    ) -> None:
+        job = _make_job(repo=config.repos[0])
+        await _create_db_job(session_factory, job)
+
+        await runtime.start_or_enqueue(job)
+        # Give the asyncio task time to start and finish
+        await asyncio.sleep(0.3)
+        # The FakeAgentAdapter finishes fast (delay=0), so the job should complete
+        assert runtime.running_count == 0  # completed
+
+    async def test_enqueue_when_at_capacity(
+        self, runtime: RuntimeService, session_factory: async_sessionmaker[AsyncSession], config: TowerConfig
+    ) -> None:
+        """When max_concurrent_jobs is reached, new jobs get enqueued."""
+        # Create a slow adapter so jobs stay in-flight
+        slow_adapter = FakeAgentAdapter(delay=2.0)
+        runtime._adapter = slow_adapter
+
+        jobs = []
+        for i in range(3):
+            job = _make_job(job_id=f"job-{i}", repo=config.repos[0])
+            await _create_db_job(session_factory, job)
+            jobs.append(job)
+
+        # Start first two (within default capacity of 2)
+        await runtime.start_or_enqueue(jobs[0])
+        await runtime.start_or_enqueue(jobs[1])
+        assert runtime.running_count == 2
+
+        # Third should be enqueued
+        await runtime.start_or_enqueue(jobs[2])
+        # running_count shouldn't increase (still 2 running tasks)
+        assert runtime.running_count == 2
+
+        # Verify job-2 was transitioned to queued state in DB
+        async with session_factory() as session:
+            from backend.persistence.job_repo import JobRepository
+
+            repo = JobRepository(session)
+            row = await repo.get("job-2")
+            assert row is not None
+            assert row.state == JobState.queued
+
+        # Cleanup
+        await runtime.shutdown()
+
+    async def test_running_count_property(self, runtime: RuntimeService) -> None:
+        assert runtime.running_count == 0
+        assert runtime.max_concurrent == 2  # default
+
+
+# ---------------------------------------------------------------------------
+# RuntimeService — event translation
+# ---------------------------------------------------------------------------
+
+
+class TestEventTranslation:
+    def test_log_event_translated(self, runtime: RuntimeService) -> None:
+        event = SessionEvent(
+            kind=SessionEventKind.log,
+            payload={"level": "info", "message": "test"},
+        )
+        result = runtime._translate_event("job-1", event)
+        assert result is not None
+        assert result.kind == DomainEventKind.log_line_emitted
+        assert result.job_id == "job-1"
+
+    def test_transcript_event_translated(self, runtime: RuntimeService) -> None:
+        event = SessionEvent(
+            kind=SessionEventKind.transcript,
+            payload={"role": "agent", "content": "hello"},
+        )
+        result = runtime._translate_event("job-1", event)
+        assert result is not None
+        assert result.kind == DomainEventKind.transcript_updated
+
+    def test_file_changed_to_diff_updated(self, runtime: RuntimeService) -> None:
+        event = SessionEvent(
+            kind=SessionEventKind.file_changed,
+            payload={"path": "foo.py", "action": "modified"},
+        )
+        result = runtime._translate_event("job-1", event)
+        assert result is not None
+        assert result.kind == DomainEventKind.diff_updated
+
+    def test_approval_request_translated(self, runtime: RuntimeService) -> None:
+        event = SessionEvent(
+            kind=SessionEventKind.approval_request,
+            payload={"description": "need approval"},
+        )
+        result = runtime._translate_event("job-1", event)
+        assert result is not None
+        assert result.kind == DomainEventKind.approval_requested
+
+    def test_error_event_translated(self, runtime: RuntimeService) -> None:
+        event = SessionEvent(
+            kind=SessionEventKind.error,
+            payload={"message": "boom"},
+        )
+        result = runtime._translate_event("job-1", event)
+        assert result is not None
+        assert result.kind == DomainEventKind.job_failed
+
+    def test_done_event_returns_none(self, runtime: RuntimeService) -> None:
+        event = SessionEvent(kind=SessionEventKind.done, payload={})
+        result = runtime._translate_event("job-1", event)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# RuntimeService — job lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestJobLifecycle:
+    async def test_successful_job_publishes_events(
+        self,
+        runtime: RuntimeService,
+        event_bus: EventBus,
+        session_factory: async_sessionmaker[AsyncSession],
+        config: TowerConfig,
+    ) -> None:
+        published: list[DomainEvent] = []
+
+        async def _collect(e: DomainEvent) -> None:
+            published.append(e)
+
+        event_bus.subscribe(_collect)
+
+        job = _make_job(repo=config.repos[0])
+        await _create_db_job(session_factory, job)
+
+        await runtime.start_or_enqueue(job)
+        await asyncio.sleep(0.5)
+
+        # Should have log, transcript, diff, transcript events + job_succeeded
+        kinds = [e.kind for e in published]
+        assert DomainEventKind.log_line_emitted in kinds
+        assert DomainEventKind.transcript_updated in kinds
+        assert DomainEventKind.diff_updated in kinds
+        assert DomainEventKind.job_succeeded in kinds
+
+    async def test_cancel_running_job(
+        self, runtime: RuntimeService, session_factory: async_sessionmaker[AsyncSession], config: TowerConfig
+    ) -> None:
+        # Use slow adapter to keep job running
+        slow_adapter = FakeAgentAdapter(delay=5.0)
+        runtime._adapter = slow_adapter
+
+        job = _make_job(repo=config.repos[0])
+        await _create_db_job(session_factory, job)
+
+        await runtime.start_or_enqueue(job)
+        await asyncio.sleep(0.1)
+        assert runtime.running_count == 1
+
+        await runtime.cancel(job.id)
+        await asyncio.sleep(0.3)
+        assert runtime.running_count == 0
+
+    async def test_cancel_queued_job(
+        self, runtime: RuntimeService, session_factory: async_sessionmaker[AsyncSession], config: TowerConfig
+    ) -> None:
+        slow_adapter = FakeAgentAdapter(delay=5.0)
+        runtime._adapter = slow_adapter
+
+        # Fill capacity
+        j1 = _make_job(job_id="j1", repo=config.repos[0])
+        j2 = _make_job(job_id="j2", repo=config.repos[0])
+        j3 = _make_job(job_id="j3", repo=config.repos[0])
+        await _create_db_job(session_factory, j1)
+        await _create_db_job(session_factory, j2)
+        await _create_db_job(session_factory, j3)
+
+        await runtime.start_or_enqueue(j1)
+        await runtime.start_or_enqueue(j2)
+        await runtime.start_or_enqueue(j3)  # queued
+        await asyncio.sleep(0.1)
+
+        # Cancel the queued job
+        await runtime.cancel("j3")
+        async with session_factory() as session:
+            from backend.persistence.job_repo import JobRepository
+
+            repo = JobRepository(session)
+            row = await repo.get("j3")
+            assert row is not None
+            assert row.state == JobState.canceled
+
+        await runtime.shutdown()
+
+    async def test_send_message_delegates_to_strategy(
+        self, runtime: RuntimeService, session_factory: async_sessionmaker[AsyncSession], config: TowerConfig
+    ) -> None:
+        slow_adapter = FakeAgentAdapter(delay=5.0)
+        runtime._adapter = slow_adapter
+
+        job = _make_job(repo=config.repos[0])
+        await _create_db_job(session_factory, job)
+
+        await runtime.start_or_enqueue(job)
+        await asyncio.sleep(0.1)
+
+        # Should not raise
+        await runtime.send_message(job.id, "hello")
+        # Non-existent job should also not raise
+        await runtime.send_message("no-such-job", "hello")
+
+        await runtime.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# RuntimeService — recovery on startup
+# ---------------------------------------------------------------------------
+
+
+class TestRecovery:
+    async def test_recover_fails_orphaned_running_jobs(
+        self,
+        runtime: RuntimeService,
+        event_bus: EventBus,
+        session_factory: async_sessionmaker[AsyncSession],
+        config: TowerConfig,
+    ) -> None:
+        published: list[DomainEvent] = []
+
+        async def _collect(e: DomainEvent) -> None:
+            published.append(e)
+
+        event_bus.subscribe(_collect)
+
+        job = _make_job(repo=config.repos[0], state=JobState.running)
+        await _create_db_job(session_factory, job)
+
+        await runtime.recover_on_startup()
+
+        async with session_factory() as session:
+            from backend.persistence.job_repo import JobRepository
+
+            repo = JobRepository(session)
+            row = await repo.get(job.id)
+            assert row is not None
+            assert row.state == JobState.failed
+
+        # Should have published a job_failed event
+        failed_events = [e for e in published if e.kind == DomainEventKind.job_failed]
+        assert len(failed_events) == 1
+        assert failed_events[0].payload["reason"] == "process_restarted"
+
+    async def test_recover_restarts_queued_jobs(
+        self, runtime: RuntimeService, session_factory: async_sessionmaker[AsyncSession], config: TowerConfig
+    ) -> None:
+        job = _make_job(repo=config.repos[0], state=JobState.queued)
+        await _create_db_job(session_factory, job)
+
+        await runtime.recover_on_startup()
+        await asyncio.sleep(0.5)
+
+        # The queued job should have been started and completed (fast adapter)
+        async with session_factory() as session:
+            from backend.persistence.job_repo import JobRepository
+
+            repo = JobRepository(session)
+            row = await repo.get(job.id)
+            assert row is not None
+            assert row.state == JobState.succeeded
+
+
+# ---------------------------------------------------------------------------
+# RuntimeService — shutdown
+# ---------------------------------------------------------------------------
+
+
+class TestShutdown:
+    async def test_shutdown_cancels_all_tasks(
+        self, runtime: RuntimeService, session_factory: async_sessionmaker[AsyncSession], config: TowerConfig
+    ) -> None:
+        slow_adapter = FakeAgentAdapter(delay=10.0)
+        runtime._adapter = slow_adapter
+
+        job = _make_job(repo=config.repos[0])
+        await _create_db_job(session_factory, job)
+
+        await runtime.start_or_enqueue(job)
+        await asyncio.sleep(0.1)
+        assert runtime.running_count == 1
+
+        await runtime.shutdown()
+        # After shutdown, tasks should be cleaned up
+        assert runtime.running_count == 0
+
+
+# ---------------------------------------------------------------------------
+# FakeAgentAdapter
+# ---------------------------------------------------------------------------
+
+
+class TestFakeAgentAdapter:
+    async def test_create_session_returns_fake_id(self) -> None:
+        adapter = FakeAgentAdapter()
+        config = SessionConfig(workspace_path="/tmp", prompt="test")
+        session_id = await adapter.create_session(config)
+        assert session_id.startswith("fake-")
+
+    async def test_stream_events_produces_scripted_events(self) -> None:
+        adapter = FakeAgentAdapter(delay=0.0)
+        config = SessionConfig(workspace_path="/tmp", prompt="test")
+        session_id = await adapter.create_session(config)
+
+        events = []
+        async for event in adapter.stream_events(session_id):
+            events.append(event)
+
+        assert len(events) == 5
+        assert events[0].kind == SessionEventKind.log
+        assert events[1].kind == SessionEventKind.transcript
+        assert events[2].kind == SessionEventKind.file_changed
+        assert events[3].kind == SessionEventKind.transcript
+        assert events[4].kind == SessionEventKind.done
+
+    async def test_abort_stops_stream(self) -> None:
+        adapter = FakeAgentAdapter(delay=0.1)
+        config = SessionConfig(workspace_path="/tmp", prompt="test")
+        session_id = await adapter.create_session(config)
+
+        await adapter.abort_session(session_id)
+
+        events = []
+        async for event in adapter.stream_events(session_id):
+            events.append(event)
+
+        # Aborted session returns immediately, yields no events
+        assert len(events) == 0
+
+    async def test_send_message_noop(self) -> None:
+        adapter = FakeAgentAdapter()
+        # Should not raise
+        await adapter.send_message("fake-123", "hello")
+
+
+# ---------------------------------------------------------------------------
+# SingleAgentExecutor
+# ---------------------------------------------------------------------------
+
+
+class TestSingleAgentExecutor:
+    async def test_execute_yields_events(self) -> None:
+        adapter = FakeAgentAdapter(delay=0.0)
+        executor = SingleAgentExecutor()
+        config = SessionConfig(workspace_path="/tmp", prompt="test")
+
+        events = []
+        async for event in executor.execute(config, adapter):
+            events.append(event)
+
+        assert len(events) == 5
+        assert events[-1].kind == SessionEventKind.done
+
+    async def test_send_message_after_execute(self) -> None:
+        adapter = FakeAgentAdapter(delay=0.0)
+        executor = SingleAgentExecutor()
+        config = SessionConfig(workspace_path="/tmp", prompt="test")
+
+        # Must run execute first so session_id is set
+        async for _ in executor.execute(config, adapter):
+            pass
+
+        # Should not raise
+        await executor.send_message("test message")
+
+    async def test_abort(self) -> None:
+        adapter = FakeAgentAdapter(delay=0.0)
+        executor = SingleAgentExecutor()
+        config = SessionConfig(workspace_path="/tmp", prompt="test")
+
+        async for _ in executor.execute(config, adapter):
+            break  # start but don't finish
+
+        await executor.abort()
+
+
+# ---------------------------------------------------------------------------
+# Strategy Registry
+# ---------------------------------------------------------------------------
+
+
+class TestStrategyRegistry:
+    def test_single_agent_in_registry(self) -> None:
+        from backend.models.api_schemas import StrategyKind
+
+        assert StrategyKind.single_agent in STRATEGY_REGISTRY
+        assert STRATEGY_REGISTRY[StrategyKind.single_agent] is SingleAgentExecutor
+
+
+# ---------------------------------------------------------------------------
+# MCP Server Discovery
+# ---------------------------------------------------------------------------
+
+
+class TestMCPDiscovery:
+    def test_empty_when_no_files_exist(self, config: TowerConfig) -> None:
+        result = _discover_mcp_servers("/nonexistent/repo", config)
+        assert result == {}
+
+    def test_reads_vscode_mcp_json(self, tmp_path: Path, config: TowerConfig) -> None:
+        mcp_dir = tmp_path / ".vscode"
+        mcp_dir.mkdir()
+        mcp_json = {
+            "servers": {
+                "myserver": {
+                    "command": "npx",
+                    "args": ["-y", "@myserver/mcp"],
+                    "env": {"TOKEN": "abc"},
+                }
+            }
+        }
+        (mcp_dir / "mcp.json").write_text(json.dumps(mcp_json))
+
+        result = _discover_mcp_servers(str(tmp_path), config)
+        assert "myserver" in result
+        assert result["myserver"].command == "npx"
+        assert result["myserver"].args == ["-y", "@myserver/mcp"]
+        assert result["myserver"].env == {"TOKEN": "abc"}
+
+    def test_tower_yml_disables_servers(self, tmp_path: Path, config: TowerConfig) -> None:
+        # Add a server via .vscode/mcp.json
+        mcp_dir = tmp_path / ".vscode"
+        mcp_dir.mkdir()
+        mcp_json = {
+            "servers": {
+                "keep": {"command": "keep-cmd", "args": []},
+                "remove": {"command": "remove-cmd", "args": []},
+            }
+        }
+        (mcp_dir / "mcp.json").write_text(json.dumps(mcp_json))
+
+        # Disable 'remove' via .tower.yml
+        tower_yml = {"tools": {"mcp": {"disabled": ["remove"]}}}
+        (tmp_path / ".tower.yml").write_text(yaml.dump(tower_yml))
+
+        result = _discover_mcp_servers(str(tmp_path), config)
+        assert "keep" in result
+        assert "remove" not in result
+
+    def test_malformed_mcp_json_handled(self, tmp_path: Path, config: TowerConfig) -> None:
+        mcp_dir = tmp_path / ".vscode"
+        mcp_dir.mkdir()
+        (mcp_dir / "mcp.json").write_text("{invalid json")
+
+        # Should not raise
+        result = _discover_mcp_servers(str(tmp_path), config)
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# Protected paths resolution
+# ---------------------------------------------------------------------------
+
+
+class TestProtectedPaths:
+    def test_no_tower_yml(self) -> None:
+        result = _resolve_protected_paths("/nonexistent")
+        assert result == []
+
+    def test_reads_protected_paths(self, tmp_path: Path) -> None:
+        tower_yml = {"protected_paths": ["src/config.py", "secrets/"]}
+        (tmp_path / ".tower.yml").write_text(yaml.dump(tower_yml))
+
+        result = _resolve_protected_paths(str(tmp_path))
+        assert result == ["src/config.py", "secrets/"]
+
+    def test_malformed_yaml_returns_empty(self, tmp_path: Path) -> None:
+        (tmp_path / ".tower.yml").write_text(":::invalid:::")
+        result = _resolve_protected_paths(str(tmp_path))
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Session config builder
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSessionConfig:
+    def test_uses_worktree_path_when_set(self, config: TowerConfig) -> None:
+        job = _make_job()
+        job.worktree_path = "/some/worktree"
+        result = _build_session_config(job, config)
+        assert result.workspace_path == "/some/worktree"
+        assert result.prompt == job.prompt
+
+    def test_falls_back_to_repo(self, config: TowerConfig) -> None:
+        job = _make_job()
+        job.worktree_path = None
+        result = _build_session_config(job, config)
+        assert result.workspace_path == job.repo
+
+
+# ---------------------------------------------------------------------------
+# _make_event_id
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Concurrency guards
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrencyGuards:
+    async def test_double_start_guard(
+        self, runtime: RuntimeService, session_factory: async_sessionmaker[AsyncSession], config: TowerConfig
+    ) -> None:
+        """_start_job should no-op if a task for the job already exists."""
+        slow_adapter = FakeAgentAdapter(delay=5.0)
+        runtime._adapter = slow_adapter
+
+        job = _make_job(repo=config.repos[0])
+        await _create_db_job(session_factory, job)
+
+        await runtime.start_or_enqueue(job)
+        await asyncio.sleep(0.1)
+        assert runtime.running_count == 1
+
+        # Attempt to start the same job again (simulating a race)
+        await runtime._start_job(job)
+        # Should still have only one running task
+        assert runtime.running_count == 1
+
+        await runtime.shutdown()
+
+    async def test_dequeue_respects_capacity(
+        self, runtime: RuntimeService, session_factory: async_sessionmaker[AsyncSession], config: TowerConfig
+    ) -> None:
+        """_dequeue_next under the lock should not exceed max_concurrent."""
+        slow_adapter = FakeAgentAdapter(delay=5.0)
+        runtime._adapter = slow_adapter
+
+        # Create 3 queued jobs
+        for i in range(3):
+            job = _make_job(job_id=f"job-{i}", repo=config.repos[0])
+            await _create_db_job(session_factory, job)
+            await runtime.start_or_enqueue(job)
+
+        await asyncio.sleep(0.1)
+        # 2 running, 1 queued
+        assert runtime.running_count == 2
+
+        # Multiple concurrent dequeue calls should not exceed capacity
+        await asyncio.gather(
+            runtime._dequeue_next(),
+            runtime._dequeue_next(),
+        )
+        # Still at capacity
+        assert runtime.running_count <= runtime.max_concurrent
+
+        await runtime.shutdown()
+
+    async def test_cancel_already_canceled_is_idempotent(
+        self, runtime: RuntimeService, session_factory: async_sessionmaker[AsyncSession], config: TowerConfig
+    ) -> None:
+        """CancelledError handler should not fail if job is already canceled."""
+        slow_adapter = FakeAgentAdapter(delay=5.0)
+        runtime._adapter = slow_adapter
+
+        job = _make_job(repo=config.repos[0])
+        await _create_db_job(session_factory, job)
+
+        await runtime.start_or_enqueue(job)
+        await asyncio.sleep(0.1)
+
+        # Transition to canceled via DB directly (simulating route handler)
+        async with session_factory() as session:
+            svc = runtime._make_job_service(session)
+            await svc.transition_state(job.id, JobState.canceled)
+            await session.commit()
+
+        # Now cancel via runtime — the CancelledError handler should see
+        # that the job is already canceled and skip the transition
+        await runtime.cancel(job.id)
+        await asyncio.sleep(0.3)
+
+        # Should complete without errors
+        assert runtime.running_count == 0
+
+
+class TestRecoveryCapacity:
+    async def test_recover_respects_capacity(
+        self, runtime: RuntimeService, session_factory: async_sessionmaker[AsyncSession], config: TowerConfig
+    ) -> None:
+        """recover_on_startup uses start_or_enqueue, respecting max_concurrent."""
+        slow_adapter = FakeAgentAdapter(delay=5.0)
+        runtime._adapter = slow_adapter
+
+        # Create 3 queued jobs
+        for i in range(3):
+            job = _make_job(job_id=f"job-{i}", repo=config.repos[0], state=JobState.queued)
+            await _create_db_job(session_factory, job)
+
+        await runtime.recover_on_startup()
+        await asyncio.sleep(0.1)
+
+        # Should only start max_concurrent (2), not all 3
+        assert runtime.running_count == runtime.max_concurrent
+
+        await runtime.shutdown()
+
+
+class TestJobStateChangedEvent:
+    async def test_state_change_publishes_correct_event_kind(
+        self,
+        runtime: RuntimeService,
+        event_bus: EventBus,
+        session_factory: async_sessionmaker[AsyncSession],
+        config: TowerConfig,
+    ) -> None:
+        """_publish_state_event should use job_state_changed, not job_created."""
+        published: list[DomainEvent] = []
+
+        async def _collect(e: DomainEvent) -> None:
+            published.append(e)
+
+        event_bus.subscribe(_collect)
+
+        job = _make_job(repo=config.repos[0])
+        await _create_db_job(session_factory, job)
+
+        await runtime.start_or_enqueue(job)
+        await asyncio.sleep(0.5)
+
+        state_change_events = [e for e in published if e.kind == DomainEventKind.job_state_changed]
+        assert len(state_change_events) >= 1
+        # Should NOT have published any job_created events
+        created_events = [e for e in published if e.kind == DomainEventKind.job_created]
+        assert len(created_events) == 0
+
+
+class TestMakeEventId:
+    def test_format(self) -> None:
+        eid = _make_event_id()
+        assert eid.startswith("evt-")
+        assert len(eid) == 16  # "evt-" + 12 hex chars
+
+    def test_unique(self) -> None:
+        ids = {_make_event_id() for _ in range(100)}
+        assert len(ids) == 100

--- a/backend/tests/unit/test_runtime_service.py
+++ b/backend/tests/unit/test_runtime_service.py
@@ -367,6 +367,7 @@ class TestJobLifecycle:
     async def test_cancel_queued_job(
         self, runtime: RuntimeService, session_factory: async_sessionmaker[AsyncSession], config: TowerConfig
     ) -> None:
+        """cancel() for a non-running job is a no-op (state change is the API layer's job)."""
         slow_adapter = FakeAgentAdapter(delay=5.0)
         runtime._adapter = slow_adapter
 
@@ -383,7 +384,7 @@ class TestJobLifecycle:
         await runtime.start_or_enqueue(j3)  # queued
         await asyncio.sleep(0.1)
 
-        # Cancel the queued job
+        # cancel() should be a no-op for queued jobs (no task to cancel)
         await runtime.cancel("j3")
         async with session_factory() as session:
             from backend.persistence.job_repo import JobRepository
@@ -391,7 +392,8 @@ class TestJobLifecycle:
             repo = JobRepository(session)
             row = await repo.get("j3")
             assert row is not None
-            assert row.state == JobState.canceled
+            # State remains queued — API layer handles the transition
+            assert row.state == JobState.queued
 
         await runtime.shutdown()
 
@@ -848,3 +850,113 @@ class TestMakeEventId:
     def test_unique(self) -> None:
         ids = {_make_event_id() for _ in range(100)}
         assert len(ids) == 100
+
+
+# ---------------------------------------------------------------------------
+# Red-team: error events should cause job failure, not succeeded
+# ---------------------------------------------------------------------------
+
+
+class ErrorAdapter(AgentAdapterInterface):
+    """Adapter that emits an error event before completing."""
+
+    async def create_session(self, config: SessionConfig) -> str:
+        return "err-session"
+
+    async def stream_events(self, session_id: str) -> AsyncGenerator[SessionEvent, None]:
+        yield SessionEvent(
+            kind=SessionEventKind.log,
+            payload={"level": "info", "message": "Starting"},
+        )
+        yield SessionEvent(
+            kind=SessionEventKind.error,
+            payload={"message": "Something went wrong"},
+        )
+
+    async def send_message(self, session_id: str, message: str) -> None:
+        pass
+
+    async def abort_session(self, session_id: str) -> None:
+        pass
+
+
+class TestErrorEventCausesFailure:
+    async def test_error_event_fails_job(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        event_bus: EventBus,
+        config: TowerConfig,
+    ) -> None:
+        """A job whose adapter emits an error event should end as failed, not succeeded."""
+        error_adapter = ErrorAdapter()
+        runtime = RuntimeService(
+            session_factory=session_factory,
+            event_bus=event_bus,
+            adapter=error_adapter,
+            config=config,
+        )
+
+        published: list[DomainEvent] = []
+
+        async def _collect(e: DomainEvent) -> None:
+            published.append(e)
+
+        event_bus.subscribe(_collect)
+
+        job = _make_job(repo=config.repos[0])
+        await _create_db_job(session_factory, job)
+
+        await runtime.start_or_enqueue(job)
+        await asyncio.sleep(0.5)
+
+        # Should have a job_failed event, NOT job_succeeded
+        kinds = [e.kind for e in published]
+        assert DomainEventKind.job_failed in kinds
+        assert DomainEventKind.job_succeeded not in kinds
+
+        # DB state should be failed
+        from backend.models.db import JobRow
+
+        async with session_factory() as session:
+            from sqlalchemy import select
+
+            row = (await session.execute(select(JobRow).where(JobRow.id == job.id))).scalar_one()
+            assert row.state == JobState.failed
+
+
+# ---------------------------------------------------------------------------
+# Red-team: start_or_enqueue uses dequeue lock
+# ---------------------------------------------------------------------------
+
+
+class TestStartOrEnqueueCapacitySafety:
+    async def test_concurrent_start_or_enqueue_respects_capacity(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        event_bus: EventBus,
+        config: TowerConfig,
+    ) -> None:
+        """Multiple concurrent start_or_enqueue calls should not exceed max_concurrent."""
+        slow_adapter = FakeAgentAdapter(delay=5.0)
+        runtime = RuntimeService(
+            session_factory=session_factory,
+            event_bus=event_bus,
+            adapter=slow_adapter,
+            config=config,
+        )
+        config.runtime.max_concurrent_jobs = 1
+
+        jobs = []
+        for i in range(3):
+            job = _make_job(job_id=f"race-{i}", repo=config.repos[0])
+            await _create_db_job(session_factory, job)
+            jobs.append(job)
+
+        # Fire all start_or_enqueue calls concurrently
+        await asyncio.gather(*(runtime.start_or_enqueue(j) for j in jobs))
+        await asyncio.sleep(0.1)
+
+        # Should only have 1 running (max_concurrent=1)
+        assert runtime.running_count <= config.runtime.max_concurrent_jobs
+
+        await runtime.shutdown()


### PR DESCRIPTION
## Summary

Implements Phase 4 of the Tower roadmap: Agent Integration & Runtime Service.

### Changes

- **RuntimeService**: Capacity-limited job execution engine with async task management, queue overflow, cancel support, and startup recovery
- **CopilotAdapter**: Wraps the `copilot-agent-sdk` Python SDK behind `AgentAdapterInterface`, using the real SDK API (`SessionConfig`, `MessageOptions`, `CopilotSession`)
- **SingleAgentExecutor**: Execution strategy that translates SDK session events into Tower domain events (log, transcript, diff, done/error)
- **STRATEGY_REGISTRY**: Pluggable strategy lookup for execution strategies
- **Job routes**: Updated to delegate start/cancel/send-message to RuntimeService
- **Event model**: Added `job_state_changed` event kind for state transition events
- **Lifespan**: RuntimeService initialized in FastAPI lifespan with recovery on startup and graceful shutdown

### Bug Fixes (found during pressure testing)

1. **Double-start race condition**: `_start_job` now guards against duplicate task creation
2. **Over-capacity race**: `_dequeue_next` uses an `asyncio.Lock` to prevent concurrent dequeues from exceeding capacity
3. **Non-idempotent cancel**: CancelledError handler checks current state before transitioning
4. **Recovery bypassed capacity**: `recover_on_startup` now routes through `start_or_enqueue` instead of `_start_job`
5. **Wrong event kind**: State change events now use `job_state_changed` instead of `job_created`

### Tests

40 new tests covering:
- Capacity & queueing (start within capacity, enqueue overflow)
- Event translation (SDK events → domain events)
- Job lifecycle (success, cancel running, cancel queued, send message)
- Recovery (fail orphaned running, restart queued)
- Graceful shutdown
- Concurrency guards (double-start, dequeue capacity, idempotent cancel)
- Recovery capacity limits
- Event kind correctness

All 291 tests pass. All pre-commit hooks (ruff, mypy, format) pass.