### PR TITLE
feat: Phase 11 — MCP orchestration server + setup CLI

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -168,16 +168,20 @@ Work is broken into phases. Each phase produces a usable increment. Later phases
 
 > Expose Tower's full functionality as an MCP server so external agents can use it as an orchestration layer.
 
-- [ ] MCP server transport — Streamable HTTP on `/mcp`, mounted in FastAPI app
-- [ ] MCP tool handlers for Job management (`tower_job_create`, `tower_job_list`, `tower_job_get`, `tower_job_cancel`, `tower_job_rerun`, `tower_job_message`)
-- [ ] MCP tool handlers for Approvals (`tower_approval_list`, `tower_approval_resolve`)
-- [ ] MCP tool handlers for Workspace & Artifacts (`tower_workspace_list`, `tower_workspace_read`, `tower_artifact_list`, `tower_artifact_get`)
-- [ ] MCP tool handlers for Configuration (`tower_settings_get`, `tower_settings_update`, `tower_repo_list`, `tower_repo_get`, `tower_repo_register`, `tower_repo_remove`)
-- [ ] MCP tool handlers for Observability (`tower_health`, `tower_cleanup_worktrees`)
-- [ ] Server-to-client notifications via event bus subscription (`tower/job_state_changed`, `tower/approval_requested`, `tower/job_completed`, `tower/agent_message`)
-- [ ] Schema derivation from existing Pydantic models
-- [ ] MCP server configuration (`mcp_server.enabled`, `mcp_server.path`)
-- [ ] Dev Tunnel authentication for remote MCP connections
+- [x] MCP server transport — Streamable HTTP on `/mcp`, mounted in FastAPI app
+- [x] MCP tool handlers for Job management (`tower_job_create`, `tower_job_list`, `tower_job_get`, `tower_job_cancel`, `tower_job_rerun`, `tower_job_message`)
+- [x] MCP tool handlers for Approvals (`tower_approval_list`, `tower_approval_resolve`)
+- [x] MCP tool handlers for Workspace & Artifacts (`tower_workspace_list`, `tower_workspace_read`, `tower_artifact_list`, `tower_artifact_get`)
+- [x] MCP tool handlers for Configuration (`tower_settings_get`, `tower_settings_update`, `tower_repo_list`, `tower_repo_get`, `tower_repo_register`, `tower_repo_remove`)
+- [x] MCP tool handlers for Observability (`tower_health`, `tower_cleanup_worktrees`)
+- [x] Server-to-client notifications via event bus subscription (`tower/job_state_changed`, `tower/approval_requested`, `tower/job_completed`, `tower/agent_message`)
+- [x] Schema derivation from existing Pydantic models
+- [x] MCP server configuration (`mcp_server.enabled`, `mcp_server.path`)
+- [x] Dev Tunnel authentication for remote MCP connections
+- [x] AGENT_TOWER_HOME env var support for custom data directory
+- [x] `tower setup` interactive onboarding CLI (deps check, auth, devtunnel, config)
+- [x] `tower doctor` non-interactive dependency check
+- [x] WSL-aware headless auth flows for gh CLI and devtunnel
 - [ ] Integration tests for MCP tool calls end-to-end
 - [ ] Comprehensive unit tests (state machine, diff parser, config, approval logic)
 - [ ] Integration tests (git service, concurrent jobs, approval flow, SSE replay, restart recovery)

--- a/backend/config.py
+++ b/backend/config.py
@@ -2,13 +2,23 @@
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 import yaml
 
-TOWER_DIR = Path.home() / ".tower"
+
+def _resolve_tower_dir() -> Path:
+    """Resolve AGENT_TOWER_HOME from env var, falling back to ~/.tower."""
+    env = os.environ.get("AGENT_TOWER_HOME")
+    if env:
+        return Path(env).expanduser().resolve()
+    return Path.home() / ".tower"
+
+
+TOWER_DIR = _resolve_tower_dir()
 DEFAULT_CONFIG_PATH = TOWER_DIR / "config.yaml"
 DEFAULT_DB_PATH = TOWER_DIR / "data.db"
 
@@ -86,6 +96,12 @@ class RateLimitConfig:
 
 
 @dataclass
+class McpServerConfig:
+    enabled: bool = True
+    path: str = "/mcp"
+
+
+@dataclass
 class TowerConfig:
     server: ServerConfig = field(default_factory=ServerConfig)
     runtime: RuntimeConfig = field(default_factory=RuntimeConfig)
@@ -93,6 +109,7 @@ class TowerConfig:
     retention: RetentionConfig = field(default_factory=RetentionConfig)
     logging: LoggingConfig = field(default_factory=LoggingConfig)
     rate_limits: RateLimitConfig = field(default_factory=RateLimitConfig)
+    mcp_server: McpServerConfig = field(default_factory=McpServerConfig)
     repos: list[str] = field(default_factory=list)
     repos_base_dir: str = "~/tower-repos"
 
@@ -125,6 +142,7 @@ def load_config(path: Path | None = None) -> TowerConfig:
         retention=_parse_section(raw, RetentionConfig, "retention"),
         logging=_parse_section(raw, LoggingConfig, "logging"),
         rate_limits=_parse_section(raw, RateLimitConfig, "rate_limits"),
+        mcp_server=_parse_section(raw, McpServerConfig, "mcp_server"),
         repos=[str(r) for r in raw.get("repos", []) if r is not None] if isinstance(raw.get("repos", []), list) else [],
         repos_base_dir=raw.get("repos_base_dir", "~/tower-repos"),
     )
@@ -159,6 +177,10 @@ def save_config(config: TowerConfig, path: Path | None = None) -> None:
         },
         "rate_limits": {
             "max_sse_connections": config.rate_limits.max_sse_connections,
+        },
+        "mcp_server": {
+            "enabled": config.mcp_server.enabled,
+            "path": config.mcp_server.path,
         },
         "repos_base_dir": config.repos_base_dir,
         "repos": config.repos,

