### PR TITLE
feat(phase-8): voice input with local faster-whisper transcription

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -126,13 +126,13 @@ Work is broken into phases. Each phase produces a usable increment. Later phases
 
 > Local transcription with faster-whisper.
 
-- [ ] `VoiceService` — load model, transcribe audio bytes
-- [ ] Voice endpoint (`POST /api/voice/transcribe`)
-- [ ] Frontend audio capture (MediaRecorder, WebM/Opus)
-- [ ] Voice input button component (press-and-hold)
-- [ ] Client-side size limit enforcement
-- [ ] "Local transcription" indicator in UI
-- [ ] Voice config (`voice.enabled`, `voice.model`, `voice.max_audio_size_mb`)
+- [x] `VoiceService` — load model, transcribe audio bytes
+- [x] Voice endpoint (`POST /api/voice/transcribe`)
+- [x] Frontend audio capture (MediaRecorder, WebM/Opus)
+- [x] Voice input button component (press-and-hold)
+- [x] Client-side size limit enforcement
+- [x] "Local transcription" indicator in UI
+- [x] Voice config (`voice.enabled`, `voice.model`, `voice.max_audio_size_mb`)
 
 ---
 

--- a/backend/api/voice.py
+++ b/backend/api/voice.py
@@ -2,9 +2,64 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter
+import asyncio
+from typing import TYPE_CHECKING
+
+from fastapi import APIRouter, HTTPException, Request, UploadFile
+
+from backend.models.api_schemas import TranscribeResponse
+
+if TYPE_CHECKING:
+    from backend.services.voice_service import VoiceService
 
 router = APIRouter(tags=["voice"])
 
+ALLOWED_AUDIO_TYPES = frozenset({"audio/webm", "audio/ogg", "audio/wav", "audio/mpeg", "audio/mp4", "audio/x-wav"})
 
-# POST /api/voice/transcribe — Upload audio, receive transcript
+_transcribe_semaphore = asyncio.Semaphore(2)
+
+
+def _get_voice_service(request: Request) -> VoiceService:
+    return request.app.state.voice_service  # type: ignore[no-any-return]
+
+
+@router.post("/voice/transcribe", response_model=TranscribeResponse)
+async def transcribe(request: Request, audio: UploadFile) -> TranscribeResponse:
+    """Upload audio, receive transcript."""
+    voice_service: VoiceService = _get_voice_service(request)
+
+    if voice_service is None:
+        raise HTTPException(status_code=501, detail="Voice transcription is disabled")
+
+    # Validate content type
+    if audio.content_type and audio.content_type not in ALLOWED_AUDIO_TYPES:
+        raise HTTPException(status_code=415, detail="Unsupported audio format")
+
+    # Stream-read with early abort on size limit
+    max_bytes: int = request.app.state.voice_max_bytes
+    chunks: list[bytes] = []
+    total = 0
+    while True:
+        chunk = await audio.read(64 * 1024)  # 64 KB chunks
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > max_bytes:
+            raise HTTPException(
+                status_code=413,
+                detail=f"Audio exceeds {max_bytes // (1024 * 1024)} MB limit",
+            )
+        chunks.append(chunk)
+    data = b"".join(chunks)
+
+    if len(data) == 0:
+        raise HTTPException(status_code=400, detail="Empty audio file")
+
+    # Concurrency-limited, off-event-loop transcription
+    if _transcribe_semaphore._value == 0:  # noqa: SLF001
+        raise HTTPException(status_code=429, detail="Transcription busy, try again later")
+
+    async with _transcribe_semaphore:
+        text = await asyncio.to_thread(voice_service.transcribe, data)
+
+    return TranscribeResponse(text=text)

--- a/backend/main.py
+++ b/backend/main.py
@@ -19,6 +19,7 @@ from backend.services.approval_service import ApprovalService
 from backend.services.event_bus import EventBus
 from backend.services.runtime_service import RuntimeService
 from backend.services.sse_manager import SSEManager
+from backend.services.voice_service import VoiceService
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
@@ -73,6 +74,13 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     app.state.sse_manager = sse_manager
     app.state.runtime_service = runtime_service
     app.state.approval_service = approval_service
+
+    # --- Voice service ---
+    voice_service: VoiceService | None = None
+    if config.voice.enabled:
+        voice_service = VoiceService(model_name=config.voice.model)
+    app.state.voice_service = voice_service
+    app.state.voice_max_bytes = config.voice.max_audio_size_mb * 1024 * 1024
 
     # Session factory available for route handlers that need ad-hoc sessions
     app.state.session_factory = session_factory

--- a/backend/services/voice_service.py
+++ b/backend/services/voice_service.py
@@ -2,8 +2,50 @@
 
 from __future__ import annotations
 
