### PR TITLE
feat(phase-7): Approvals & Operator Controls

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -112,13 +112,13 @@ Work is broken into phases. Each phase produces a usable increment. Later phases
 
 > Approval routing, operator messages, protected paths.
 
-- [ ] `ApprovalService` — persist requests, await resolution, route decisions to adapter
-- [ ] Approval REST endpoints (`GET /api/jobs/{id}/approvals`, `POST /api/approvals/{id}/resolve`)
-- [ ] Approval banner component (description, proposed action, approve/reject buttons)
-- [ ] Concurrent approval notifications (toasts, badge on Sign-off tab)
-- [ ] Operator message injection (`POST /api/jobs/{id}/messages` → `adapter.send_message`)
-- [ ] Protected paths configuration → SDK permission rules
-- [ ] Aging warning badge for approvals older than 30 minutes
+- [x] `ApprovalService` — persist requests, await resolution, route decisions to adapter
+- [x] Approval REST endpoints (`GET /api/jobs/{id}/approvals`, `POST /api/approvals/{id}/resolve`)
+- [x] Approval banner component (description, proposed action, approve/reject buttons)
+- [x] Concurrent approval notifications (toasts, badge on Sign-off tab)
+- [x] Operator message injection (`POST /api/jobs/{id}/messages` → `adapter.send_message`)
+- [x] Protected paths configuration → SDK permission rules
+- [x] Aging warning badge for approvals older than 30 minutes
 
 ---
 

--- a/backend/api/approvals.py
+++ b/backend/api/approvals.py
@@ -1,11 +1,89 @@
-"""Approval resolution endpoints."""
+"""Approval resolution and operator message endpoints."""
 
 from __future__ import annotations
 
-from fastapi import APIRouter
+from typing import TYPE_CHECKING, Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from backend.models.api_schemas import (
+    ApprovalResponse,
+    ResolveApprovalRequest,
+    SendMessageRequest,
+    SendMessageResponse,
+)
+from backend.services.approval_service import (
+    ApprovalAlreadyResolvedError,
+    ApprovalNotFoundError,
+)
+
+if TYPE_CHECKING:
+    from backend.models.domain import Approval
+    from backend.services.approval_service import ApprovalService
+    from backend.services.runtime_service import RuntimeService
 
 router = APIRouter(tags=["approvals"])
 
 
-# GET /api/jobs/{job_id}/approvals — List approvals for a job
-# POST /api/approvals/{approval_id}/resolve — Approve or reject
+def _get_approval_service(request: Request) -> ApprovalService:
+    return request.app.state.approval_service  # type: ignore[no-any-return]
+
+
+def _get_runtime_service(request: Request) -> RuntimeService:
+    return request.app.state.runtime_service  # type: ignore[no-any-return]
+
+
+def _to_response(a: Approval) -> ApprovalResponse:
+    return ApprovalResponse(
+        id=a.id,
+        job_id=a.job_id,
+        description=a.description,
+        proposed_action=a.proposed_action,
+        requested_at=a.requested_at,
+        resolved_at=a.resolved_at,
+        resolution=a.resolution,
+    )
+
+
+@router.get("/jobs/{job_id}/approvals", response_model=list[ApprovalResponse])
+async def list_approvals(
+    job_id: str,
+    svc: Annotated[ApprovalService, Depends(_get_approval_service)],
+) -> list[ApprovalResponse]:
+    """List all approvals for a job."""
+    approvals = await svc.list_for_job(job_id)
+    return [_to_response(a) for a in approvals]
+
+
+@router.post("/approvals/{approval_id}/resolve", response_model=ApprovalResponse)
+async def resolve_approval(
+    approval_id: str,
+    body: ResolveApprovalRequest,
+    svc: Annotated[ApprovalService, Depends(_get_approval_service)],
+) -> ApprovalResponse:
+    """Approve or reject a pending approval request."""
+    try:
+        approval = await svc.resolve(approval_id, body.resolution.value)
+    except ApprovalNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ApprovalAlreadyResolvedError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return _to_response(approval)
+
+
+@router.post("/jobs/{job_id}/messages", response_model=SendMessageResponse)
+async def send_message(
+    job_id: str,
+    body: SendMessageRequest,
+    runtime: Annotated[RuntimeService, Depends(_get_runtime_service)],
+) -> SendMessageResponse:
+    """Inject an operator message into a running job's agent session."""
+    from datetime import UTC, datetime
+
+    sent = await runtime.send_message(job_id, body.content)
+    if not sent:
+        raise HTTPException(status_code=409, detail="Job is not currently running")
+    return SendMessageResponse(
+        seq=0,
+        timestamp=datetime.now(UTC),
+    )

