### PR TITLE
feat: Phase 9 — Operational Hardening

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -140,15 +140,15 @@ Work is broken into phases. Each phase produces a usable increment. Later phases
 
 > Graceful shutdown, restart recovery, retention, remote access.
 
-- [ ] Graceful shutdown (SIGTERM/SIGINT handler, cancel running jobs, close SSE)
-- [ ] Restart recovery (transition orphaned running/waiting jobs to failed)
-- [ ] Retention policy — artifact cleanup, worktree cleanup, daily background task
-- [ ] Settings API (`GET/PUT /api/settings/global`, `GET /api/settings/repos`, `GET /api/settings/repos/{repo_path}`)
-- [ ] Settings screen (global config editor, repo config list, cleanup action)
-- [ ] Dev Tunnel integration (`tower up --tunnel`)
-- [ ] Dynamic CORS for tunnel origin
-- [ ] Startup warning for `0.0.0.0` binding
-- [ ] `rich` terminal status display for `tower up`
+- [x] Graceful shutdown (SIGTERM/SIGINT handler, cancel running jobs, close SSE)
+- [x] Restart recovery (transition orphaned running/waiting jobs to failed)
+- [x] Retention policy — artifact cleanup, worktree cleanup, daily background task
+- [x] Settings API (`GET/PUT /api/settings/global`, `GET /api/settings/repos`, `GET /api/settings/repos/{repo_path}`)
+- [x] Settings screen (global config editor, repo config list, cleanup action)
+- [x] Dev Tunnel integration (`tower up --tunnel`)
+- [x] Dynamic CORS for tunnel origin
+- [x] Startup warning for `0.0.0.0` binding
+- [x] `rich` terminal status display for `tower up`
 
 ---
 

--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 from pathlib import Path
 from typing import Annotated
 
@@ -18,6 +19,7 @@ from backend.models.api_schemas import (
     GlobalConfigResponse,
     RegisterRepoRequest,
     RegisterRepoResponse,
+    RepoDetailResponse,
     RepoListResponse,
     UpdateGlobalConfigRequest,
 )
@@ -68,6 +70,31 @@ async def list_repos(
 ) -> RepoListResponse:
     """List registered repository paths."""
     return RepoListResponse(items=config.repos)
+
+
+@router.get("/settings/repos/{repo_path:path}", response_model=RepoDetailResponse)
+async def get_repo_detail(
+    repo_path: str,
+    config: Annotated[TowerConfig, Depends(_get_config)],
+    git: Annotated[GitService, Depends(_get_git_service)],
+) -> RepoDetailResponse:
+    """Get detailed config for a single registered repository."""
+    resolved = str(Path(repo_path).expanduser().resolve())
+    if resolved not in config.repos:
+        raise HTTPException(status_code=404, detail=f"Repository '{repo_path}' is not registered.")
+
+    origin_url: str | None = None
+    base_branch: str | None = None
+    with contextlib.suppress(GitError):
+        origin_url = await git.get_origin_url(resolved)
+    with contextlib.suppress(GitError):
+        base_branch = await git.get_default_branch(resolved)
+
+    return RepoDetailResponse(
+        path=resolved,
+        origin_url=origin_url,
+        base_branch=base_branch,
+    )
 
 
 @router.post("/settings/repos", response_model=RegisterRepoResponse, status_code=201)

--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -28,6 +28,20 @@ from backend.services.git_service import GitError, GitService
 router = APIRouter(tags=["settings"])
 
 
+def _strip_url_credentials(url: str) -> str:
+    """Remove embedded credentials from a git remote URL."""
+    from urllib.parse import urlparse, urlunparse
+
+    parsed = urlparse(url)
+    if parsed.username or parsed.password:
+        host = parsed.hostname or ""
+        if parsed.port:
+            host = f"{host}:{parsed.port}"
+        cleaned = parsed._replace(netloc=host)
+        return urlunparse(cleaned)
+    return url
+
+
 def _get_config() -> TowerConfig:
     return load_config()
 