+import io
+
+import structlog
+from faster_whisper import WhisperModel
+
+logger = structlog.get_logger()
+
+ALLOWED_MODELS = frozenset(
+    {
+        "tiny",
+        "tiny.en",
+        "base",
+        "base.en",
+        "small",
+        "small.en",
+        "medium",
+        "medium.en",
+        "large-v2",
+        "large-v3",
+    }
+)
+
 
 class VoiceService:
-    """Transcribes audio using faster-whisper locally."""
+    """Transcribes audio using faster-whisper locally.
 
-    pass
+    The model is loaded once and reused across requests.
+    """
+
+    def __init__(self, model_name: str = "base.en") -> None:
+        if model_name not in ALLOWED_MODELS:
+            raise ValueError(f"Invalid voice model '{model_name}'. Allowed: {sorted(ALLOWED_MODELS)}")
+        self._model_name = model_name
+        self._model: WhisperModel | None = None
+
+    def _ensure_model(self) -> WhisperModel:
+        if self._model is None:
+            logger.info("voice_model_loading", model=self._model_name)
+            self._model = WhisperModel(self._model_name, device="cpu", compute_type="int8")
+            logger.info("voice_model_loaded", model=self._model_name)
+        return self._model
+
+    def transcribe(self, audio_bytes: bytes) -> str:
+        """Transcribe raw audio bytes and return the text."""
+        model = self._ensure_model()
+        segments, _ = model.transcribe(io.BytesIO(audio_bytes))
+        return " ".join(seg.text.strip() for seg in segments)

--- a/backend/tests/unit/test_redteam_api.py
+++ b/backend/tests/unit/test_redteam_api.py
@@ -172,9 +172,10 @@ class TestStubRoutes:
         assert resp.status_code in (404, 405, 500)
 
     @pytest.mark.asyncio
-    async def test_voice_transcribe_returns_404(self, client: AsyncClient) -> None:
+    async def test_voice_transcribe_returns_error(self, client: AsyncClient) -> None:
+        # No audio field → 422 validation error (endpoint is now implemented)
         resp = await client.post("/api/voice/transcribe")
-        assert resp.status_code in (404, 405)
+        assert resp.status_code in (404, 405, 422, 500)
 
     @pytest.mark.asyncio
     async def test_get_global_settings_returns_200(self, client: AsyncClient) -> None:

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -190,4 +190,21 @@ export function sendOperatorMessage(
   });
 }
 
+// --- Voice ---
+
+export async function transcribeAudio(audio: Blob): Promise<string> {
+  const form = new FormData();
+  form.append("audio", audio, "recording.webm");
+  const res = await fetch(`${BASE}/voice/transcribe`, {
+    method: "POST",
+    body: form,
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ detail: res.statusText }));
+    throw new ApiError(res.status, (body as { detail?: string }).detail ?? res.statusText);
+  }
+  const data = (await res.json()) as { text: string };
+  return data.text;
+}
+
 export { ApiError };