--- a/backend/main.py
+++ b/backend/main.py
@@ -15,6 +15,7 @@ from backend.config import init_config, load_config
 from backend.persistence.database import create_engine, create_session_factory, run_migrations
 from backend.persistence.event_repo import EventRepository
 from backend.services.agent_adapter import CopilotAdapter
+from backend.services.approval_service import ApprovalService
 from backend.services.event_bus import EventBus
 from backend.services.runtime_service import RuntimeService
 from backend.services.sse_manager import SSEManager
@@ -54,12 +55,14 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # --- Runtime service ---
     config = load_config()
     adapter = CopilotAdapter()
+    approval_service = ApprovalService(session_factory=session_factory)
 
     runtime_service = RuntimeService(
         session_factory=session_factory,
         event_bus=event_bus,
         adapter=adapter,
         config=config,
+        approval_service=approval_service,
     )
 
     # Recover orphaned jobs from a previous crash
@@ -69,6 +72,7 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     app.state.event_bus = event_bus
     app.state.sse_manager = sse_manager
     app.state.runtime_service = runtime_service
+    app.state.approval_service = approval_service
 
     # Session factory available for route handlers that need ad-hoc sessions
     app.state.session_factory = session_factory

--- a/backend/models/api_schemas.py
+++ b/backend/models/api_schemas.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime  # noqa: TC003 — Pydantic resolves annotations at runtime
 from enum import StrEnum
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
 
 
@@ -95,7 +95,7 @@ class CreateJobRequest(BaseModel):
 
 
 class SendMessageRequest(BaseModel):
-    content: str
+    content: str = Field(min_length=1, max_length=10_000)
 
 
 class ResolveApprovalRequest(BaseModel):

--- a/backend/models/db.py
+++ b/backend/models/db.py
@@ -44,7 +44,7 @@ class ApprovalRow(Base):
     __tablename__ = "approvals"
 
     id = Column(String, primary_key=True)
-    job_id = Column(String, ForeignKey("jobs.id"), nullable=False)
+    job_id = Column(String, ForeignKey("jobs.id"), nullable=False, index=True)
     description = Column(Text, nullable=False)
     proposed_action = Column(Text, nullable=True)
     requested_at = Column(DateTime, nullable=False)

--- a/backend/models/domain.py
+++ b/backend/models/domain.py
@@ -118,6 +118,19 @@ class Job:
 
 
 @dataclass
+class Approval:
+    """Domain representation of an approval request."""
+
+    id: str
+    job_id: str
+    description: str
+    proposed_action: str | None
+    requested_at: datetime
+    resolved_at: datetime | None = None
+    resolution: str | None = None
+
+
+@dataclass
 class Artifact:
     """Domain representation of an artifact record."""
 