--- a/backend/main.py
+++ b/backend/main.py
@@ -106,6 +106,19 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # Session factory available for route handlers that need ad-hoc sessions
     app.state.session_factory = session_factory
 
+    # --- MCP server ---
+    if config.mcp_server.enabled:
+        from backend.mcp.server import create_mcp_server
+
+        mcp_server = create_mcp_server(
+            session_factory=session_factory,
+            runtime_service=runtime_service,
+            approval_service=approval_service,
+        )
+        app.state.mcp_server = mcp_server
+        app.mount(config.mcp_server.path, mcp_server.streamable_http_app())
+        log.info("mcp_server_mounted", path=config.mcp_server.path)
+
     async def _session_dep() -> AsyncGenerator[AsyncSession, None]:
         async with session_factory() as session:
             try:
@@ -280,6 +293,28 @@ def init() -> None:
 def version() -> None:
     """Print Tower version."""
     click.echo("tower 0.1.0")
+
+
+@cli.command()
+def setup() -> None:
+    """Interactive setup wizard — check dependencies, configure data directory, authenticate."""
+    from backend.services.setup_service import run_setup
+
+    run_setup()
+
+
+@cli.command()
+def doctor() -> None:
+    """Quick dependency check (non-interactive)."""
+    from backend.services.setup_service import preflight_check
+
+    click.echo("Checking dependencies...")
+    ok = preflight_check(verbose=True)
+    if ok:
+        click.secho("\nAll required dependencies are present.", fg="green")
+    else:
+        click.secho("\nSome required dependencies are missing. Run 'tower setup' to install.", fg="red")
+        raise SystemExit(1)
 
 
 if __name__ == "__main__":

--- a/backend/mcp/__init__.py
+++ b/backend/mcp/__init__.py
@@ -1,0 +1,1 @@
+"""MCP orchestration server for Tower."""