--- a/frontend/src/components/JobCreationScreen.tsx
+++ b/frontend/src/components/JobCreationScreen.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { createJob, fetchRepos } from "../api/client";
+import { VoiceButton } from "./VoiceButton";
 
 export function JobCreationScreen() {
   const navigate = useNavigate();
@@ -102,6 +103,10 @@ export function JobCreationScreen() {
             onChange={(e) => setPrompt(e.target.value)}
             placeholder="Describe the task for the coding agent…"
             required
+          />
+          <VoiceButton
+            onTranscript={(text) => setPrompt((prev) => (prev ? `${prev} ${text}` : text))}
+            disabled={submitting}
           />
         </div>
 

--- a/frontend/src/components/OperatorMessageInput.tsx
+++ b/frontend/src/components/OperatorMessageInput.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, type ReactNode, type FormEvent } from "react";
 import { sendOperatorMessage } from "../api/client";
+import { VoiceButton } from "./VoiceButton";
 
 export function OperatorMessageInput({ jobId }: { jobId: string }): ReactNode {
   const [content, setContent] = useState("");
@@ -40,6 +41,10 @@ export function OperatorMessageInput({ jobId }: { jobId: string }): ReactNode {
       >
         Send
       </button>
+      <VoiceButton
+        onTranscript={(text) => setContent((prev) => (prev ? `${prev} ${text}` : text))}
+        disabled={sending}
+      />
     </form>
   );
 }

--- a/frontend/src/components/VoiceButton.tsx
+++ b/frontend/src/components/VoiceButton.tsx
@@ -1,0 +1,105 @@
+import { useState, useRef, useCallback, type ReactNode } from "react";
+import { transcribeAudio } from "../api/client";
+
+/** Maximum audio size in bytes (10 MB, matches backend default). */
+const MAX_AUDIO_BYTES = 10 * 1024 * 1024;
+
+interface VoiceButtonProps {
+  /** Called when transcription completes with the resulting text. */
+  onTranscript: (text: string) => void;
+  disabled?: boolean;
+}
+
+/**
+ * Press-and-hold microphone button for voice input.
+ * Records audio via MediaRecorder when held, uploads on release,
+ * and returns the transcribed text.
+ */
+export function VoiceButton({ onTranscript, disabled }: VoiceButtonProps): ReactNode {
+  const [recording, setRecording] = useState(false);
+  const [transcribing, setTranscribing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const streamRef = useRef<MediaStream | null>(null);
+
+  const stopRecording = useCallback(() => {
+    if (recorderRef.current && recorderRef.current.state !== "inactive") {
+      recorderRef.current.stop();
+    }
+  }, []);
+
+  const startRecording = useCallback(async () => {
+    setError(null);
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      streamRef.current = stream;
+      const recorder = new MediaRecorder(stream);
+      recorderRef.current = recorder;
+      chunksRef.current = [];
+
+      recorder.ondataavailable = (e) => {
+        if (e.data.size > 0) chunksRef.current.push(e.data);
+      };
+
+      recorder.onstop = async () => {
+        // Stop all tracks
+        stream.getTracks().forEach((t) => t.stop());
+        streamRef.current = null;
+
+        const blob = new Blob(chunksRef.current, { type: "audio/webm" });
+        setRecording(false);
+
+        if (blob.size === 0) return;
+
+        if (blob.size > MAX_AUDIO_BYTES) {
+          setError(`Recording exceeds ${MAX_AUDIO_BYTES / (1024 * 1024)} MB limit`);
+          return;
+        }
+
+        setTranscribing(true);
+        try {
+          const text = await transcribeAudio(blob);
+          if (text.trim()) onTranscript(text.trim());
+        } catch {
+          setError("Transcription failed");
+        } finally {
+          setTranscribing(false);
+        }
+      };
+
+      recorder.start();
+      setRecording(true);
+    } catch {
+      setError("Microphone access denied");
+    }
+  }, [onTranscript]);
+
+  const isActive = recording || transcribing;
+
+  return (
+    <span className="voice-button-wrapper">
+      <button
+        type="button"
+        className={`btn btn--sm voice-button${recording ? " voice-button--recording" : ""}`}
+        onPointerDown={() => void startRecording()}
+        onPointerUp={stopRecording}
+        onPointerLeave={stopRecording}
+        disabled={disabled || transcribing}
+        title={recording ? "Release to stop" : "Hold to record"}
+        aria-label={recording ? "Recording… release to stop" : "Hold to dictate"}
+      >
+        {transcribing ? "…" : "🎤"}
+      </button>
+      {isActive && (
+        <span className="voice-indicator">
+          {recording ? "Recording…" : "Transcribing…"}
+        </span>
+      )}
+      {error && <span className="voice-error">{error}</span>}
+      <span className="voice-local-badge" title="Audio is transcribed locally on your machine">
+        Local transcription
+      </span>
+    </span>
+  );
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     # Web framework
     "fastapi>=0.115,<1",
     "uvicorn[standard]>=0.32,<1",
+    "python-multipart>=0.0.9",
     # Database
     "sqlalchemy>=2.0,<3",
     "aiosqlite>=0.20,<1",


### PR DESCRIPTION
## Phase 8: Voice Input

Implements local voice transcription using `faster-whisper`:

### Backend
- **VoiceService**: Loads whisper model lazily on first request, transcribes audio bytes via `faster-whisper` (`base.en` model by default, CPU int8 inference)
- **Voice endpoint**: `POST /api/voice/transcribe` — multipart/form-data upload with size limit enforcement (413 for oversized, 400 for empty)
- **Wired in main.py lifespan**: VoiceService created when `voice.enabled` is true, stored on `app.state`
- **Added `python-multipart`** dependency for file upload handling

### Frontend
- **VoiceButton component**: Press-and-hold microphone button using `MediaRecorder` API. Records WebM/Opus audio, enforces 10MB client-side limit, uploads to backend, returns transcribed text
- **JobCreationScreen integration**: VoiceButton next to prompt textarea — dictated text appended to prompt
- **OperatorMessageInput integration**: VoiceButton next to send button — dictated text appended to message
- **"Local transcription" indicator** shown next to the mic button

### Configuration
Voice is controlled by existing config:
```yaml
voice:
  enabled: true
  model: base.en
  max_audio_size_mb: 10
```