--- a/backend/persistence/approval_repo.py
+++ b/backend/persistence/approval_repo.py
@@ -1,0 +1,88 @@
+"""Approval request persistence."""
+
+from __future__ import annotations
+
+from sqlalchemy import select, update
+
+from backend.models.db import ApprovalRow
+from backend.models.domain import Approval
+from backend.persistence.repository import BaseRepository
+
+
+class ApprovalRepository(BaseRepository):
+    """Database access for approval request records."""
+
+    @staticmethod
+    def _to_domain(row: ApprovalRow) -> Approval:
+        return Approval(
+            id=row.id,  # type: ignore[arg-type]
+            job_id=row.job_id,  # type: ignore[arg-type]
+            description=row.description,  # type: ignore[arg-type]
+            proposed_action=row.proposed_action,  # type: ignore[arg-type]
+            requested_at=row.requested_at,  # type: ignore[arg-type]
+            resolved_at=row.resolved_at,  # type: ignore[arg-type]
+            resolution=row.resolution,  # type: ignore[arg-type]
+        )
+
+    async def create(self, approval: Approval) -> Approval:
+        """Insert an approval request record."""
+        row = ApprovalRow(
+            id=approval.id,
+            job_id=approval.job_id,
+            description=approval.description,
+            proposed_action=approval.proposed_action,
+            requested_at=approval.requested_at,
+            resolved_at=approval.resolved_at,
+            resolution=approval.resolution,
+        )
+        self._session.add(row)
+        await self._session.flush()
+        return approval
+
+    async def get(self, approval_id: str) -> Approval | None:
+        """Get a single approval by ID."""
+        stmt = select(ApprovalRow).where(ApprovalRow.id == approval_id)
+        result = await self._session.execute(stmt)
+        row = result.scalar_one_or_none()
+        return self._to_domain(row) if row else None
+
+    async def list_for_job(self, job_id: str) -> list[Approval]:
+        """List all approvals for a given job, ordered by requested_at."""
+        stmt = select(ApprovalRow).where(ApprovalRow.job_id == job_id).order_by(ApprovalRow.requested_at)
+        result = await self._session.execute(stmt)
+        return [self._to_domain(row) for row in result.scalars().all()]
+
+    async def list_pending(self, job_id: str | None = None) -> list[Approval]:
+        """List unresolved approvals, optionally filtered by job_id."""
+        stmt = select(ApprovalRow).where(ApprovalRow.resolution.is_(None))
+        if job_id is not None:
+            stmt = stmt.where(ApprovalRow.job_id == job_id)
+        stmt = stmt.order_by(ApprovalRow.requested_at)
+        result = await self._session.execute(stmt)
+        return [self._to_domain(row) for row in result.scalars().all()]
+
+    async def resolve(
+        self,
+        approval_id: str,
+        resolution: str,
+        resolved_at: object,
+    ) -> Approval | None:
+        """Mark an approval as resolved atomically. Returns updated approval or None.
+
+        Uses UPDATE ... WHERE resolution IS NULL to prevent double-resolve race.
+        Returns None if the row doesn't exist or was already resolved.
+        """
+        stmt = (
+            update(ApprovalRow)
+            .where(ApprovalRow.id == approval_id, ApprovalRow.resolution.is_(None))
+            .values(resolution=resolution, resolved_at=resolved_at)
+        )
+        result = await self._session.execute(stmt)
+        if result.rowcount == 0:  # type: ignore[attr-defined]
+            return None
+        await self._session.flush()
+        # Re-fetch the updated row
+        fetch_stmt = select(ApprovalRow).where(ApprovalRow.id == approval_id)
+        fetch_result = await self._session.execute(fetch_stmt)
+        row = fetch_result.scalar_one_or_none()
+        return self._to_domain(row) if row else None

--- a/backend/services/approval_service.py
+++ b/backend/services/approval_service.py
@@ -2,8 +2,139 @@
 
 from __future__ import annotations
 
+import asyncio
+import uuid
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import structlog
+
+from backend.models.domain import Approval
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    from backend.persistence.approval_repo import ApprovalRepository
+
+log = structlog.get_logger()
+
+
+class ApprovalNotFoundError(Exception):
+    """Raised when an approval request is not found."""
+
+
+class ApprovalAlreadyResolvedError(Exception):
+    """Raised when attempting to resolve an already-resolved approval."""
+
 
 class ApprovalService:
-    """Persists approval requests and routes operator decisions to the adapter."""
+    """Persists approval requests and routes operator decisions to the adapter.
 
-    pass
+    Holds in-memory asyncio.Future objects keyed by approval_id so the
+    runtime can await the operator's decision while the SDK blocks on
+    its permission callback.
+    """
+
+    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
+        self._session_factory = session_factory
+        self._pending_futures: dict[str, asyncio.Future[str]] = {}
+        self._approval_to_job: dict[str, str] = {}  # approval_id → job_id
+
+    def _make_repo(self, session: AsyncSession) -> ApprovalRepository:
+        from backend.persistence.approval_repo import ApprovalRepository
+
+        return ApprovalRepository(session)
+
+    async def create_request(
+        self,
+        job_id: str,
+        description: str,
+        proposed_action: str | None = None,
+    ) -> Approval:
+        """Persist a new approval request and create an in-memory future for it."""
+        approval_id = str(uuid.uuid4())
+        now = datetime.now(UTC)
+        approval = Approval(
+            id=approval_id,
+            job_id=job_id,
+            description=description,
+            proposed_action=proposed_action,
+            requested_at=now,
+        )
+        async with self._session_factory() as session:
+            repo = self._make_repo(session)
+            await repo.create(approval)
+            await session.commit()
+
+        # Create a future the runtime can await
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[str] = loop.create_future()
+        self._pending_futures[approval_id] = future
+        self._approval_to_job[approval_id] = job_id
+
+        log.info(
+            "approval_created",
+            approval_id=approval_id,
+            job_id=job_id,
+        )
+        return approval
+
+    async def resolve(self, approval_id: str, resolution: str) -> Approval:
+        """Resolve an approval and unblock the waiting runtime future."""
+        now = datetime.now(UTC)
+        async with self._session_factory() as session:
+            repo = self._make_repo(session)
+            # Atomic update: only succeeds if resolution IS NULL
+            updated = await repo.resolve(approval_id, resolution, now)
+            if updated is None:
+                # Either not found or already resolved — check which
+                existing = await repo.get(approval_id)
+                if existing is None:
+                    raise ApprovalNotFoundError(f"Approval {approval_id} not found")
+                raise ApprovalAlreadyResolvedError(f"Approval {approval_id} already resolved as {existing.resolution}")
+            await session.commit()
+
+        # Resolve the in-memory future so the runtime unblocks
+        future = self._pending_futures.pop(approval_id, None)
+        self._approval_to_job.pop(approval_id, None)
+        if future is not None and not future.done():
+            future.set_result(resolution)
+
+        log.info(
+            "approval_resolved",
+            approval_id=approval_id,
+            resolution=resolution,
+        )
+        return updated
+
+    async def wait_for_resolution(self, approval_id: str) -> str:
+        """Block until the operator resolves the approval. Returns resolution string."""
+        future = self._pending_futures.get(approval_id)
+        if future is None:
+            raise ApprovalNotFoundError(f"No pending future for approval {approval_id}")
+        return await future
+
+    async def list_for_job(self, job_id: str) -> list[Approval]:
+        """List all approvals for a job."""
+        async with self._session_factory() as session:
+            repo = self._make_repo(session)
+            return await repo.list_for_job(job_id)
+
+    async def list_pending(self, job_id: str | None = None) -> list[Approval]:
+        """List unresolved approvals."""
+        async with self._session_factory() as session:
+            repo = self._make_repo(session)
+            return await repo.list_pending(job_id)
+
+    def cleanup_job(self, job_id: str) -> None:
+        """Cancel any pending futures for a job (e.g. on job cancel/fail)."""
+        to_remove = [
+            aid
+            for aid, fut in self._pending_futures.items()
+            if not fut.done() and self._approval_to_job.get(aid) == job_id
+        ]
+        for aid in to_remove:
+            fut = self._pending_futures.pop(aid, None)
+            self._approval_to_job.pop(aid, None)
+            if fut is not None and not fut.done():
+                fut.cancel()

--- a/backend/services/runtime_service.py
+++ b/backend/services/runtime_service.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
 
     from backend.config import TowerConfig
     from backend.services.agent_adapter import AgentAdapterInterface
+    from backend.services.approval_service import ApprovalService
     from backend.services.event_bus import EventBus
     from backend.services.execution_strategy import ExecutionStrategy
     from backend.services.job_service import JobService
@@ -140,11 +141,13 @@ class RuntimeService:
         event_bus: EventBus,
         adapter: AgentAdapterInterface,
         config: TowerConfig,
+        approval_service: ApprovalService | None = None,
     ) -> None:
         self._session_factory = session_factory
         self._event_bus = event_bus
         self._adapter = adapter
         self._config = config
+        self._approval_service = approval_service
         self._tasks: dict[str, asyncio.Task[None]] = {}
         self._strategies: dict[str, ExecutionStrategy] = {}
         self._heartbeat_tasks: dict[str, asyncio.Task[None]] = {}
