### PR TITLE
feat(phase-10): Post-Completion & Polish

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -156,11 +156,11 @@ Work is broken into phases. Each phase produces a usable increment. Later phases
 
 > PR creation, performance, comprehensive testing.
 
-- [ ] PR creation after successful job (GitHub MCP tools or `gh` CLI)
-- [ ] PR URL in `JobSucceeded` payload and Job Detail screen
-- [ ] Virtualized rendering for logs and transcript panels (`@tanstack/react-virtual`)
-- [ ] Memoized Kanban column selectors (prevent full-board re-renders)
-- [ ] Large diff lazy loading in Monaco
+- [x] PR creation after successful job (GitHub MCP tools or `gh` CLI)
+- [x] PR URL in `JobSucceeded` payload and Job Detail screen
+- [x] Virtualized rendering for logs and transcript panels (`@tanstack/react-virtual`)
+- [x] Memoized Kanban column selectors (prevent full-board re-renders)
+- [x] Large diff lazy loading in Monaco
 
 ---
 

--- a/alembic/versions/a1b2c3d4e5f6_add_pr_url_to_jobs.py
+++ b/alembic/versions/a1b2c3d4e5f6_add_pr_url_to_jobs.py
@@ -1,0 +1,29 @@
+"""add pr_url to jobs
+
+Revision ID: a1b2c3d4e5f6
+Revises: eef13d8f8935
+Create Date: 2026-03-12 20:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: str | Sequence[str] | None = "eef13d8f8935"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add pr_url column to jobs table."""
+    op.add_column("jobs", sa.Column("pr_url", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    """Remove pr_url column from jobs table."""
+    op.drop_column("jobs", "pr_url")

--- a/backend/api/jobs.py
+++ b/backend/api/jobs.py
@@ -62,6 +62,7 @@ def _job_to_response(job: object) -> JobResponse:
         created_at=j.created_at,
         updated_at=j.updated_at,
         completed_at=j.completed_at,
+        pr_url=j.pr_url,
     )
 
 

--- a/backend/models/api_schemas.py
+++ b/backend/models/api_schemas.py
@@ -133,6 +133,7 @@ class JobResponse(CamelModel):
     created_at: datetime
     updated_at: datetime
     completed_at: datetime | None
+    pr_url: str | None = None
 
 
 class JobListResponse(CamelModel):

--- a/backend/models/db.py
+++ b/backend/models/db.py
@@ -22,6 +22,7 @@ class JobRow(Base):
     branch = Column(String, nullable=True)
     worktree_path = Column(String, nullable=True)
     session_id = Column(String, nullable=True)
+    pr_url = Column(String, nullable=True)
     created_at = Column(DateTime, nullable=False)
     updated_at = Column(DateTime, nullable=False)
     completed_at = Column(DateTime, nullable=True)

--- a/backend/models/domain.py
+++ b/backend/models/domain.py
@@ -115,6 +115,7 @@ class Job:
     created_at: datetime
     updated_at: datetime
     completed_at: datetime | None = None
+    pr_url: str | None = None
 
 
 @dataclass

--- a/backend/persistence/job_repo.py
+++ b/backend/persistence/job_repo.py
@@ -38,6 +38,7 @@ class JobRepository(BaseRepository):
             created_at=row.created_at,  # type: ignore[arg-type]
             updated_at=row.updated_at,  # type: ignore[arg-type]
             completed_at=row.completed_at,  # type: ignore[arg-type]
+            pr_url=row.pr_url,  # type: ignore[arg-type]
         )
 
     async def create(self, job: Job) -> Job:
@@ -55,6 +56,7 @@ class JobRepository(BaseRepository):
             created_at=job.created_at,
             updated_at=job.updated_at,
             completed_at=job.completed_at,
+            pr_url=job.pr_url,
         )
         self._session.add(row)
         await self._session.flush()
@@ -108,4 +110,13 @@ class JobRepository(BaseRepository):
         row.updated_at = updated_at  # type: ignore[assignment]
         if completed_at is not None:
             row.completed_at = completed_at  # type: ignore[assignment]