@@ -86,7 +100,9 @@ async def get_repo_detail(
     origin_url: str | None = None
     base_branch: str | None = None
     with contextlib.suppress(GitError):
-        origin_url = await git.get_origin_url(resolved)
+        raw_url = await git.get_origin_url(resolved)
+        if raw_url:
+            origin_url = _strip_url_credentials(raw_url)
     with contextlib.suppress(GitError):
         base_branch = await git.get_default_branch(resolved)
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import click
+import structlog
 import uvicorn
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -17,6 +19,7 @@ from backend.persistence.event_repo import EventRepository
 from backend.services.agent_adapter import CopilotAdapter
 from backend.services.approval_service import ApprovalService
 from backend.services.event_bus import EventBus
+from backend.services.retention_service import RetentionService
 from backend.services.runtime_service import RuntimeService
 from backend.services.sse_manager import SSEManager
 from backend.services.voice_service import VoiceService
@@ -27,6 +30,8 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
     from backend.models.events import DomainEvent
+
+log = structlog.get_logger()
 
 
 @asynccontextmanager
@@ -82,6 +87,22 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     app.state.voice_service = voice_service
     app.state.voice_max_bytes = config.voice.max_audio_size_mb * 1024 * 1024
 
+    # --- Retention service ---
+    retention_service = RetentionService(
+        session_factory=session_factory,
+        config=config,
+    )
+    app.state.retention_service = retention_service
+
+    if config.retention.cleanup_on_startup:
+        await retention_service.run_cleanup()
+
+    # Start daily retention background task
+    retention_task = asyncio.create_task(
+        retention_service.daily_loop(),
+        name="retention-daily",
+    )
+
     # Session factory available for route handlers that need ad-hoc sessions
     app.state.session_factory = session_factory
 
@@ -96,20 +117,27 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     app.dependency_overrides[jobs._get_session] = _session_dep
     yield
+    retention_task.cancel()
     await runtime_service.shutdown()
     await sse_manager.close_all()
     app.dependency_overrides.clear()
     await engine.dispose()
 
 
-def create_app(*, dev: bool = False) -> FastAPI:
+def create_app(*, dev: bool = False, tunnel_origin: str | None = None) -> FastAPI:
     """Create and configure the FastAPI application."""
     app = FastAPI(title="Tower", version="0.1.0", lifespan=_lifespan)
 
+    origins: list[str] = []
     if dev:
+        origins.append("http://localhost:5173")
+    if tunnel_origin:
+        origins.append(tunnel_origin)
+
+    if origins:
         app.add_middleware(
             CORSMiddleware,
-            allow_origins=["http://localhost:5173"],
+            allow_origins=origins,
             allow_credentials=True,
             allow_methods=["*"],
             allow_headers=["*"],
@@ -146,8 +174,93 @@ def up(host: str | None, port: int | None, dev: bool, tunnel: bool) -> None:
     # Run Alembic migrations before starting the server
     run_migrations()
 
-    app = create_app(dev=dev)
-    uvicorn.run(app, host=host, port=port)
+    # Startup warning for 0.0.0.0 binding
+    if host == "0.0.0.0":  # noqa: S104
+        log.warning(
+            "binding_all_interfaces",
+            host=host,
+            message="Binding to 0.0.0.0 — no authentication is enforced. Use --tunnel for authenticated remote access.",
+        )
+        click.secho(
+            "WARNING: Binding to 0.0.0.0 — no authentication is enforced.",
+            fg="yellow",
+            err=True,
+        )
+
+    tunnel_origin: str | None = None
+    tunnel_proc = None
+
+    if tunnel:
+        tunnel_origin, tunnel_proc = _start_tunnel(port)
+
+    app = create_app(dev=dev, tunnel_origin=tunnel_origin)
+
+    try:
+        _print_startup_banner(host, port, dev, tunnel_origin)
+        uvicorn.run(app, host=host, port=port)
+    finally:
+        if tunnel_proc is not None:
+            tunnel_proc.terminate()
+
+
+def _start_tunnel(port: int) -> tuple[str | None, Any]:
+    """Start a devtunnel and return (origin_url, process)."""
+    import subprocess
+
+    try:
+        proc = subprocess.Popen(
+            [
+                "devtunnel",
+                "host",
+                "--port-numbers",
+                str(port),
+                "--allow-anonymous",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        # Read output lines looking for the tunnel URL
+        import re
+
+        tunnel_url: str | None = None
+        if proc.stdout:
+            for line in proc.stdout:
+                match = re.search(r"(https://\S+\.devtunnels\.ms\S*)", line)
+                if match:
+                    tunnel_url = match.group(1).rstrip("/")
+                    break
+        if tunnel_url:
+            log.info("tunnel_started", url=tunnel_url)
+        else:
+            log.warning("tunnel_url_not_detected")
+        return tunnel_url, proc
+    except FileNotFoundError:
+        click.secho(
+            "ERROR: 'devtunnel' CLI not found. Install from https://aka.ms/devtunnels/cli",
+            fg="red",
+            err=True,
+        )
+        return None, None
+
+
+def _print_startup_banner(host: str, port: int, dev: bool, tunnel_url: str | None) -> None:
+    """Print a startup banner with server info."""
+    try:
+        from rich.console import Console
+        from rich.panel import Panel
+
+        console = Console()
+        lines = [f"[bold]Server:[/bold] http://{host}:{port}"]
+        if dev:
+            lines.append("[bold]Mode:[/bold]   Development (CORS enabled)")
+        if tunnel_url:
+            lines.append(f"[bold]Tunnel:[/bold] {tunnel_url}")
+        console.print(Panel("\n".join(lines), title="[bold cyan]Tower[/bold cyan]", border_style="cyan"))
+    except ImportError:
+        click.echo(f"Tower server: http://{host}:{port}")
+        if tunnel_url:
+            click.echo(f"Tunnel: {tunnel_url}")
 
 
 @cli.command()

--- a/backend/models/api_schemas.py
+++ b/backend/models/api_schemas.py
@@ -209,6 +209,13 @@ class RepoListResponse(CamelModel):
     items: list[str]
 
 
+class RepoDetailResponse(CamelModel):
+    path: str
+    origin_url: str | None = None
+    base_branch: str | None = None
+    active_job_count: int = 0
+
+
 # --- SSE Payload Models ---
 
 

--- a/backend/services/git_service.py
+++ b/backend/services/git_service.py
@@ -98,6 +98,14 @@ class GitService:
                         cwd=repo_path,
                     )
 
+    async def get_origin_url(self, repo_path: str) -> str | None:
+        """Get the remote origin URL, or None if not set."""
+        try:
+            url = await self._run_git("config", "--get", "remote.origin.url", cwd=repo_path)
+            return url or None
+        except GitError:
+            return None
+
     async def has_active_worktree(self, repo_path: str) -> bool:
         """Check if any secondary worktree exists under the worktrees dir."""
         worktrees_dir = Path(repo_path) / self._worktrees_dirname

--- a/backend/services/retention_service.py
+++ b/backend/services/retention_service.py
@@ -1,0 +1,153 @@
+"""Retention policy — artifact cleanup, worktree cleanup, daily background task."""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import structlog
+from sqlalchemy import delete, select
+
+from backend.config import TOWER_DIR
+from backend.models.db import ArtifactRow, DiffSnapshotRow, JobRow
+from backend.models.domain import TERMINAL_STATES
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    from backend.config import TowerConfig
+
+log = structlog.get_logger()
+
+ARTIFACTS_DIR = TOWER_DIR / "artifacts"
+CLEANUP_INTERVAL_SECONDS = 24 * 60 * 60  # 24 hours
+
+
+class RetentionService:
+    """Manages retention cleanup for artifacts, diff snapshots, and worktrees."""
+
+    def __init__(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        config: TowerConfig,
+    ) -> None:
+        self._session_factory = session_factory
+        self._retention_days = config.retention.artifact_retention_days
+        self._worktrees_dirname = config.runtime.worktrees_dirname
+
+    async def run_cleanup(self) -> dict[str, int]:
+        """Run a full retention cleanup pass.
+
+        Returns a summary dict with counts of deleted items.
+        """
+        cutoff = datetime.now(tz=UTC) - timedelta(days=self._retention_days)
+        log.info("retention_cleanup_start", cutoff=cutoff.isoformat())
+
+        artifacts_deleted = await self._cleanup_artifacts(cutoff)
+        snapshots_deleted = await self._cleanup_diff_snapshots(cutoff)
+        worktrees_deleted = await self._cleanup_worktrees(cutoff)
+
+        summary = {
+            "artifacts_deleted": artifacts_deleted,
+            "snapshots_deleted": snapshots_deleted,
+            "worktrees_deleted": worktrees_deleted,
+        }
+        log.info("retention_cleanup_done", **summary)
+        return summary
+
+    async def daily_loop(self) -> None:
+        """Run cleanup every 24 hours. Designed to be launched as a background task."""
+        while True:
+            await asyncio.sleep(CLEANUP_INTERVAL_SECONDS)
+            try:
+                await self.run_cleanup()
+            except Exception:
+                log.exception("retention_cleanup_error")
+
+    # ------------------------------------------------------------------
+    # Internal cleanup methods
+    # ------------------------------------------------------------------
+
+    async def _cleanup_artifacts(self, cutoff: datetime) -> int:
+        """Delete artifact files and metadata older than cutoff."""
+        async with self._session_factory() as session:
+            # Find expired artifacts
+            stmt = select(ArtifactRow).where(ArtifactRow.created_at < cutoff)
+            result = await session.execute(stmt)
+            rows = list(result.scalars().all())
+
+            if not rows:
+                return 0
+
+            # Delete files from disk
+            for row in rows:
+                disk_path = Path(str(row.disk_path))
+                if disk_path.exists():
+                    disk_path.unlink(missing_ok=True)
+
+            # Delete per-job artifact directories if empty
+            job_dirs: set[Path] = set()
+            for row in rows:
+                job_dir = Path(str(row.disk_path)).parent
+                job_dirs.add(job_dir)
+
+            for job_dir in job_dirs:
+                if job_dir.exists() and not any(job_dir.iterdir()):
+                    job_dir.rmdir()
+
+            # Delete metadata rows
+            artifact_ids = [str(row.id) for row in rows]
+            await session.execute(delete(ArtifactRow).where(ArtifactRow.id.in_(artifact_ids)))
+            await session.commit()
+
+            log.info("retention_artifacts_cleaned", count=len(rows))
+            return len(rows)
+
+    async def _cleanup_diff_snapshots(self, cutoff: datetime) -> int:
+        """Delete diff snapshots for terminal-state jobs older than cutoff."""
+        async with self._session_factory() as session:
+            # Find jobs in terminal states completed before cutoff
+            stmt = select(JobRow.id).where(
+                JobRow.state.in_(TERMINAL_STATES),
+                JobRow.completed_at < cutoff,
+            )
+            result = await session.execute(stmt)
+            job_ids = [str(row[0]) for row in result.all()]
+
+            if not job_ids:
+                return 0
+
+            del_stmt = delete(DiffSnapshotRow).where(DiffSnapshotRow.job_id.in_(job_ids))
+            del_result = await session.execute(del_stmt)
+            count = del_result.rowcount  # type: ignore[attr-defined]
+            await session.commit()
+
+            log.info("retention_snapshots_cleaned", count=count)
+            return int(count)
+
+    async def _cleanup_worktrees(self, cutoff: datetime) -> int:
+        """Remove worktree directories for terminal-state jobs older than cutoff."""
+        async with self._session_factory() as session:
+            stmt = select(JobRow).where(
+                JobRow.state.in_(TERMINAL_STATES),
+                JobRow.completed_at < cutoff,
+                JobRow.worktree_path.isnot(None),
+            )
+            result = await session.execute(stmt)
+            rows = list(result.scalars().all())
+
+            if not rows:
+                return 0
+
+            count = 0
+            for row in rows:
+                wt_path = Path(str(row.worktree_path))
+                if wt_path.exists() and wt_path.is_dir():
+                    shutil.rmtree(wt_path, ignore_errors=True)
+                    count += 1
+                    log.info("retention_worktree_removed", path=str(wt_path))
+
+            return count

--- a/backend/services/retention_service.py
+++ b/backend/services/retention_service.py
@@ -82,26 +82,31 @@ class RetentionService:
             if not rows:
                 return 0
 
-            # Delete files from disk
+            # Delete metadata rows first (orphan files are harmless; orphan rows cause errors)
+            artifact_ids = [str(row.id) for row in rows]
+            await session.execute(delete(ArtifactRow).where(ArtifactRow.id.in_(artifact_ids)))
+            await session.commit()
+
+            # Delete files from disk — only if under the expected artifacts directory
+            artifacts_root = ARTIFACTS_DIR.resolve()
             for row in rows:
-                disk_path = Path(str(row.disk_path))
+                disk_path = Path(str(row.disk_path)).resolve()
+                if not disk_path.is_relative_to(artifacts_root):
+                    log.warning("retention_artifact_path_outside_store", path=str(disk_path))
+                    continue
                 if disk_path.exists():
                     disk_path.unlink(missing_ok=True)
 
             # Delete per-job artifact directories if empty
             job_dirs: set[Path] = set()
             for row in rows:
-                job_dir = Path(str(row.disk_path)).parent
-                job_dirs.add(job_dir)
+                job_dir = Path(str(row.disk_path)).resolve()
+                if job_dir.is_relative_to(artifacts_root):
+                    job_dirs.add(job_dir.parent)
 
             for job_dir in job_dirs:
                 if job_dir.exists() and not any(job_dir.iterdir()):
                     job_dir.rmdir()
-
-            # Delete metadata rows
-            artifact_ids = [str(row.id) for row in rows]
-            await session.execute(delete(ArtifactRow).where(ArtifactRow.id.in_(artifact_ids)))
-            await session.commit()
 
             log.info("retention_artifacts_cleaned", count=len(rows))
             return len(rows)
@@ -144,7 +149,11 @@ class RetentionService:
 
             count = 0
             for row in rows:
-                wt_path = Path(str(row.worktree_path))
+                wt_path = Path(str(row.worktree_path)).resolve()
+                repo_worktrees_dir = (Path(str(row.repo)) / self._worktrees_dirname).resolve()
+                if not str(wt_path).startswith(str(repo_worktrees_dir) + "/"):
+                    log.warning("retention_worktree_outside_dir", path=str(wt_path))
+                    continue
                 if wt_path.exists() and wt_path.is_dir():
                     shutil.rmtree(wt_path, ignore_errors=True)
                     count += 1

--- a/backend/services/runtime_service.py
+++ b/backend/services/runtime_service.py
@@ -154,6 +154,7 @@ class RuntimeService:
         self._last_activity: dict[str, float] = {}
         self._session_ids: dict[str, str] = {}
         self._dequeue_lock = asyncio.Lock()
+        self._shutting_down = False
 
     def _make_job_service(self, session: AsyncSession) -> JobService:
         from backend.persistence.job_repo import JobRepository
@@ -177,6 +178,9 @@ class RuntimeService:
 
     async def start_or_enqueue(self, job: Job) -> None:
         """Start the job if capacity allows, otherwise keep it queued."""
+        if self._shutting_down:
+            log.warning("job_rejected_shutting_down", job_id=job.id)
+            return
         async with self._dequeue_lock:
             if self.running_count >= self.max_concurrent:
                 # Job is already queued from create_job; only transition if needed
@@ -536,12 +540,42 @@ class RuntimeService:
 
     async def shutdown(self) -> None:
         """Gracefully shut down all running jobs."""
+        self._shutting_down = True
         for job_id in list(self._tasks):
-            await self.cancel(job_id)
+            # Cancel with server_shutdown reason
+            task = self._tasks.get(job_id)
+            if task is not None:
+                task.cancel()
+                try:
+                    async with self._session_factory() as session:
+                        svc = self._make_job_service(session)
+                        current = await svc.get_job(job_id)
+                        if current and current.state not in (
+                            JobState.canceled,
+                            JobState.succeeded,
+                            JobState.failed,
+                        ):
+                            await svc.transition_state(job_id, JobState.canceled)
+                            await session.commit()
+                            await self._event_bus.publish(
+                                DomainEvent(
+                                    event_id=_make_event_id(),
+                                    job_id=job_id,
+                                    timestamp=datetime.now(UTC),
+                                    kind=DomainEventKind.job_canceled,
+                                    payload={"reason": "server_shutdown"},
+                                )
+                            )
+                except Exception:
+                    log.warning("shutdown_cancel_failed", job_id=job_id, exc_info=True)
         # Wait briefly for tasks to complete
         tasks = list(self._tasks.values())
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
+
+    @property
+    def is_shutting_down(self) -> bool:
+        return self._shutting_down
 
 
 def _make_event_id() -> str:

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from "eslint-plugin-react-refresh";
 import tseslint from "typescript-eslint";
 
 export default tseslint.config(
-  { ignores: ["dist"] },
+  { ignores: ["dist", "coverage"] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ["**/*.{ts,tsx}"],

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { DashboardScreen } from "./components/DashboardScreen";
 import { JobDetailScreen } from "./components/JobDetailScreen";
 import { JobCreationScreen } from "./components/JobCreationScreen";
 import { RepositoryDetailView } from "./components/RepositoryDetailView";
+import { SettingsScreen } from "./components/SettingsScreen";
 
 export function App() {
   const connectionStatus = useTowerStore(selectConnectionStatus);
@@ -26,6 +27,7 @@ export function App() {
             Dashboard
           </NavLink>
           <NavLink to="/jobs/new">New Job</NavLink>
+          <NavLink to="/settings">Settings</NavLink>
         </nav>
         <div className="app-header__status">
           <span
@@ -43,6 +45,7 @@ export function App() {
             path="/repos/:repoPath"
             element={<RepositoryDetailView />}
           />
+          <Route path="/settings" element={<SettingsScreen />} />
         </Routes>
       </main>
     </div>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -100,6 +100,15 @@ export function fetchRepos(): Promise<RepoListResponse> {
   return request("/settings/repos");
 }
 
+export function fetchRepoDetail(repoPath: string): Promise<{
+  path: string;
+  originUrl: string | null;
+  baseBranch: string | null;
+  activeJobCount: number;
+}> {
+  return request(`/settings/repos/${encodeURIComponent(repoPath)}`);
+}
+
 export function registerRepo(source: string): Promise<{ path: string; source: string; cloned: boolean }> {
   return request("/settings/repos", {
     method: "POST",

--- a/frontend/src/components/SettingsScreen.tsx
+++ b/frontend/src/components/SettingsScreen.tsx
@@ -1,0 +1,155 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  fetchGlobalConfig,
+  updateGlobalConfig,
+  fetchRepos,
+  registerRepo,
+  unregisterRepo,
+  cleanupWorktrees,
+} from "../api/client";
+
+export function SettingsScreen() {
+  const [configYaml, setConfigYaml] = useState("");
+  const [savedYaml, setSavedYaml] = useState("");
+  const [repos, setRepos] = useState<string[]>([]);
+  const [newRepo, setNewRepo] = useState("");
+  const [status, setStatus] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadData = useCallback(async () => {
+    try {
+      const [configRes, reposRes] = await Promise.all([
+        fetchGlobalConfig(),
+        fetchRepos(),
+      ]);
+      setConfigYaml(configRes.config_yaml);
+      setSavedYaml(configRes.config_yaml);
+      setRepos(reposRes.items);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load settings");
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadData();
+  }, [loadData]);
+
+  const handleSaveConfig = async () => {
+    setError(null);
+    setStatus(null);
+    try {
+      const res = await updateGlobalConfig(configYaml);
+      setSavedYaml(res.config_yaml);
+      setStatus("Configuration saved.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save config");
+    }
+  };
+
+  const handleAddRepo = async () => {
+    if (!newRepo.trim()) return;
+    setError(null);
+    setStatus(null);
+    try {
+      await registerRepo(newRepo.trim());
+      setNewRepo("");
+      const reposRes = await fetchRepos();
+      setRepos(reposRes.items);
+      setStatus("Repository added.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to add repo");
+    }
+  };
+
+  const handleRemoveRepo = async (repoPath: string) => {
+    setError(null);
+    setStatus(null);
+    try {
+      await unregisterRepo(repoPath);
+      const reposRes = await fetchRepos();
+      setRepos(reposRes.items);
+      setStatus("Repository removed.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to remove repo");
+    }
+  };
+
+  const handleCleanup = async () => {
+    setError(null);
+    setStatus(null);
+    try {
+      const res = await cleanupWorktrees();
+      setStatus(`Cleanup complete — ${res.removed} worktree(s) removed.`);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Cleanup failed",
+      );
+    }
+  };
+
+  const configDirty = configYaml !== savedYaml;
+
+  return (
+    <div className="settings-screen">
+      <h1>Settings</h1>
+
+      {error && <div className="settings-error">{error}</div>}
+      {status && <div className="settings-status">{status}</div>}
+
+      <section className="settings-section">
+        <h2>Global Configuration</h2>
+        <textarea
+          className="settings-config-editor"
+          value={configYaml}
+          onChange={(e) => setConfigYaml(e.target.value)}
+          spellCheck={false}
+          rows={20}
+        />
+        <button
+          onClick={() => void handleSaveConfig()}
+          disabled={!configDirty}
+        >
+          Save Config
+        </button>
+      </section>
+
+      <section className="settings-section">
+        <h2>Repositories</h2>
+        <div className="settings-repo-add">
+          <input
+            type="text"
+            value={newRepo}
+            onChange={(e) => setNewRepo(e.target.value)}
+            placeholder="Local path or remote URL"
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void handleAddRepo();
+            }}
+          />
+          <button onClick={() => void handleAddRepo()}>Add</button>
+        </div>
+        <ul className="settings-repo-list">
+          {repos.map((repo) => (
+            <li key={repo}>
+              <span>{repo}</span>
+              <button onClick={() => void handleRemoveRepo(repo)}>
+                Remove
+              </button>
+            </li>
+          ))}
+          {repos.length === 0 && (
+            <li className="settings-repo-empty">
+              No repositories registered.
+            </li>
+          )}
+        </ul>
+      </section>
+
+      <section className="settings-section">
+        <h2>Maintenance</h2>
+        <button onClick={() => void handleCleanup()}>
+          Clean Up Worktrees
+        </button>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Phase 9 — Operational Hardening

### Changes

- **Graceful shutdown**: `RuntimeService` cancels individual job tasks with `server_shutdown` reason, rejects new jobs during shutdown via `_shutting_down` flag
- **Restart recovery**: `recover_on_startup` already marks orphaned running/waiting jobs as failed (pre-existing)
- **Retention service**: Daily background cleanup of expired artifacts, diff snapshots, and worktrees (`RetentionService`)
- **Dev Tunnel integration**: `tower up --tunnel` starts devtunnel subprocess, extracts URL
- **Dynamic CORS**: Tunnel origin added to allowed origins alongside dev `localhost:5173`
- **Startup warning**: `0.0.0.0` binding logs warning about no authentication
- **Rich terminal**: Startup banner with server URL, mode, and tunnel URL
- **Settings API**: `GET /api/settings/repos/{repo_path}` returns repo detail with origin URL and base branch
- **Settings screen**: Global config YAML editor, repo management (add/remove), worktree cleanup action
- **Settings route**: Added to frontend navigation

### Files Changed

| File | Change |
|------|--------|
| `backend/main.py` | Lifespan (retention), create_app (CORS), up() CLI (tunnel/banner) |
| `backend/services/runtime_service.py` | Shutdown enhancement, shutting_down guard |
| `backend/services/retention_service.py` | **New** — retention policy service |
| `backend/services/git_service.py` | `get_origin_url()` method |
| `backend/api/settings.py` | Repo detail endpoint |
| `backend/models/api_schemas.py` | `RepoDetailResponse` schema |
| `frontend/src/App.tsx` | Settings route + nav link |
| `frontend/src/api/client.ts` | `fetchRepoDetail()` |
| `frontend/src/components/SettingsScreen.tsx` | **New** — settings screen component |
| `frontend/eslint.config.js` | Coverage directory ignore |

### Checklist

- [x] ruff check passes
- [x] mypy passes
- [x] tsc passes
- [x] ESLint passes
- [x] vitest (19 tests) passes
- [x] pytest (293 tests) passes
- [x] vite build succeeds