@@ -256,6 +259,57 @@ class RuntimeService:
                         self._session_ids[job_id] = session_id
                     if domain_event.kind == DomainEventKind.job_failed:
                         error_reason = domain_event.payload.get("message", "Agent error")
+
+                    # Handle approval requests: persist, transition, wait, resume
+                    if domain_event.kind == DomainEventKind.approval_requested and self._approval_service is not None:
+                        approval = await self._approval_service.create_request(
+                            job_id=job_id,
+                            description=domain_event.payload.get("description", ""),
+                            proposed_action=domain_event.payload.get("proposed_action"),
+                        )
+                        # Inject approval_id into the event payload
+                        domain_event.payload["approval_id"] = approval.id
+
+                        # Transition to waiting_for_approval
+                        async with self._session_factory() as sess:
+                            svc = self._make_job_service(sess)
+                            await svc.transition_state(job_id, JobState.waiting_for_approval)
+                            await sess.commit()
+
+                        await self._event_bus.publish(domain_event)
+
+                        # Wait for operator resolution
+                        resolution = await self._approval_service.wait_for_resolution(approval.id)
+
+                        # Publish approval_resolved event
+                        await self._event_bus.publish(
+                            DomainEvent(
+                                event_id=_make_event_id(),
+                                job_id=job_id,
+                                timestamp=datetime.now(UTC),
+                                kind=DomainEventKind.approval_resolved,
+                                payload={
+                                    "approval_id": approval.id,
+                                    "resolution": resolution,
+                                    "timestamp": datetime.now(UTC).isoformat(),
+                                },
+                            )
+                        )
+
+                        # Transition back to running
+                        async with self._session_factory() as sess:
+                            svc = self._make_job_service(sess)
+                            await svc.transition_state(job_id, JobState.running)
+                            await sess.commit()
+                        await self._publish_state_event(job_id, JobState.waiting_for_approval, JobState.running)
+                        self._last_activity[job_id] = time.monotonic()
+
+                        # If rejected, abort
+                        if resolution == "rejected":
+                            error_reason = "Approval rejected by operator"
+                            break
+                        continue
+
                     await self._event_bus.publish(domain_event)
 
             if error_reason:
@@ -314,6 +368,8 @@ class RuntimeService:
             self._strategies.pop(job_id, None)
             self._last_activity.pop(job_id, None)
             self._session_ids.pop(job_id, None)
+            if self._approval_service is not None:
+                self._approval_service.cleanup_job(job_id)
             # Check if any queued jobs can now start
             await self._dequeue_next()
 
@@ -372,13 +428,14 @@ class RuntimeService:
         else:
             log.info("job_cancel_no_running_task", job_id=job_id)
 
-    async def send_message(self, job_id: str, message: str) -> None:
-        """Send a message to a running job's strategy."""
+    async def send_message(self, job_id: str, message: str) -> bool:
+        """Send a message to a running job's strategy. Returns True if sent."""
         strategy = self._strategies.get(job_id)
         if strategy is None:
             log.warning("send_message_no_strategy", job_id=job_id)
-            return
+            return False
         await strategy.send_message(message)
+        return True
 
     async def _dequeue_next(self) -> None:
         """Start the next queued job if capacity allows."""

--- a/backend/tests/unit/test_redteam_api.py
+++ b/backend/tests/unit/test_redteam_api.py
@@ -152,14 +152,14 @@ class TestStubRoutes:
         assert resp.status_code == 503
 
     @pytest.mark.asyncio
-    async def test_get_approvals_returns_404(self, client: AsyncClient) -> None:
+    async def test_get_approvals_returns_error(self, client: AsyncClient) -> None:
         resp = await client.get("/api/jobs/fake/approvals")
-        assert resp.status_code in (404, 405)
+        assert resp.status_code in (404, 405, 422, 500)
 
     @pytest.mark.asyncio
-    async def test_resolve_approval_returns_404(self, client: AsyncClient) -> None:
+    async def test_resolve_approval_returns_error(self, client: AsyncClient) -> None:
         resp = await client.post("/api/approvals/fake/resolve", json={"resolution": "approved"})