+        await self._session.flush()
+
+    async def update_pr_url(self, job_id: str, pr_url: str) -> None:
+        """Store the PR URL on a job row."""
+        result = await self._session.execute(select(JobRow).where(JobRow.id == job_id))
+        row = result.scalar_one_or_none()
+        if row is None:
+            return
+        row.pr_url = pr_url  # type: ignore[assignment]
         await self._session.flush()

--- a/backend/services/runtime_service.py
+++ b/backend/services/runtime_service.py
@@ -485,6 +485,7 @@ class RuntimeService:
 
     async def _try_create_pr(self, job_id: str) -> str | None:
         """Best-effort PR creation via ``gh pr create``. Returns the PR URL or None."""
+        import re
         import shutil
         import subprocess  # noqa: S404
 
@@ -500,6 +501,15 @@ class RuntimeService:
             log.info("pr_creation_skipped_no_worktree", job_id=job_id)
             return None
 
+        # Validate branch and base_ref to prevent argument injection
+        _ref_pattern = re.compile(r"^[a-zA-Z0-9/_.-]+$")
+        if not _ref_pattern.match(job.branch):
+            log.warning("pr_creation_invalid_branch", job_id=job_id)
+            return None
+        if not _ref_pattern.match(job.base_ref):
+            log.warning("pr_creation_invalid_base_ref", job_id=job_id)
+            return None
+
         try:
             result = await asyncio.to_thread(
                 subprocess.run,  # noqa: S603
@@ -510,11 +520,12 @@ class RuntimeService:
                     "--title",
                     f"[Tower] {job.prompt[:80]}",
                     "--body",
-                    f"Automated PR created by Tower for job `{job_id}`.\n\n**Prompt:** {job.prompt}",
+                    f"Automated PR created by Tower for job `{job_id}`.",
                     "--head",
                     job.branch,
                     "--base",
                     job.base_ref,
+                    "--",
                 ],
                 capture_output=True,
                 text=True,

--- a/backend/services/runtime_service.py
+++ b/backend/services/runtime_service.py
@@ -321,10 +321,18 @@ class RuntimeService:
                 await self._fail_job(job_id, error_reason)
                 return
 
+            # Best-effort PR creation before transitioning to succeeded
+            pr_url = await self._try_create_pr(job_id)
+
             # Strategy completed normally → succeeded
             async with self._session_factory() as session:
                 svc = self._make_job_service(session)
                 await svc.transition_state(job_id, JobState.succeeded)
+                if pr_url:
+                    from backend.persistence.job_repo import JobRepository
+
+                    job_repo = JobRepository(session)
+                    await job_repo.update_pr_url(job_id, pr_url)
                 await session.commit()
             await self._event_bus.publish(
                 DomainEvent(
@@ -332,10 +340,10 @@ class RuntimeService:
                     job_id=job_id,
                     timestamp=datetime.now(UTC),
                     kind=DomainEventKind.job_succeeded,
-                    payload={},
+                    payload={"pr_url": pr_url} if pr_url else {},
                 )
             )
-            log.info("job_succeeded", job_id=job_id)
+            log.info("job_succeeded", job_id=job_id, pr_url=pr_url)
         except asyncio.CancelledError:
             log.info("job_canceled_by_task", job_id=job_id)
             try:
@@ -474,6 +482,58 @@ class RuntimeService:
             )
         except Exception:
             log.error("fail_job_transition_failed", job_id=job_id, exc_info=True)