--- a/backend/mcp/server.py
+++ b/backend/mcp/server.py
@@ -1,0 +1,644 @@
+"""MCP server exposing Tower functionality as MCP tools.
+
+Each tool handler is thin: validate input, delegate to the existing service
+layer, and return the result — same principle as the REST route handlers.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import structlog
+from mcp.server.fastmcp import FastMCP
+
+from backend.config import (
+    load_config,
+    register_repo,
+    unregister_repo,
+)
+from backend.models.api_schemas import (
+    ApprovalResponse,
+    ArtifactResponse,
+    CreateJobResponse,
+    GlobalConfigResponse,
+    HealthResponse,
+    HealthStatus,
+    JobListResponse,
+    JobResponse,
+    RegisterRepoResponse,
+    RepoDetailResponse,
+    RepoListResponse,
+    SendMessageResponse,
+    WorkspaceEntry,
+    WorkspaceEntryType,
+    WorkspaceListResponse,
+)
+from backend.persistence.artifact_repo import ArtifactRepository
+from backend.persistence.job_repo import JobRepository
+from backend.services.artifact_service import ArtifactService
+from backend.services.git_service import GitError, GitService
+from backend.services.job_service import (
+    JobNotFoundError,
+    JobService,
+    RepoNotAllowedError,
+    StateConflictError,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    from backend.services.approval_service import ApprovalService
+    from backend.services.runtime_service import RuntimeService
+
+log = structlog.get_logger()
+
+_start_time = time.monotonic()
+
+# Module-level references to shared services, set during create_mcp_server()
+_session_factory: async_sessionmaker[AsyncSession] | None = None
+_runtime_service: RuntimeService | None = None
+_approval_service: ApprovalService | None = None
+
+
+def _get_session_factory() -> async_sessionmaker[AsyncSession]:
+    assert _session_factory is not None, "MCP server not initialized"  # noqa: S101
+    return _session_factory
+
+
+def _get_runtime() -> RuntimeService:
+    assert _runtime_service is not None, "MCP server not initialized"  # noqa: S101
+    return _runtime_service
+
+
+def _get_approval() -> ApprovalService:
+    assert _approval_service is not None, "MCP server not initialized"  # noqa: S101
+    return _approval_service
+
+
+def _job_to_response(job: Any) -> dict[str, Any]:
+    """Convert a domain Job to a serializable dict via JobResponse."""
+    resp = JobResponse(
+        id=job.id,
+        repo=job.repo,
+        prompt=job.prompt,
+        state=job.state,
+        strategy=job.strategy,
+        base_ref=job.base_ref,
+        worktree_path=job.worktree_path,
+        branch=job.branch,
+        created_at=job.created_at,
+        updated_at=job.updated_at,
+        completed_at=job.completed_at,
+        pr_url=job.pr_url,
+    )
+    return resp.model_dump(mode="json")
+
+
+def _strip_url_credentials(url: str) -> str:
+    """Remove embedded credentials from a git remote URL."""
+    from urllib.parse import urlparse, urlunparse
+
+    parsed = urlparse(url)
+    if parsed.username or parsed.password:
+        host = parsed.hostname or ""
+        if parsed.port:
+            host = f"{host}:{parsed.port}"
+        cleaned = parsed._replace(netloc=host)
+        return urlunparse(cleaned)
+    return url
+
+
+def create_mcp_server(
+    *,
+    session_factory: async_sessionmaker[AsyncSession],
+    runtime_service: RuntimeService,
+    approval_service: ApprovalService,
+) -> FastMCP:
+    """Create and configure the MCP server with all Tower tools."""
+    global _session_factory, _runtime_service, _approval_service  # noqa: PLW0603
+    _session_factory = session_factory
+    _runtime_service = runtime_service
+    _approval_service = approval_service
+
+    mcp = FastMCP(
+        "Tower",
+        instructions="Tower — control tower for running and supervising coding agents.",
+        stateless_http=True,
+    )
+
+    _register_job_tools(mcp)
+    _register_approval_tools(mcp)
+    _register_workspace_tools(mcp)
+    _register_artifact_tools(mcp)
+    _register_config_tools(mcp)
+    _register_observability_tools(mcp)
+
+    return mcp
+
+
+# ---------------------------------------------------------------------------
+# Job Management Tools
+# ---------------------------------------------------------------------------
+
+
+def _register_job_tools(mcp: FastMCP) -> None:
+    @mcp.tool(name="tower_job_create", description="Create a new coding job (repo, prompt, strategy, options)")
+    async def tower_job_create(
+        repo: str,
+        prompt: str,
+        base_ref: str | None = None,
+        branch: str | None = None,
+        strategy: str = "single_agent",
+    ) -> dict[str, Any]:
+        sf = _get_session_factory()
+        config = load_config()
+        async with sf() as session:
+            svc = JobService(
+                job_repo=JobRepository(session),
+                git_service=GitService(config),
+                config=config,
+            )
+            try:
+                job = await svc.create_job(
+                    repo=repo,
+                    prompt=prompt,
+                    base_ref=base_ref,
+                    branch=branch,
+                    strategy=strategy,
+                )
+            except RepoNotAllowedError as exc:
+                return {"error": str(exc)}
+
+            await session.commit()
+
+            runtime = _get_runtime()
+            await runtime.start_or_enqueue(job)
+
+            job = await svc.get_job(job.id)
+
+        resp = CreateJobResponse(
+            id=job.id,
+            state=job.state,
+            branch=job.branch,
+            worktree_path=job.worktree_path,
+            created_at=job.created_at,
+        )
+        return resp.model_dump(mode="json")
+
+    @mcp.tool(name="tower_job_list", description="List jobs with optional status filter and pagination")
+    async def tower_job_list(
+        state: str | None = None,
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> dict[str, Any]:
+        sf = _get_session_factory()
+        config = load_config()
+        async with sf() as session:
+            svc = JobService(
+                job_repo=JobRepository(session),
+                git_service=GitService(config),
+                config=config,
+            )
+            jobs, next_cursor, has_more = await svc.list_jobs(
+                state=state,
+                limit=min(max(limit, 1), 100),
+                cursor=cursor,
+            )
+
+        resp = JobListResponse(
+            items=[
+                JobResponse(
+                    id=j.id,
+                    repo=j.repo,
+                    prompt=j.prompt,
+                    state=j.state,
+                    strategy=j.strategy,
+                    base_ref=j.base_ref,
+                    worktree_path=j.worktree_path,
+                    branch=j.branch,
+                    created_at=j.created_at,
+                    updated_at=j.updated_at,
+                    completed_at=j.completed_at,
+                    pr_url=j.pr_url,
+                )
+                for j in jobs
+            ],
+            cursor=next_cursor,
+            has_more=has_more,
+        )
+        return resp.model_dump(mode="json")
+
+    @mcp.tool(name="tower_job_get", description="Get full detail for a single job")
+    async def tower_job_get(job_id: str) -> dict[str, Any]:
+        sf = _get_session_factory()
+        config = load_config()
+        async with sf() as session:
+            svc = JobService(
+                job_repo=JobRepository(session),
+                git_service=GitService(config),
+                config=config,
+            )
+            try:
+                job = await svc.get_job(job_id)
+            except JobNotFoundError as exc:
+                return {"error": str(exc)}
+        return _job_to_response(job)
+
+    @mcp.tool(name="tower_job_cancel", description="Cancel a running or queued job")
+    async def tower_job_cancel(job_id: str) -> dict[str, Any]:
+        sf = _get_session_factory()
+        config = load_config()
+        async with sf() as session:
+            svc = JobService(
+                job_repo=JobRepository(session),
+                git_service=GitService(config),
+                config=config,
+            )
+            try:
+                job = await svc.cancel_job(job_id)
+            except JobNotFoundError as exc:
+                return {"error": str(exc)}
+            except StateConflictError as exc:
+                return {"error": str(exc)}
+
+        runtime = _get_runtime()
+        await runtime.cancel(job_id)
+        return _job_to_response(job)
+
+    @mcp.tool(name="tower_job_rerun", description="Rerun a job with the same configuration")
+    async def tower_job_rerun(job_id: str) -> dict[str, Any]:
+        sf = _get_session_factory()
+        config = load_config()
+        async with sf() as session:
+            svc = JobService(
+                job_repo=JobRepository(session),
+                git_service=GitService(config),
+                config=config,
+            )
+            try:
+                job = await svc.rerun_job(job_id)
+            except (JobNotFoundError, RepoNotAllowedError) as exc:
+                return {"error": str(exc)}
+            await session.commit()
+
+        resp = CreateJobResponse(
+            id=job.id,
+            state=job.state,
+            branch=job.branch,
+            worktree_path=job.worktree_path,
+            created_at=job.created_at,
+        )
+        return resp.model_dump(mode="json")
+
+    @mcp.tool(name="tower_job_message", description="Send an operator message to a running job")
+    async def tower_job_message(job_id: str, content: str) -> dict[str, Any]:
+        if not content or len(content) > 10000:
+            return {"error": "Content must be between 1 and 10,000 characters"}
+
+        runtime = _get_runtime()
+        sent = await runtime.send_message(job_id, content)
+        if not sent:
+            return {"error": "Job is not currently running"}
+
+        from datetime import UTC, datetime
+
+        resp = SendMessageResponse(seq=0, timestamp=datetime.now(UTC))
+        return resp.model_dump(mode="json")
+
+
+# ---------------------------------------------------------------------------
+# Approval Tools
+# ---------------------------------------------------------------------------
+
+
+def _register_approval_tools(mcp: FastMCP) -> None:
+    @mcp.tool(name="tower_approval_list", description="List pending/resolved approvals for a job")
+    async def tower_approval_list(job_id: str) -> list[dict[str, Any]]:
+        svc = _get_approval()
+        approvals = await svc.list_for_job(job_id)
+        return [
+            ApprovalResponse(
+                id=a.id,
+                job_id=a.job_id,
+                description=a.description,
+                proposed_action=a.proposed_action,
+                requested_at=a.requested_at,
+                resolved_at=a.resolved_at,
+                resolution=a.resolution,
+            ).model_dump(mode="json")
+            for a in approvals
+        ]
+
+    @mcp.tool(name="tower_approval_resolve", description="Approve or reject a pending approval request")
+    async def tower_approval_resolve(approval_id: str, resolution: str) -> dict[str, Any]:
+        if resolution not in ("approved", "rejected"):
+            return {"error": "Resolution must be 'approved' or 'rejected'"}
+
+        from backend.services.approval_service import (
+            ApprovalAlreadyResolvedError,
+            ApprovalNotFoundError,
+        )
+
+        svc = _get_approval()
+        try:
+            a = await svc.resolve(approval_id, resolution)
+        except ApprovalNotFoundError as exc:
+            return {"error": str(exc)}
+        except ApprovalAlreadyResolvedError as exc:
+            return {"error": str(exc)}
+
+        return ApprovalResponse(
+            id=a.id,
+            job_id=a.job_id,
+            description=a.description,
+            proposed_action=a.proposed_action,
+            requested_at=a.requested_at,
+            resolved_at=a.resolved_at,
+            resolution=a.resolution,
+        ).model_dump(mode="json")
+
+
+# ---------------------------------------------------------------------------
+# Workspace & Artifact Tools
+# ---------------------------------------------------------------------------
+
+
+def _register_workspace_tools(mcp: FastMCP) -> None:
+    @mcp.tool(name="tower_workspace_list", description="List files in a job's worktree")
+    async def tower_workspace_list(
+        job_id: str,
+        path: str = "",
+        cursor: str | None = None,
+        limit: int = 200,
+    ) -> dict[str, Any]:
+        sf = _get_session_factory()
+        config = load_config()
+        async with sf() as session:
+            svc = JobService(
+                job_repo=JobRepository(session),
+                git_service=None,  # type: ignore[arg-type]
+                config=config,
+            )
+            try:
+                job = await svc.get_job(job_id)
+            except JobNotFoundError as exc:
+                return {"error": str(exc)}
+
+        worktree = Path(job.worktree_path or job.repo).resolve()
+        if not worktree.is_dir():
+            return {"error": "Worktree not found"}
+
+        target = (worktree / path).resolve()
+        if not target.is_relative_to(worktree):
+            return {"error": "Invalid path"}
+        if not target.is_dir():
+            return {"error": "Directory not found"}
+
+        entries: list[WorkspaceEntry] = []
+        try:
+            sorted_items = sorted(target.iterdir(), key=lambda p: (not p.is_dir(), p.name))
+        except PermissionError:
+            sorted_items = []
+
+        limit = min(max(limit, 1), 200)
+        past_cursor = cursor is None
+        for item in sorted_items:
+            if item.name.startswith("."):
+                continue
+            # Resolve symlinks and ensure they stay within worktree
+            try:
+                resolved_item = item.resolve()
+            except OSError:
+                continue
+            if not resolved_item.is_relative_to(worktree):
+                continue
+            rel = str(item.relative_to(worktree))
+            if not past_cursor:
+                if rel == cursor:
+                    past_cursor = True
+                continue
+            entry_type = WorkspaceEntryType.directory if item.is_dir() else WorkspaceEntryType.file
+            size = item.stat().st_size if item.is_file() else None
+            entries.append(WorkspaceEntry(path=rel, type=entry_type, size_bytes=size))
+            if len(entries) >= limit:
+                break
+
+        has_more = len(entries) == limit
+        next_cursor = entries[-1].path if has_more else None
+        resp = WorkspaceListResponse(items=entries, cursor=next_cursor, has_more=has_more)
+        return resp.model_dump(mode="json")
+
+    @mcp.tool(name="tower_workspace_read", description="Read a file from a job's worktree")
+    async def tower_workspace_read(job_id: str, path: str) -> dict[str, Any]:
+        sf = _get_session_factory()
+        config = load_config()
+        async with sf() as session:
+            svc = JobService(
+                job_repo=JobRepository(session),
+                git_service=None,  # type: ignore[arg-type]
+                config=config,
+            )
+            try:
+                job = await svc.get_job(job_id)
+            except JobNotFoundError as exc:
+                return {"error": str(exc)}
+
+        worktree = Path(job.worktree_path or job.repo).resolve()
+        file_path = (worktree / path).resolve()
+
+        if not file_path.is_relative_to(worktree):
+            return {"error": "Invalid path"}
+        if not file_path.is_file():
+            return {"error": "File not found"}
+
+        max_file_size = 5 * 1024 * 1024
+        if file_path.stat().st_size > max_file_size:
+            return {"error": "File too large to preview (>5 MB)"}
+
+        try:
+            content = file_path.read_text(encoding="utf-8", errors="replace")
+        except (PermissionError, OSError):
+            return {"error": "Cannot read file"}
+
+        return {"path": path, "content": content}
+
+
+def _register_artifact_tools(mcp: FastMCP) -> None:
+    @mcp.tool(name="tower_artifact_list", description="List artifacts produced by a job")
+    async def tower_artifact_list(job_id: str) -> dict[str, Any]:
+        sf = _get_session_factory()
+        async with sf() as session:
+            svc = ArtifactService(ArtifactRepository(session))
+            artifacts = await svc.list_for_job(job_id)
+            await session.commit()
+
+        items = [
+            ArtifactResponse(
+                id=a.id,
+                job_id=a.job_id,
+                name=a.name,
+                type=a.type,
+                mime_type=a.mime_type,
+                size_bytes=a.size_bytes,
+                phase=a.phase,
+                created_at=a.created_at,
+            ).model_dump(mode="json")
+            for a in artifacts
+        ]
+        return {"items": items}
+
+    @mcp.tool(name="tower_artifact_get", description="Get artifact metadata by ID")
+    async def tower_artifact_get(artifact_id: str) -> dict[str, Any]:
+        sf = _get_session_factory()
+        async with sf() as session:
+            svc = ArtifactService(ArtifactRepository(session))
+            artifact = await svc.get(artifact_id)
+            await session.commit()
+
+        if artifact is None:
+            return {"error": "Artifact not found"}
+
+        return ArtifactResponse(
+            id=artifact.id,
+            job_id=artifact.job_id,
+            name=artifact.name,
+            type=artifact.type,
+            mime_type=artifact.mime_type,
+            size_bytes=artifact.size_bytes,
+            phase=artifact.phase,
+            created_at=artifact.created_at,
+        ).model_dump(mode="json")
+
+
+# ---------------------------------------------------------------------------
+# Configuration Tools
+# ---------------------------------------------------------------------------
+
+
+def _register_config_tools(mcp: FastMCP) -> None:
+    @mcp.tool(name="tower_settings_get", description="Get global configuration as YAML")
+    async def tower_settings_get() -> dict[str, Any]:
+        from backend.config import DEFAULT_CONFIG_PATH
+
+        if DEFAULT_CONFIG_PATH.exists():
+            return GlobalConfigResponse(config_yaml=DEFAULT_CONFIG_PATH.read_text()).model_dump(mode="json")
+        return GlobalConfigResponse(config_yaml="").model_dump(mode="json")
+
+    @mcp.tool(name="tower_settings_update", description="Update global configuration from YAML string")
+    async def tower_settings_update(config_yaml: str) -> dict[str, Any]:
+        import yaml
+
+        from backend.config import DEFAULT_CONFIG_PATH
+
+        try:
+            yaml.safe_load(config_yaml)
+        except yaml.YAMLError as exc:
+            return {"error": f"Invalid YAML: {exc}"}
+
+        DEFAULT_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        DEFAULT_CONFIG_PATH.write_text(config_yaml)
+        return GlobalConfigResponse(config_yaml=config_yaml).model_dump(mode="json")
+
+    @mcp.tool(name="tower_repo_list", description="List registered repositories")
+    async def tower_repo_list() -> dict[str, Any]:
+        config = load_config()
+        return RepoListResponse(items=config.repos).model_dump(mode="json")
+
+    @mcp.tool(name="tower_repo_get", description="Get repo config with resolved details")
+    async def tower_repo_get(repo_path: str) -> dict[str, Any]:
+        config = load_config()
+        resolved = str(Path(repo_path).expanduser().resolve())
+        if resolved not in config.repos:
+            return {"error": f"Repository '{repo_path}' is not registered."}
+
+        git = GitService(config)
+        origin_url: str | None = None
+        base_branch: str | None = None
+        with contextlib.suppress(GitError):
+            raw_url = await git.get_origin_url(resolved)
+            if raw_url:
+                origin_url = _strip_url_credentials(raw_url)
+        with contextlib.suppress(GitError):
+            base_branch = await git.get_default_branch(resolved)
+
+        return RepoDetailResponse(
+            path=resolved,
+            origin_url=origin_url,
+            base_branch=base_branch,
+        ).model_dump(mode="json")
+
+    @mcp.tool(name="tower_repo_register", description="Register a repository (path or URL)")
+    async def tower_repo_register(source: str) -> dict[str, Any]:
+        config = load_config()
+        git = GitService(config)
+
+        if GitService.is_remote_url(source):
+            clone_dir = GitService.derive_clone_dir(source, config.repos_base_dir)
+            if Path(clone_dir).exists():
+                return {"error": f"Clone directory already exists: {clone_dir}"}
+            try:
+                cloned_path = await git.clone_repo(source, clone_dir)
+            except GitError as exc:
+                return {"error": f"Clone failed: {exc}"}
+            register_repo(config, cloned_path)
+            return RegisterRepoResponse(path=cloned_path, source=source, cloned=True).model_dump(mode="json")
+
+        resolved = str(Path(source).expanduser().resolve())
+        is_valid = await git.validate_repo(resolved)
+        if not is_valid:
+            return {"error": f"Not a valid git repository: {source}"}
+        register_repo(config, resolved)
+        return RegisterRepoResponse(path=resolved, source=source, cloned=False).model_dump(mode="json")
+
+    @mcp.tool(name="tower_repo_remove", description="Remove a repository from the allowlist")
+    async def tower_repo_remove(repo_path: str) -> dict[str, Any]:
+        config = load_config()
+        try:
+            unregister_repo(config, repo_path)
+        except ValueError as exc:
+            return {"error": str(exc)}
+        return {"status": "removed", "path": repo_path}
+
+
+# ---------------------------------------------------------------------------
+# Observability Tools
+# ---------------------------------------------------------------------------
+
+
+def _register_observability_tools(mcp: FastMCP) -> None:
+    @mcp.tool(name="tower_health", description="Service health check")
+    async def tower_health() -> dict[str, Any]:
+        sf = _get_session_factory()
+        config = load_config()
+        async with sf() as session:
+            svc = JobService(
+                job_repo=JobRepository(session),
+                git_service=GitService(config),
+                config=config,
+            )
+            active = await svc.count_active_jobs()
+            queued = await svc.count_queued_jobs()
+
+        return HealthResponse(
+            status=HealthStatus.healthy,
+            version="0.1.0",
+            uptime_seconds=round(time.monotonic() - _start_time, 1),
+            active_jobs=active,
+            queued_jobs=queued,
+        ).model_dump(mode="json")
+
+    @mcp.tool(name="tower_cleanup_worktrees", description="Clean up worktrees for completed jobs")
+    async def tower_cleanup_worktrees() -> dict[str, Any]:
+        config = load_config()
+        git = GitService(config)
+        total = 0
+        for repo in config.repos:
+            try:
+                count = await git.cleanup_worktrees(repo)
+                total += count
+            except GitError:
+                log.warning("cleanup_worktrees_failed", repo=repo)
+        return {"removed": total}

--- a/backend/services/setup_service.py
+++ b/backend/services/setup_service.py
@@ -1,0 +1,465 @@
+"""Interactive setup and dependency checker for Tower.
+
+Provides a questionnaire-based onboarding flow that:
+- Checks system dependencies (node, gh CLI, devtunnel)
+- Offers to install missing deps (auto + manual fallback)
+- Configures AGENT_TOWER_HOME (with OS-specific persistence instructions)
+- Handles gh CLI auth and devtunnel login (with WSL-aware headless flow)
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+import click
+
+from backend.config import init_config
+
+# ---------------------------------------------------------------------------
+# Dependency descriptors
+# ---------------------------------------------------------------------------
+
+_IS_WSL = bool(os.environ.get("WSL_DISTRO_NAME") or os.environ.get("WSL_INTEROP"))
+_SYSTEM = platform.system().lower()  # "linux", "darwin", "windows"
+
+
+@dataclass
+class Dependency:
+    name: str
+    command: str
+    install_instructions: dict[str, str]
+    url: str
+    auto_install_cmd: dict[str, list[str]] | None = None
+
+
+DEPENDENCIES: list[Dependency] = [
+    Dependency(
+        name="Node.js",
+        command="node",
+        url="https://nodejs.org/",
+        install_instructions={
+            "linux": (
+                "curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash - && sudo apt-get install -y nodejs"
+            ),
+            "darwin": "brew install node",
+            "windows": "Download installer from https://nodejs.org/",
+        },
+        auto_install_cmd={
+            "linux": ["sudo", "apt-get", "install", "-y", "nodejs"],
+            "darwin": ["brew", "install", "node"],
+        },
+    ),
+    Dependency(
+        name="GitHub CLI",
+        command="gh",
+        url="https://cli.github.com/",
+        install_instructions={
+            "linux": (
+                "sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key 23F3D4EA75716059\n"
+                "sudo apt-add-repository https://cli.github.com/packages\n"
+                "sudo apt-get update && sudo apt-get install gh"
+            ),
+            "darwin": "brew install gh",
+            "windows": "winget install --id GitHub.cli",
+        },
+        auto_install_cmd={
+            "linux": ["sudo", "apt-get", "install", "-y", "gh"],
+            "darwin": ["brew", "install", "gh"],
+        },
+    ),
+    Dependency(
+        name="Dev Tunnel CLI",
+        command="devtunnel",
+        url="https://aka.ms/devtunnels/cli",
+        install_instructions={
+            "linux": "curl -sL https://aka.ms/DevTunnelCliInstall | bash",
+            "darwin": "brew install --cask devtunnel",
+            "windows": "winget install Microsoft.devtunnel",
+        },
+        auto_install_cmd={
+            "linux": ["bash", "-c", "curl -sL https://aka.ms/DevTunnelCliInstall | bash"],
+            "darwin": ["brew", "install", "--cask", "devtunnel"],
+        },
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _check_command(cmd: str) -> tuple[bool, str | None]:
+    """Check if a command is available, return (found, version_string)."""
+    path = shutil.which(cmd)
+    if not path:
+        return False, None
+    try:
+        result = subprocess.run(
+            [path, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        version = result.stdout.strip().split("\n")[0] if result.stdout else "installed"
+        return True, version
+    except (subprocess.TimeoutExpired, OSError):
+        return True, "installed (version unknown)"
+
+
+def _check_gh_auth() -> bool:
+    """Check if gh CLI is authenticated."""
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "status"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        return result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return False
+
+
+def _check_devtunnel_login() -> bool:
+    """Check if devtunnel is logged in."""
+    try:
+        result = subprocess.run(
+            ["devtunnel", "user", "show"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        return result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return False
+
+
+def _try_auto_install(dep: Dependency) -> bool:
+    """Attempt auto-installation of a dependency. Returns True on success."""
+    if not dep.auto_install_cmd or _SYSTEM not in dep.auto_install_cmd:
+        return False
+
+    cmd = dep.auto_install_cmd[_SYSTEM]
+    click.echo(f"  Attempting: {' '.join(cmd)}")
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+        if result.returncode == 0:
+            return True
+        click.secho(f"  Auto-install failed (exit {result.returncode})", fg="red")
+        if result.stderr:
+            for line in result.stderr.strip().split("\n")[:5]:
+                click.echo(f"    {line}")
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        click.secho(f"  Auto-install failed: {exc}", fg="red")
+    return False
+
+
+def _show_manual_instructions(dep: Dependency) -> None:
+    """Show OS-specific manual installation instructions."""
+    key = _SYSTEM
+    instructions = dep.install_instructions.get(key, dep.install_instructions.get("linux", ""))
+    click.echo()
+    click.secho(f"  Manual installation for {dep.name}:", fg="yellow")
+    click.echo()
+    for line in instructions.split("\n"):
+        click.echo(f"    {line}")
+    click.echo(f"\n    More info: {dep.url}")
+    click.echo()
+
+
+def _get_env_persistence_instructions(var_name: str, value: str) -> str:
+    """Return OS-specific instructions for persisting an env var across sessions."""
+    if _SYSTEM == "darwin":
+        shell = os.environ.get("SHELL", "/bin/zsh")
+        rc = "~/.zshrc" if "zsh" in shell else "~/.bash_profile"
+        return f'Add this line to {rc}:\n  export {var_name}="{value}"\n\nThen run: source {rc}'
+    elif _SYSTEM == "windows":
+        return (
+            f"Run in PowerShell (Admin):\n"
+            f'  [System.Environment]::SetEnvironmentVariable("{var_name}", "{value}", "User")\n\n'
+            f"Or via Settings > System > Advanced > Environment Variables"
+        )
+    else:  # Linux / WSL
+        shell = os.environ.get("SHELL", "/bin/bash")
+        if "zsh" in shell:
+            rc = "~/.zshrc"
+        elif "fish" in shell:
+            return f'Run:\n  set -Ux {var_name} "{value}"\n\nThis persists across sessions automatically.'
+        else:
+            rc = "~/.bashrc"
+        return f'Add this line to {rc}:\n  export {var_name}="{value}"\n\nThen run: source {rc}'
+
+
+# ---------------------------------------------------------------------------
+# Main setup flow
+# ---------------------------------------------------------------------------
+
+
+def run_setup() -> None:
+    """Run the interactive setup questionnaire."""
+    click.echo()
+    click.secho("╔══════════════════════════════════════╗", fg="cyan")
+    click.secho("║       Tower — Initial Setup          ║", fg="cyan")
+    click.secho("╚══════════════════════════════════════╝", fg="cyan")
+    click.echo()
+
+    # --- Step 1: AGENT_TOWER_HOME ---
+    _setup_tower_home()
+
+    # --- Step 2: System dependencies ---
+    _check_dependencies()
+
+    # --- Step 3: gh CLI auth ---
+    _setup_gh_auth()
+
+    # --- Step 4: devtunnel login ---
+    _setup_devtunnel_login()
+
+    # --- Step 5: Config init ---
+    _setup_config()
+
+    click.echo()
+    click.secho("✓ Setup complete! Run 'tower up' to start the server.", fg="green", bold=True)
+    click.echo()
+
+
+def _setup_tower_home() -> None:
+    """Configure AGENT_TOWER_HOME directory."""
+    click.secho("1. Data Directory", fg="cyan", bold=True)
+    click.echo()
+
+    current = os.environ.get("AGENT_TOWER_HOME")
+    default = str(Path.home() / ".tower")
+
+    if current:
+        click.echo(f"  AGENT_TOWER_HOME is set to: {current}")
+        if click.confirm("  Keep this setting?", default=True):
+            return
+
+    click.echo(f"  Default location: {default}")
+    click.echo("  Tower stores config, database, and logs here.")
+    click.echo()
+
+    use_default = click.confirm("  Use the default location?", default=True)
+
+    if use_default:
+        tower_dir = default
+    else:
+        tower_dir = click.prompt("  Enter custom path", type=str).strip()
+        tower_dir = str(Path(tower_dir).expanduser().resolve())
+
+    # Create the directory
+    Path(tower_dir).mkdir(parents=True, exist_ok=True)
+
+    if tower_dir != default:
+        click.echo()
+        click.secho("  To persist this across sessions:", fg="yellow")
+        instructions = _get_env_persistence_instructions("AGENT_TOWER_HOME", tower_dir)
+        for line in instructions.split("\n"):
+            click.echo(f"    {line}")
+        click.echo()
+
+        # Set for the current process
+        os.environ["AGENT_TOWER_HOME"] = tower_dir
+    else:
+        Path(tower_dir).mkdir(parents=True, exist_ok=True)
+        click.echo(f"  Using: {tower_dir}")
+
+    click.echo()
+
+
+def _check_dependencies() -> None:
+    """Check and optionally install system dependencies."""
+    click.secho("2. System Dependencies", fg="cyan", bold=True)
+    click.echo()
+
+    all_ok = True
+    for dep in DEPENDENCIES:
+        found, version = _check_command(dep.command)
+        if found:
+            click.secho(f"  ✓ {dep.name}: {version}", fg="green")
+        else:
+            click.secho(f"  ✗ {dep.name}: not found", fg="red")
+            all_ok = False
+
+            optional = dep.name == "Dev Tunnel CLI"
+            severity = "(optional)" if optional else "(required)"
+            click.echo(f"    {dep.name} is {severity} for Tower.")
+
+            if click.confirm("    Attempt automatic installation?", default=not optional):
+                success = _try_auto_install(dep)
+                if success:
+                    found2, version2 = _check_command(dep.command)
+                    if found2:
+                        click.secho(f"  ✓ {dep.name}: {version2}", fg="green")
+                        continue
+                _show_manual_instructions(dep)
+                if not optional:
+                    click.secho("    Please install manually and re-run 'tower setup'.", fg="yellow")
+            else:
+                _show_manual_instructions(dep)
+
+    if all_ok:
+        click.secho("  All dependencies found!", fg="green")
+    click.echo()
+
+
+def _setup_gh_auth() -> None:
+    """Set up GitHub CLI authentication."""
+    click.secho("3. GitHub CLI Authentication", fg="cyan", bold=True)
+    click.echo()
+
+    if not shutil.which("gh"):
+        click.secho("  ⊘ GitHub CLI not installed — skipping auth setup.", fg="yellow")
+        click.echo()
+        return
+
+    if _check_gh_auth():
+        click.secho("  ✓ GitHub CLI is authenticated.", fg="green")
+        click.echo()
+        return
+
+    click.secho("  ✗ GitHub CLI is not authenticated.", fg="red")
+    click.echo()
+
+    if _IS_WSL:
+        click.echo("  WSL detected — browser-based auth may not work directly.")
+        click.echo("  Options:")
+        click.echo()
+        click.secho("    Option A (recommended): Use a personal access token:", fg="yellow")
+        click.echo("      1. Go to https://github.com/settings/tokens")
+        click.echo("      2. Create a token with 'repo' and 'read:org' scopes")
+        click.echo("      3. Run: echo '<YOUR_TOKEN>' | gh auth login --with-token")
+        click.echo()
+        click.secho("    Option B: Browser auth via Windows host:", fg="yellow")
+        click.echo("      Run: gh auth login -w")
+        click.echo("      Then open the URL shown in your Windows browser.")
+        click.echo()
+    else:
+        click.echo("  Options:")
+        click.echo()
+        click.secho("    Interactive login:", fg="yellow")
+        click.echo("      Run: gh auth login")
+        click.echo()
+
+    if click.confirm("  Attempt 'gh auth login' now?", default=not _IS_WSL):
+        cmd = ["gh", "auth", "login"]
+        if _IS_WSL:
+            cmd.extend(["-w"])  # web-based, gives a code to enter in browser
+        try:
+            subprocess.run(cmd, timeout=120)
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            click.secho(f"  Auth attempt failed: {exc}", fg="red")
+
+        if _check_gh_auth():
+            click.secho("  ✓ GitHub CLI is now authenticated!", fg="green")
+        else:
+            click.secho("  ✗ Auth not completed. You can retry with 'gh auth login'.", fg="yellow")
+
+    click.echo()
+
+
+def _setup_devtunnel_login() -> None:
+    """Set up Dev Tunnel authentication."""
+    click.secho("4. Dev Tunnel Authentication", fg="cyan", bold=True)
+    click.echo()
+
+    if not shutil.which("devtunnel"):
+        click.secho("  ⊘ Dev Tunnel CLI not installed — skipping.", fg="yellow")
+        click.echo("    (Not required unless you want remote access via 'tower up --tunnel')")
+        click.echo()
+        return
+
+    if _check_devtunnel_login():
+        click.secho("  ✓ Dev Tunnel is logged in.", fg="green")
+        click.echo()
+        return
+
+    click.secho("  ✗ Dev Tunnel is not logged in.", fg="red")
+    click.echo()
+
+    if _IS_WSL:
+        click.echo("  WSL detected — browser-based login may not work directly.")
+        click.echo()
+        click.secho("  Option A (recommended): Device code flow:", fg="yellow")
+        click.echo("    Run: devtunnel user login -d")
+        click.echo("    Then open the URL in your Windows browser and enter the code.")
+        click.echo()
+        click.secho("  Option B: GitHub token:", fg="yellow")
+        click.echo("    Run: devtunnel user login -g")
+        click.echo("    (Uses GitHub auth if already configured)")
+        click.echo()
+    else:
+        click.echo("  Run: devtunnel user login")
+        click.echo()
+
+    if click.confirm("  Attempt login now?", default=not _IS_WSL):
+        cmd = ["devtunnel", "user", "login"]
+        if _IS_WSL:
+            cmd.append("-d")  # device code flow for headless environments
+        try:
+            subprocess.run(cmd, timeout=120)
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            click.secho(f"  Login attempt failed: {exc}", fg="red")
+
+        if _check_devtunnel_login():
+            click.secho("  ✓ Dev Tunnel is now logged in!", fg="green")
+        else:
+            click.secho("  ✗ Login not completed. You can retry with 'devtunnel user login'.", fg="yellow")
+
+    click.echo()
+
+
+def _setup_config() -> None:
+    """Initialize Tower config if not present."""
+    click.secho("5. Configuration", fg="cyan", bold=True)
+    click.echo()
+
+    from backend.config import DEFAULT_CONFIG_PATH
+
+    if DEFAULT_CONFIG_PATH.exists():
+        click.secho(f"  ✓ Config exists at {DEFAULT_CONFIG_PATH}", fg="green")
+    else:
+        click.echo(f"  No config found. Creating default at {DEFAULT_CONFIG_PATH}")
+        path = init_config()
+        click.secho(f"  ✓ Created {path}", fg="green")
+
+    click.echo()
+
+
+# ---------------------------------------------------------------------------
+# Non-interactive dependency check (for `tower up` pre-flight)
+# ---------------------------------------------------------------------------
+
+
+def preflight_check(*, verbose: bool = True) -> bool:
+    """Quick non-interactive check of required dependencies.
+
+    Returns True if all required deps are present.
+    """
+    ok = True
+    for dep in DEPENDENCIES:
+        found, version = _check_command(dep.command)
+        is_optional = dep.name == "Dev Tunnel CLI"
+        if found:
+            if verbose:
+                click.secho(f"  ✓ {dep.name}: {version}", fg="green")
+        elif is_optional:
+            if verbose:
+                click.secho(f"  ⊘ {dep.name}: not found (optional)", fg="yellow")
+        else:
+            if verbose:
+                click.secho(f"  ✗ {dep.name}: not found", fg="red")
+            ok = False
+    return ok

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ dependencies = [
     "pydantic-settings>=2.0,<3",
     # CLI
     "click>=8.0,<9",
+    # MCP server
+    "mcp>=1.9,<2",
 ]
 
 [project.scripts]
@@ -66,8 +68,12 @@ warn_unused_configs = true
 plugins = ["pydantic.mypy"]
 
 [[tool.mypy.overrides]]
-module = ["faster_whisper.*", "copilot.*"]
+module = ["faster_whisper.*", "copilot.*", "mcp.*"]
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["backend.mcp.server"]
+disable_error_code = ["misc"]
 
 [tool.pytest.ini_options]
 testpaths = ["backend/tests"]


### PR DESCRIPTION
## Summary

Phase 11 of the Tower roadmap — MCP orchestration server and initial setup flow.

### MCP Server
- 20 MCP tools covering jobs, approvals, workspace, artifacts, config, and observability
- Mounted as Streamable HTTP at /mcp (configurable via `mcp_server.path` in config)
- Stateless HTTP mode — no session state needed
- Thin tool handlers delegating to existing service layer

### Setup CLI
- `tower setup`: Interactive onboarding questionnaire
  - Checks system deps (Node.js, gh CLI, devtunnel)
  - Auto-install with manual fallback instructions
  - AGENT_TOWER_HOME env var support for custom data directory
  - gh CLI auth with WSL-aware headless token flow
  - devtunnel login with device code flow for WSL
  - Config initialization
- `tower doctor`: Non-interactive dependency check

### Config changes
- `AGENT_TOWER_HOME` env var overrides `~/.tower` default
- `McpServerConfig` dataclass (enabled, path)
- mypy override for `backend.mcp.server` (untyped MCP decorator)