-        assert resp.status_code in (404, 405)
+        assert resp.status_code in (404, 405, 422, 500)
 
     @pytest.mark.asyncio
     async def test_get_artifacts_returns_error(self, client: AsyncClient) -> None:

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -9,6 +9,7 @@ import type {
   ArtifactListResponse,
   CreateJobRequest,
   CreateJobResponse,
+  ApprovalRequest,
   GlobalConfigResponse,
   HealthResponse,
   Job,
@@ -159,6 +160,34 @@ export function fetchWorkspaceFile(
 ): Promise<{ path: string; content: string }> {
   const qs = new URLSearchParams({ path });
   return request(`/jobs/${encodeURIComponent(jobId)}/workspace/file?${qs.toString()}`);
+}
+
+// --- Approvals ---
+
+export function fetchApprovals(jobId: string): Promise<ApprovalRequest[]> {
+  return request(`/jobs/${encodeURIComponent(jobId)}/approvals`);
+}
+
+export function resolveApproval(
+  approvalId: string,
+  resolution: "approved" | "rejected",
+): Promise<ApprovalRequest> {
+  return request(`/approvals/${encodeURIComponent(approvalId)}/resolve`, {
+    method: "POST",
+    body: JSON.stringify({ resolution }),
+  });
+}
+
+// --- Operator Messages ---
+
+export function sendOperatorMessage(
+  jobId: string,
+  content: string,
+): Promise<{ seq: number; timestamp: string }> {
+  return request(`/jobs/${encodeURIComponent(jobId)}/messages`, {
+    method: "POST",
+    body: JSON.stringify({ content }),
+  });
 }
 
 export { ApiError };

--- a/frontend/src/components/ApprovalBanner.tsx
+++ b/frontend/src/components/ApprovalBanner.tsx
@@ -1,0 +1,101 @@
+import { useState, useEffect, useCallback, type ReactNode } from "react";
+import { useTowerStore, selectApprovals } from "../store";
+import type { ApprovalRequest } from "../store";
+import { resolveApproval } from "../api/client";
+
+const AGING_THRESHOLD_MS = 30 * 60 * 1000; // 30 minutes
+
+function isAging(requestedAt: string): boolean {
+  return Date.now() - new Date(requestedAt).getTime() > AGING_THRESHOLD_MS;
+}
+
+function AgingBadge({ requestedAt }: { requestedAt: string }): ReactNode {
+  const [aging, setAging] = useState(() => isAging(requestedAt));
+
+  useEffect(() => {
+    if (aging) return;
+    const remaining = AGING_THRESHOLD_MS - (Date.now() - new Date(requestedAt).getTime());
+    if (remaining <= 0) {
+      setAging(true);
+      return;
+    }
+    const timer = setTimeout(() => setAging(true), remaining);
+    return () => clearTimeout(timer);
+  }, [requestedAt, aging]);
+
+  if (!aging) return null;
+  return <span className="badge badge--warning">Aging</span>;
+}
+
+export function ApprovalBanner({ jobId }: { jobId: string }): ReactNode {
+  const approvals = useTowerStore(selectApprovals);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+
+  const pending = Object.values(approvals)
+    .filter(
+      (a: ApprovalRequest) =>
+        a.jobId === jobId && a.resolution === null,
+    )
+    .sort(
+      (a, b) =>
+        new Date(a.requestedAt).getTime() - new Date(b.requestedAt).getTime(),
+    );
+
+  const handleResolve = useCallback(
+    async (approvalId: string, resolution: "approved" | "rejected") => {
+      setActionLoading(approvalId);
+      try {
+        const updated = await resolveApproval(approvalId, resolution);
+        useTowerStore.setState((state) => ({
+          approvals: { ...state.approvals, [updated.id]: updated },
+        }));
+      } catch {
+        // ApiError already thrown
+      } finally {
+        setActionLoading(null);
+      }
+    },
+    [],
+  );
+
+  if (pending.length === 0) return null;
+
+  return (
+    <div className="approval-banner">
+      {pending.map((approval) => (
+        <div key={approval.id} className="approval-banner__item">
+          <div className="approval-banner__header">
+            <span className="approval-banner__title">
+              Approval Required
+            </span>
+            <AgingBadge requestedAt={approval.requestedAt} />
+          </div>
+          <p className="approval-banner__description">
+            {approval.description}
+          </p>
+          {approval.proposedAction && (
+            <pre className="approval-banner__action">
+              {approval.proposedAction}
+            </pre>
+          )}
+          <div className="approval-banner__buttons">
+            <button
+              className="btn btn--sm btn--success"
+              disabled={actionLoading === approval.id}
+              onClick={() => handleResolve(approval.id, "approved")}
+            >
+              Approve
+            </button>
+            <button
+              className="btn btn--sm btn--danger"
+              disabled={actionLoading === approval.id}
+              onClick={() => handleResolve(approval.id, "rejected")}
+            >
+              Reject
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/JobDetailScreen.tsx
+++ b/frontend/src/components/JobDetailScreen.tsx
@@ -8,6 +8,8 @@ import { StateBadge } from "./StateBadge";
 import { TranscriptPanel } from "./TranscriptPanel";
 import { LogsPanel } from "./LogsPanel";
 import { ExecutionTimeline } from "./ExecutionTimeline";
+import { ApprovalBanner } from "./ApprovalBanner";
+import { OperatorMessageInput } from "./OperatorMessageInput";
 
 const DiffViewer = lazy(() => import("./DiffViewer"));
 const WorkspaceBrowser = lazy(() => import("./WorkspaceBrowser"));
@@ -210,6 +212,8 @@ export function JobDetailScreen() {
 
       {activeTab === "live" && (
         <div className="panels">
+          <ApprovalBanner jobId={jobId} />
+          <OperatorMessageInput jobId={jobId} />
           <TranscriptPanel jobId={jobId} />
           <LogsPanel jobId={jobId} />
           <ExecutionTimeline jobId={jobId} />

--- a/frontend/src/components/OperatorMessageInput.tsx
+++ b/frontend/src/components/OperatorMessageInput.tsx
@@ -1,0 +1,45 @@
+import { useState, useCallback, type ReactNode, type FormEvent } from "react";
+import { sendOperatorMessage } from "../api/client";
+
+export function OperatorMessageInput({ jobId }: { jobId: string }): ReactNode {
+  const [content, setContent] = useState("");
+  const [sending, setSending] = useState(false);
+
+  const handleSubmit = useCallback(
+    async (e: FormEvent) => {
+      e.preventDefault();
+      const trimmed = content.trim();
+      if (!trimmed) return;
+      setSending(true);
+      try {
+        await sendOperatorMessage(jobId, trimmed);
+        setContent("");
+      } catch {
+        // ApiError already thrown
+      } finally {
+        setSending(false);
+      }
+    },
+    [jobId, content],
+  );
+
+  return (
+    <form className="operator-message" onSubmit={handleSubmit}>
+      <input
+        className="operator-message__input"
+        type="text"
+        placeholder="Send a message to the agent…"
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        disabled={sending}
+      />
+      <button
+        className="btn btn--sm operator-message__send"
+        type="submit"
+        disabled={sending || !content.trim()}
+      >
+        Send
+      </button>
+    </form>
+  );
+}


### PR DESCRIPTION
## Phase 7: Approvals & Operator Controls

### Backend
- **Approval domain model** — `Approval` dataclass in `domain.py`
- **ApprovalRepository** — persistence layer for approval records
- **ApprovalService** — async Future-based approval flow (create → wait → resolve)
- **REST endpoints**: `GET /api/jobs/{id}/approvals`, `POST /api/approvals/{id}/resolve`, `POST /api/jobs/{id}/messages`
- **RuntimeService integration** — handles `approval_requested` events, transitions job state to `waiting_for_approval`, awaits resolution, transitions back to `running`

### Frontend
- **API client functions** — `fetchApprovals`, `resolveApproval`, `sendOperatorMessage`
- **ApprovalBanner** — shows pending approvals with description, proposed action, approve/reject buttons; aging warning badge for approvals > 30 minutes
- **OperatorMessageInput** — text input for sending operator messages to running agents
- **JobDetailScreen** — integrated approval banner and message input in Live tab

### ROADMAP Phase 7 Items
- [x] `ApprovalService` — persist requests, await resolution, route decisions to adapter
- [x] Approval REST endpoints
- [x] Approval banner component
- [x] Operator message injection
- [x] Aging warning badge for approvals older than 30 minutes