+
+    async def _try_create_pr(self, job_id: str) -> str | None:
+        """Best-effort PR creation via ``gh pr create``. Returns the PR URL or None."""
+        import shutil
+        import subprocess  # noqa: S404
+
+        if shutil.which("gh") is None:
+            log.info("pr_creation_skipped_no_gh", job_id=job_id)
+            return None
+
+        async with self._session_factory() as session:
+            svc = self._make_job_service(session)
+            job = await svc.get_job(job_id)
+
+        if job is None or not job.worktree_path or not job.branch:
+            log.info("pr_creation_skipped_no_worktree", job_id=job_id)
+            return None
+
+        try:
+            result = await asyncio.to_thread(
+                subprocess.run,  # noqa: S603
+                [
+                    "gh",
+                    "pr",
+                    "create",
+                    "--title",
+                    f"[Tower] {job.prompt[:80]}",
+                    "--body",
+                    f"Automated PR created by Tower for job `{job_id}`.\n\n**Prompt:** {job.prompt}",
+                    "--head",
+                    job.branch,
+                    "--base",
+                    job.base_ref,
+                ],
+                capture_output=True,
+                text=True,
+                cwd=job.worktree_path,
+                timeout=60,
+            )
+            if result.returncode == 0:
+                pr_url = result.stdout.strip()
+                log.info("pr_created", job_id=job_id, pr_url=pr_url)
+                return pr_url
+            log.warning(
+                "pr_creation_failed",
+                job_id=job_id,
+                returncode=result.returncode,
+                stderr=result.stderr[:500],
+            )
+        except Exception:
+            log.warning("pr_creation_error", job_id=job_id, exc_info=True)
+        return None
 
     async def _publish_state_event(self, job_id: str, previous_state: str | None, new_state: str) -> None:
         """Publish a job state change event."""

--- a/frontend/src/components/DiffViewer.tsx
+++ b/frontend/src/components/DiffViewer.tsx
@@ -1,12 +1,17 @@
 /**
- * DiffViewer — displays structured diff output with file list and hunk details.
+ * DiffViewer — displays structured diff output with Monaco DiffEditor.
  *
- * Uses a simple text-based diff view. File list on the left, diff content on the right.
+ * File sidebar on the left, Monaco DiffEditor on the right.
+ * Diff content is lazy-loaded per file (only builds original/modified for selected file).
  */
 
-import { useEffect, useMemo, useState } from "react";
+import { lazy, Suspense, useEffect, useMemo, useState } from "react";
 import type { DiffFileModel } from "../api/types";
 import { selectJobDiffs, useTowerStore } from "../store";
+
+const DiffEditor = lazy(() =>
+  import("@monaco-editor/react").then((m) => ({ default: m.DiffEditor })),
+);
 
 interface DiffViewerProps {
   jobId: string;
@@ -38,6 +43,53 @@ function statusColor(status: string): string {
   }
 }
 
+/** Reconstruct original and modified text from hunk lines. */
+function buildDiffTexts(file: DiffFileModel): {
+  original: string;
+  modified: string;
+} {
+  const origLines: string[] = [];
+  const modLines: string[] = [];
+  for (const hunk of file.hunks) {
+    for (const line of hunk.lines) {
+      if (line.type === "context") {
+        origLines.push(line.content);
+        modLines.push(line.content);
+      } else if (line.type === "deletion") {
+        origLines.push(line.content);
+      } else if (line.type === "addition") {
+        modLines.push(line.content);
+      }
+    }
+  }
+  return { original: origLines.join("\n"), modified: modLines.join("\n") };
+}
+
+/** Guess Monaco language from file extension. */
+function guessLanguage(path: string): string {
+  const ext = path.split(".").pop()?.toLowerCase() ?? "";
+  const map: Record<string, string> = {
+    ts: "typescript",
+    tsx: "typescript",
+    js: "javascript",
+    jsx: "javascript",
+    py: "python",
+    json: "json",
+    md: "markdown",
+    css: "css",
+    html: "html",
+    yml: "yaml",
+    yaml: "yaml",
+    sql: "sql",
+    sh: "shell",
+    bash: "shell",
+    toml: "ini",
+    rs: "rust",
+    go: "go",
+  };
+  return map[ext] ?? "plaintext";
+}
+
 export default function DiffViewer({ jobId }: DiffViewerProps) {
   const selector = useMemo(() => selectJobDiffs(jobId), [jobId]);
   const files = useTowerStore(selector);
@@ -48,6 +100,12 @@ export default function DiffViewer({ jobId }: DiffViewerProps) {
   }, [files.length]);
 
   const selectedFile = files[selectedIdx] as DiffFileModel | undefined;
+
+  // Lazy: only compute diff texts for the currently selected file
+  const diffTexts = useMemo(
+    () => (selectedFile ? buildDiffTexts(selectedFile) : null),
+    [selectedFile],
+  );
 
   const totalStats = useMemo(() => {
     let additions = 0;
@@ -66,7 +124,14 @@ export default function DiffViewer({ jobId }: DiffViewerProps) {
   }
 
   return (
-    <div style={{ display: "flex", height: "100%", fontFamily: "monospace", fontSize: 13 }}>
+    <div
+      style={{
+        display: "flex",
+        height: "100%",
+        fontFamily: "monospace",
+        fontSize: 13,
+      }}
+    >
       {/* File list sidebar */}
       <div
         style={{
@@ -76,10 +141,20 @@ export default function DiffViewer({ jobId }: DiffViewerProps) {
           flexShrink: 0,
         }}
       >
-        <div style={{ padding: "8px 12px", borderBottom: "1px solid #333", color: "#ccc" }}>
+        <div
+          style={{
+            padding: "8px 12px",
+            borderBottom: "1px solid #333",
+            color: "#ccc",
+          }}
+        >
           {files.length} file{files.length !== 1 ? "s" : ""} changed
-          <span style={{ color: "#2ea043", marginLeft: 8 }}>+{totalStats.additions}</span>
-          <span style={{ color: "#f85149", marginLeft: 4 }}>-{totalStats.deletions}</span>
+          <span style={{ color: "#2ea043", marginLeft: 8 }}>
+            +{totalStats.additions}
+          </span>
+          <span style={{ color: "#f85149", marginLeft: 4 }}>
+            -{totalStats.deletions}
+          </span>
         </div>
         {files.map((file, idx) => (
           <button
@@ -98,7 +173,9 @@ export default function DiffViewer({ jobId }: DiffViewerProps) {
               fontSize: 12,
             }}
           >
-            <span style={{ color: statusColor(file.status), marginRight: 6 }}>
+            <span
+              style={{ color: statusColor(file.status), marginRight: 6 }}
+            >
               {statusIcon(file.status)}
             </span>
             {file.path}
@@ -109,64 +186,31 @@ export default function DiffViewer({ jobId }: DiffViewerProps) {
         ))}
       </div>
 
-      {/* Diff content */}
-      <div style={{ flex: 1, overflowY: "auto", padding: 0 }}>
-        {selectedFile && (
-          <div>
-            <div
-              style={{
-                padding: "8px 16px",
-                borderBottom: "1px solid #333",
-                color: "#ccc",
-                fontWeight: "bold",
-              }}
-            >
-              {selectedFile.path}
-            </div>
-            {selectedFile.hunks.map((hunk, hunkIdx) => (
-              <div key={`${selectedFile.path}-hunk-${hunkIdx}`}>
-                <div
-                  style={{
-                    padding: "4px 16px",
-                    background: "#1c2128",
-                    color: "#8b949e",
-                    borderBottom: "1px solid #333",
-                  }}
-                >
-                  @@ -{hunk.oldStart},{hunk.oldLines} +{hunk.newStart},{hunk.newLines} @@
-                </div>
-                {hunk.lines.map((line, lineIdx) => {
-                  let bg = "transparent";
-                  let color = "#ccc";
-                  let prefix = " ";
-                  if (line.type === "addition") {
-                    bg = "rgba(46, 160, 67, 0.15)";
-                    color = "#2ea043";
-                    prefix = "+";
-                  } else if (line.type === "deletion") {
-                    bg = "rgba(248, 81, 73, 0.15)";
-                    color = "#f85149";
-                    prefix = "-";
-                  }
-                  return (
-                    <div
-                      key={`${selectedFile.path}-${hunkIdx}-${lineIdx}`}
-                      style={{
-                        padding: "0 16px",
-                        background: bg,
-                        color,
-                        whiteSpace: "pre-wrap",
-                        lineHeight: "20px",
-                      }}
-                    >
-                      {prefix}
-                      {line.content}
-                    </div>
-                  );
-                })}
+      {/* Monaco DiffEditor — lazy loaded */}
+      <div style={{ flex: 1, overflow: "hidden" }}>
+        {selectedFile && diffTexts && (
+          <Suspense
+            fallback={
+              <div style={{ padding: 16, color: "#888" }}>
+                Loading diff editor…
               </div>
-            ))}
-          </div>
+            }
+          >
+            <DiffEditor
+              original={diffTexts.original}
+              modified={diffTexts.modified}
+              language={guessLanguage(selectedFile.path)}
+              theme="vs-dark"
+              options={{
+                readOnly: true,
+                renderSideBySide: true,
+                minimap: { enabled: false },
+                scrollBeyondLastLine: false,
+                fontSize: 13,
+                lineNumbers: "on",
+              }}
+            />
+          </Suspense>
         )}
       </div>
     </div>

--- a/frontend/src/components/JobDetailScreen.tsx
+++ b/frontend/src/components/JobDetailScreen.tsx
@@ -178,6 +178,16 @@ export function JobDetailScreen() {
               </span>
             </div>
           )}
+          {job.prUrl && (
+            <div className="job-meta__field">
+              <span className="job-meta__label">Pull Request</span>
+              <span className="job-meta__value">
+                <a href={job.prUrl} target="_blank" rel="noopener noreferrer">
+                  {job.prUrl.replace(/^https?:\/\/github\.com\//, "")}
+                </a>
+              </span>
+            </div>
+          )}
         </div>
 
         <div className="job-meta__prompt">{job.prompt}</div>

--- a/frontend/src/components/JobDetailScreen.tsx
+++ b/frontend/src/components/JobDetailScreen.tsx
@@ -178,12 +178,12 @@ export function JobDetailScreen() {
               </span>
             </div>
           )}
-          {job.prUrl && (
+          {job.prUrl && /^https:\/\/github\.com\//.test(job.prUrl) && (
             <div className="job-meta__field">
               <span className="job-meta__label">Pull Request</span>
               <span className="job-meta__value">
                 <a href={job.prUrl} target="_blank" rel="noopener noreferrer">
-                  {job.prUrl.replace(/^https?:\/\/github\.com\//, "")}
+                  {job.prUrl.replace(/^https:\/\/github\.com\//, "")}
                 </a>
               </span>
             </div>

--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -1,50 +1,22 @@
-import { useMemo, useState, useCallback } from "react";
-import { useTowerStore, selectJobs } from "../store";
-import type { JobSummary } from "../store";
+import { useState, useCallback } from "react";
+import {
+  useTowerStore,
+  selectActiveJobs,
+  selectSignoffJobs,
+  selectFailedJobs,
+  selectHistoryJobs,
+} from "../store";
 import { KanbanColumn } from "./KanbanColumn";
 import { fetchJobs } from "../api/client";
-
-/** Spec §14.1: column → state mapping */
-const COLUMN_STATES: Record<string, string[]> = {
-  Active: ["queued", "running"],
-  "Sign-off": ["waiting_for_approval"],
-  Failed: ["failed"],
-  History: ["succeeded", "canceled"],
-};
-
-function filterByStates(
-  jobs: Record<string, JobSummary>,
-  states: string[],
-): JobSummary[] {
-  return Object.values(jobs)
-    .filter((j) => states.includes(j.state))
-    .sort(
-      (a, b) =>
-        new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
-    );
-}
+import { useShallow } from "zustand/react/shallow";
 
 export function KanbanBoard() {
-  const jobs = useTowerStore(selectJobs);
+  const activeJobs = useTowerStore(useShallow(selectActiveJobs));
+  const signoffJobs = useTowerStore(useShallow(selectSignoffJobs));
+  const failedJobs = useTowerStore(useShallow(selectFailedJobs));
+  const historyJobs = useTowerStore(useShallow(selectHistoryJobs));
   const [historyCursor, setHistoryCursor] = useState<string | null>(null);
   const [historyHasMore, setHistoryHasMore] = useState(true);
-
-  const activeJobs = useMemo(
-    () => filterByStates(jobs, COLUMN_STATES.Active ?? []),
-    [jobs],
-  );
-  const signoffJobs = useMemo(
-    () => filterByStates(jobs, COLUMN_STATES["Sign-off"] ?? []),
-    [jobs],
-  );
-  const failedJobs = useMemo(
-    () => filterByStates(jobs, COLUMN_STATES.Failed ?? []),
-    [jobs],
-  );
-  const historyJobs = useMemo(
-    () => filterByStates(jobs, COLUMN_STATES.History ?? []),
-    [jobs],
-  );
 
   const loadMoreHistory = useCallback(async () => {
     try {

--- a/frontend/src/components/LogsPanel.tsx
+++ b/frontend/src/components/LogsPanel.tsx
@@ -1,24 +1,45 @@
-import { useState, useMemo, useRef, useEffect } from "react";
+import { useState, useMemo, useRef, useEffect, useCallback } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { useTowerStore, selectJobLogs } from "../store";
 
 const LEVELS = ["debug", "info", "warn", "error"] as const;
 type Level = (typeof LEVELS)[number];
+
+const ESTIMATED_ROW_HEIGHT = 24;
 
 export function LogsPanel({ jobId }: { jobId: string }) {
   const logs = useTowerStore(selectJobLogs(jobId));
   const [enabledLevels, setEnabledLevels] = useState<Set<Level>>(
     new Set(["info", "warn", "error"]),
   );
-  const bottomRef = useRef<HTMLDivElement>(null);
+  const parentRef = useRef<HTMLDivElement>(null);
+  const wasAtBottom = useRef(true);
 
   const filteredLogs = useMemo(
     () => logs.filter((l) => enabledLevels.has(l.level as Level)),
     [logs, enabledLevels],
   );
 
+  const virtualizer = useVirtualizer({
+    count: filteredLogs.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => ESTIMATED_ROW_HEIGHT,
+    overscan: 20,
+  });
+
+  // Track whether user is at bottom before new items arrive
+  const onScroll = useCallback(() => {
+    const el = parentRef.current;
+    if (!el) return;
+    wasAtBottom.current = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
+  }, []);
+
+  // Auto-scroll to bottom when new logs arrive, only if user was at bottom
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [filteredLogs.length]);
+    if (wasAtBottom.current && filteredLogs.length > 0) {
+      virtualizer.scrollToIndex(filteredLogs.length - 1, { align: "end" });
+    }
+  }, [filteredLogs.length, virtualizer]);
 
   function toggleLevel(level: Level) {
     setEnabledLevels((prev) => {
@@ -48,25 +69,52 @@ export function LogsPanel({ jobId }: { jobId: string }) {
           ))}
         </div>
       </div>
-      <div className="panel__body">
+      <div
+        ref={parentRef}
+        className="panel__body"
+        onScroll={onScroll}
+        style={{ overflow: "auto" }}
+      >
         {filteredLogs.length === 0 ? (
           <div className="empty-state">
             <div className="empty-state__text">No log entries</div>
           </div>
         ) : (
-          filteredLogs.map((line) => (
-            <div key={`${line.jobId}-${line.seq}`} className="log-line">
-              <span className="log-line__time">
-                {new Date(line.timestamp).toLocaleTimeString()}
-              </span>
-              <span className={`log-line__level log-line__level--${line.level}`}>
-                {line.level}
-              </span>
-              <span className="log-line__msg">{line.message}</span>
-            </div>
-          ))
+          <div
+            style={{
+              height: virtualizer.getTotalSize(),
+              width: "100%",
+              position: "relative",
+            }}
+          >
+            {virtualizer.getVirtualItems().map((virtualItem) => {
+              const line = filteredLogs[virtualItem.index]!;
+              return (
+                <div
+                  key={`${line.jobId}-${line.seq}`}
+                  className="log-line"
+                  data-index={virtualItem.index}
+                  ref={virtualizer.measureElement}
+                  style={{
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    width: "100%",
+                    transform: `translateY(${virtualItem.start}px)`,
+                  }}
+                >
+                  <span className="log-line__time">
+                    {new Date(line.timestamp).toLocaleTimeString()}
+                  </span>
+                  <span className={`log-line__level log-line__level--${line.level}`}>
+                    {line.level}
+                  </span>
+                  <span className="log-line__msg">{line.message}</span>
+                </div>
+              );
+            })}
+          </div>
         )}
-        <div ref={bottomRef} />
       </div>
     </div>
   );

--- a/frontend/src/components/TranscriptPanel.tsx
+++ b/frontend/src/components/TranscriptPanel.tsx
@@ -1,14 +1,33 @@
-import { useRef, useEffect } from "react";
+import { useRef, useEffect, useCallback } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { useTowerStore, selectJobTranscript } from "../store";
+
+const ESTIMATED_ROW_HEIGHT = 60;
 
 export function TranscriptPanel({ jobId }: { jobId: string }) {
   const transcript = useTowerStore(selectJobTranscript(jobId));
-  const bottomRef = useRef<HTMLDivElement>(null);
+  const parentRef = useRef<HTMLDivElement>(null);
+  const wasAtBottom = useRef(true);
+
+  const virtualizer = useVirtualizer({
+    count: transcript.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => ESTIMATED_ROW_HEIGHT,
+    overscan: 10,
+  });
+
+  const onScroll = useCallback(() => {
+    const el = parentRef.current;
+    if (!el) return;
+    wasAtBottom.current = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
+  }, []);
 
   // Auto-scroll to bottom on new entries
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [transcript.length]);
+    if (wasAtBottom.current && transcript.length > 0) {
+      virtualizer.scrollToIndex(transcript.length - 1, { align: "end" });
+    }
+  }, [transcript.length, virtualizer]);
 
   return (
     <div className="panel">
@@ -16,27 +35,54 @@ export function TranscriptPanel({ jobId }: { jobId: string }) {
         <span>Transcript</span>
         <span style={{ fontSize: 11 }}>{transcript.length} messages</span>
       </div>
-      <div className="panel__body">
+      <div
+        ref={parentRef}
+        className="panel__body"
+        onScroll={onScroll}
+        style={{ overflow: "auto" }}
+      >
         {transcript.length === 0 ? (
           <div className="empty-state">
             <div className="empty-state__text">No transcript entries yet</div>
           </div>
         ) : (
-          transcript.map((entry) => (
-            <div key={`${entry.jobId}-${entry.seq}`} className="transcript-entry">
-              <div
-                className={`transcript-entry__role transcript-entry__role--${entry.role}`}
-              >
-                {entry.role}
-              </div>
-              <div className="transcript-entry__content">{entry.content}</div>
-              <div className="transcript-entry__time">
-                {new Date(entry.timestamp).toLocaleTimeString()}
-              </div>
-            </div>
-          ))
+          <div
+            style={{
+              height: virtualizer.getTotalSize(),
+              width: "100%",
+              position: "relative",
+            }}
+          >
+            {virtualizer.getVirtualItems().map((virtualItem) => {
+              const entry = transcript[virtualItem.index]!;
+              return (
+                <div
+                  key={`${entry.jobId}-${entry.seq}`}
+                  className="transcript-entry"
+                  data-index={virtualItem.index}
+                  ref={virtualizer.measureElement}
+                  style={{
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    width: "100%",
+                    transform: `translateY(${virtualItem.start}px)`,
+                  }}
+                >
+                  <div
+                    className={`transcript-entry__role transcript-entry__role--${entry.role}`}
+                  >
+                    {entry.role}
+                  </div>
+                  <div className="transcript-entry__content">{entry.content}</div>
+                  <div className="transcript-entry__time">
+                    {new Date(entry.timestamp).toLocaleTimeString()}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
         )}
-        <div ref={bottomRef} />
       </div>
     </div>
   );

--- a/frontend/src/store/index.test.ts
+++ b/frontend/src/store/index.test.ts
@@ -22,6 +22,7 @@ function makeJob(overrides: Partial<JobSummary> = {}): JobSummary {
     createdAt: "2025-01-01T00:00:00Z",
     updatedAt: "2025-01-01T00:00:00Z",
     completedAt: null,
+    prUrl: null,
     ...overrides,
   };
 }

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -32,6 +32,7 @@ export interface JobSummary {
   createdAt: string;
   updatedAt: string;
   completedAt: string | null;
+  prUrl: string | null;
 }
 
 export interface ApprovalRequest {
@@ -205,6 +206,21 @@ export const useTowerStore = create<TowerState>((set) => ({
           return state;
         }
 
+        case "job_succeeded": {
+          const jobId = payload.jobId as string;
+          const prUrl = (payload.prUrl as string | null) ?? null;
+          const existing = state.jobs[jobId];
+          if (existing && prUrl) {
+            return {
+              jobs: {
+                ...state.jobs,
+                [jobId]: { ...existing, prUrl },
+              },
+            };
+          }
+          return state;
+        }
+
         case "diff_update": {
           const jobId = payload.jobId as string;
           const changedFiles = (payload.changedFiles as DiffFileModel[]) ?? [];
@@ -233,3 +249,37 @@ export const selectJobTranscript = (jobId: string) => (state: TowerState) =>
   state.transcript[jobId] ?? [];
 export const selectJobDiffs = (jobId: string) => (state: TowerState) =>
   state.diffs[jobId] ?? [];
+
+// Per-column selectors — only recompute when jobs in that column change
+function sortByUpdatedDesc(jobs: JobSummary[]): JobSummary[] {
+  return jobs.sort(
+    (a, b) =>
+      new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+  );
+}
+
+export const selectActiveJobs = (state: TowerState): JobSummary[] =>
+  sortByUpdatedDesc(
+    Object.values(state.jobs).filter(
+      (j) => j.state === "queued" || j.state === "running",
+    ),
+  );
+
+export const selectSignoffJobs = (state: TowerState): JobSummary[] =>
+  sortByUpdatedDesc(
+    Object.values(state.jobs).filter(
+      (j) => j.state === "waiting_for_approval",
+    ),
+  );
+
+export const selectFailedJobs = (state: TowerState): JobSummary[] =>
+  sortByUpdatedDesc(
+    Object.values(state.jobs).filter((j) => j.state === "failed"),
+  );
+
+export const selectHistoryJobs = (state: TowerState): JobSummary[] =>
+  sortByUpdatedDesc(
+    Object.values(state.jobs).filter(
+      (j) => j.state === "succeeded" || j.state === "canceled",
+    ),
+  );


### PR DESCRIPTION
## Phase 10: Post-Completion & Polish

### Changes

**Backend:**
- PR creation after successful job completion (best-effort `gh pr create`)
- `pr_url` field plumbed through: `JobRow` → `Job` domain → `JobResponse` API → SSE payload
- New `update_pr_url()` method in `JobRepository`
- Alembic migration for `pr_url` column

**Frontend:**
- Virtualized `LogsPanel` using `@tanstack/react-virtual` (auto-scroll, dynamic row heights)
- Virtualized `TranscriptPanel` using `@tanstack/react-virtual` (auto-scroll, dynamic row heights)
- Memoized per-column Kanban selectors with `useShallow` (prevents full-board re-renders)
- Monaco `DiffEditor` with lazy loading per file (replaces text-based diff view)
- PR URL display in Job Detail screen
- `job_succeeded` SSE event handler updates `prUrl` in store

### ROADMAP Items
- [x] PR creation after successful job (GitHub MCP tools or `gh` CLI)
- [x] PR URL in `JobSucceeded` payload and Job Detail screen
- [x] Virtualized rendering for logs and transcript panels (`@tanstack/react-virtual`)
- [x] Memoized Kanban column selectors (prevent full-board re-renders)
- [x] Large diff lazy loading in Monaco