### PR TITLE
feat(events): P0 — nuke DomainEvent/DomainEventKind; traceforge.SessionEvent + dotted kinds end to end

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -973,108 +973,38 @@ data: {json_payload}
 
 ### 5.3 Event Types
 
-| Event Type | Payload Summary |
+Runtime events are `traceforge.SessionEvent` objects (see §11). The SSE wire carries them **as-is** — there is no translation to a separate SSE vocabulary:
+
+- **`event:`** — the event's dotted `kind` (e.g. `job.created`, `message.assistant`, `tool.call.completed`, `permission.requested`). This is the same `EventKind` value used on the event bus and in persistence.
+- **`data:`** — the `SessionEvent` serialized verbatim (`SessionEvent.model_dump_json()`):
+
+```json
+{
+  "id": "<event uuid>",
+  "session_id": "<job id>",
+  "kind": "job.created",
+  "payload": { "...": "kind-specific fields — see §11.1" },
+  "metadata": { "sequence": 12, "timestamp": "...", "turn_id": "...", "event_id": "..." }
+}
+```
+
+- **`id:`** — `metadata.sequence` (the SQLite autoincrement), falling back to the event id; drives `Last-Event-ID` replay.
+
+The frontend consumes this shape directly (`useSSE.ts`), reading `payload.*` and deriving job-state transitions from the dotted `kind` — the server does **not** emit the paired synthetic state-change frames the retired model did. The sole state event is the dotted `job.state_changed` kind, emitted on real transitions.
+
+The one non-`SessionEvent` frame is `snapshot`, sent on reconnect (see §5.4). It omits `id:` and its `data:` is a bespoke `{ jobs: JobResponse[], pending_approvals: ApprovalResponse[] }` payload.
+
+### 5.3.1 Broadcast Rules
+
+Not every kind reaches clients. `SSEManager` gates delivery (`_BROADCAST_KINDS` in `sse_manager.py` is the source of truth):
+
+| Rule | Effect |
 |---|---|
-| `job_state_changed` | `{ job_id, previous_state, new_state, timestamp }` |
-| `log_line` | `{ job_id, seq, timestamp, level, message, context }` |
-| `transcript_update` | `{ job_id, seq, timestamp, role, content }` |
-| `diff_update` | `{ job_id, changed_files: DiffFile[] }` |
-| `approval_requested` | `{ job_id, approval_id, description, proposed_action, tier, reversible, contained }` |
-| `approval_resolved` | `{ job_id, approval_id, resolution, timestamp }` |
-| `batch_approval_requested` | `{ job_id, batch_id, actions[] }` |
-| `batch_approval_resolved` | `{ job_id, batch_id, resolution }` |
-| `session_heartbeat` | `{ job_id, session_id, timestamp }` |
-| `snapshot` | `{ jobs: JobResponse[], pending_approvals: ApprovalResponse[] }` |
-| `job_resolved` | `{ jobId, resolution, prUrl?, conflictFiles? }` |
-| `job_archived` | `{ jobId }` |
-| `job_review` | `{ jobId, prUrl?, mergeStatus?, resolution? }` |
-| `job_completed` | `{ jobId }` |
-| `job_failed` | `{ jobId, reason }` |
-| `merge_completed` | `{ jobId, branch, baseRef, strategy }` |
-| `merge_conflict` | `{ jobId, branch, baseRef, conflictFiles, fallback }` |
-| `session_resumed` | `{ jobId, sessionNumber }` |
-| `job_title_updated` | `{ jobId, title?, branch?, description? }` |
-| `progress_headline` | `{ jobId, headline }` |
-| `model_downgraded` | `{ jobId, requestedModel, actualModel }` |
-| `tool_group_summary` | `{ jobId, turnId, summary }` |
-| `agent_plan_updated` | `{ jobId, steps[] }` |
-| `execution_phase_changed` | `{ jobId, phase }` |
-| `telemetry_updated` | `{ jobId, ... }` |
-| `step_started` | `{ jobId, stepId, stepNumber }` |
-| `step_completed` | `{ jobId, stepId }` |
-| `step_title_generated` | `{ jobId, stepId, title }` |
-| `step_group_updated` | `{ jobId, stepId }` |
-| `plan_step_updated` | `{ jobId, stepId }` |
-| `turn_summary` | `{ jobId, turnId, summary }` |
-| `action_classified` | `{ jobId, tier, kind, description }` |
-| `policy_settings_changed` | `{ preset, ... }` |
-| `repo_index_progress` | `{ repo, progress }` |
-| `repo_index_complete` | `{ repo }` |
-| `structural_warning` | `{ jobId, warning }` |
-| `stall_detected` | `{ jobId }` |
-| `monitor_approved` | `{ jobId, action }` |
-| `monitor_rejected` | `{ jobId, action }` |
-| `monitor_escalated` | `{ jobId, action }` |
-| `sidecar_transcript` | `{ jobId, sidecarName, content }` |
-| `sidecar_agent_message` | `{ jobId, sidecarName, message }` |
-| `sidecar_gate_verdict` | `{ jobId, sidecarName, verdict }` |
-| `sidecar_metadata_update` | `{ jobId, sidecarName, metadata }` |
-| `job_setup_progress` | `{ jobId, step }` |
+| **Broadcast allowlist** | Only allow-listed dotted kinds are sent. Internal-only kinds — `workspace.prepared`, `agent.session_started`, the `step.*` internals, `plan.updated`, `execution.phase_changed`, `progress.headline`, `sidecar.*`, `monitor.*` — are dropped at the boundary; their effect surfaces via other broadcast events or the job snapshot. |
+| **Selective suppression** | When >20 jobs are active, high-frequency kinds (`log`, `diff.updated`, `session.heartbeat`, and the transcript family) are suppressed for global/dashboard connections. |
+| **Job-scoped only** | `telemetry.updated` and `secondary_session.entry` are delivered only to a connection scoped to that job, never to global/dashboard connections. |
 
-### 5.3.1 Domain Event to SSE Event Mapping
-
-The `SSEManager` translates internal domain events into SSE events as follows:
-
-| Domain Event | SSE Event | Notes |
-|---|---|---|
-| `JobCreated` | `job_state_changed` | `previous_state: null, new_state: preparing or queued` |
-| `JobSetupProgress` | `job_setup_progress` | 1:1 mapping |
-| `WorkspacePrepared` | _(none)_ | Internal only; workspace info is in the job response |
-| `AgentSessionStarted` | _(none)_ | Internal only |
-| `LogLineEmitted` | `log_line` | 1:1 mapping |
-| `TranscriptUpdated` | `transcript_update` | 1:1 mapping |
-| `DiffUpdated` | `diff_update` | 1:1 mapping |
-| `ApprovalRequested` | `approval_requested` + `job_state_changed` | Two SSE events emitted |
-| `ApprovalResolved` | `approval_resolved` + `job_state_changed` | Two SSE events emitted |
-| `BatchApprovalRequested` | `batch_approval_requested` + `job_state_changed` | Two SSE events emitted |
-| `BatchApprovalResolved` | `batch_approval_resolved` + `job_state_changed` | Two SSE events emitted |
-| `JobReview` | `job_review` + `job_state_changed` | Two SSE events emitted |
-| `JobCompleted` | `job_completed` + `job_state_changed` | Two SSE events emitted |
-| `JobFailed` | `job_failed` + `job_state_changed` | Two SSE events emitted |
-| `JobCanceled` | `job_state_changed` | `new_state: canceled` |
-| `JobStateChanged` | `job_state_changed` | 1:1 mapping |
-| `SessionHeartbeat` | `session_heartbeat` | 1:1 mapping |
-| `MergeCompleted` | `merge_completed` | 1:1 mapping |
-| `MergeConflict` | `merge_conflict` | 1:1 mapping |
-| `SessionResumed` | `session_resumed` | 1:1 mapping |
-| `JobResolved` | `job_resolved` | 1:1 mapping |
-| `JobArchived` | `job_archived` | 1:1 mapping |
-| `JobTitleUpdated` | `job_title_updated` | 1:1 mapping |
-| `ProgressHeadline` | `progress_headline` | 1:1 mapping |
-| `ModelDowngraded` | `model_downgraded` | 1:1 mapping |
-| `ToolGroupSummary` | `tool_group_summary` | 1:1 mapping |
-| `AgentPlanUpdated` | `agent_plan_updated` | 1:1 mapping |
-| `ExecutionPhaseChanged` | `execution_phase_changed` | 1:1 mapping |
-| `TelemetryUpdated` | `telemetry_updated` | 1:1 mapping |
-| `StepStarted` | `step_started` | 1:1 mapping |
-| `StepCompleted` | `step_completed` | 1:1 mapping |
-| `StepTitleGenerated` | `step_title_generated` | 1:1 mapping |
-| `StepGroupUpdated` | `step_group_updated` | 1:1 mapping |
-| `PlanStepUpdated` | `plan_step_updated` | 1:1 mapping |
-| `TurnSummary` | `turn_summary` | 1:1 mapping |
-| `ActionClassified` | `action_classified` | 1:1 mapping |
-| `PolicySettingsChanged` | `policy_settings_changed` | 1:1 mapping |
-| `RepoIndexProgress` | `repo_index_progress` | 1:1 mapping |
-| `RepoIndexComplete` | `repo_index_complete` | 1:1 mapping |
-| `StructuralWarning` | `structural_warning` | 1:1 mapping |
-| `StallDetected` | `stall_detected` | 1:1 mapping |
-| `MonitorApproved` | `monitor_approved` | 1:1 mapping |
-| `MonitorRejected` | `monitor_rejected` | 1:1 mapping |
-| `MonitorEscalated` | `monitor_escalated` | 1:1 mapping |
-| `SidecarTranscript` | `sidecar_transcript` | 1:1 mapping |
-| `SidecarAgentMessage` | `sidecar_agent_message` | 1:1 mapping |
-| `SidecarGateVerdict` | `sidecar_gate_verdict` | 1:1 mapping |
-| `SidecarMetadataUpdate` | `sidecar_metadata_update` | 1:1 mapping |
+A job-scoped connection (a client viewing one job's detail) always receives full streaming for that job.
 
 ### 5.4 Reconnection and Replay
 
@@ -1121,7 +1051,7 @@ When more than 20 jobs are active concurrently, the SSE manager switches to a **
 | Condition | Behavior |
 |---|---|
 | Job card is open (Job Detail screen) | Full event streaming for that job continues normally |
-| Dashboard view with >20 active jobs | Job cards receive only `job_state_changed` events (no logs, transcripts, or diffs) |
+| Dashboard view with >20 active jobs | Job cards receive only `job.state_changed` events (no logs, transcripts, or diffs) |
 | Dashboard with >20 active jobs | A "Refresh page for latest updates" banner is shown above the Kanban board |
 
 This means:
@@ -1141,7 +1071,7 @@ When a job is created:
 
 1. `JobService` validates the request and persists the job in `preparing` state
 2. `GitService` creates the worktree and branch
-3. `JobService` persists a `JobCreated` event and a `WorkspacePrepared` event
+3. `JobService` persists a `job.created` event and a `workspace.prepared` event
 4. `RuntimeService` is asked to run the job
 5. If at capacity, job transitions to `queued`; otherwise proceeds immediately
 6. `RuntimeService` creates an asyncio task and job transitions to `running`
@@ -1167,17 +1097,17 @@ When an operator sends a message to a running job:
 1. `POST /api/jobs/{job_id}/messages` received
 2. Route delegates to `JobService.send_operator_message()`
 3. Service calls `adapter.send_message(session_id, message)`
-4. A `TranscriptUpdated` event is published with `role="operator"`
+4. A `message.user` transcript event is published with `role="operator"`
 
 ### 6.4 Approval Pause
 
 When the agent SDK raises a permission request (e.g., Copilot SDK calls `on_permission_request`):
 
-1. Adapter translates to `ApprovalRequested` domain event
+1. Adapter translates to `permission.requested` domain event
 2. Event bus delivers to `ApprovalService`
 3. `ApprovalService` persists the request; adapter holds the SDK callback pending
 4. Job transitions to `waiting_for_approval`
-5. `ApprovalRequested` SSE event sent to frontend
+5. `permission.requested` SSE event sent to frontend
 6. Operator approves or rejects via `POST /api/approvals/{approval_id}/resolve`
 7. `ApprovalService` records resolution; adapter returns the decision to the SDK callback
 
@@ -1188,7 +1118,7 @@ When the backend process receives `SIGTERM` or `SIGINT` (e.g., operator presses 
 1. Stop accepting new job creation requests (return `503 Service Unavailable`)
 2. For each running job:
    a. Call `adapter.abort_session(session_id)`
-   b. Publish a `JobCanceled` event with `reason: "server_shutdown"`
+   b. Publish a `job.canceled` event with `reason: "server_shutdown"`
    c. Transition the job to `canceled`
 3. Close all SSE connections
 4. Allow up to 10 seconds for in-flight requests to complete
@@ -1202,7 +1132,7 @@ Queued jobs remain in `queued` state and are picked up on next startup.
 On startup, before accepting requests, the backend runs recovery:
 
 1. Query for all jobs in `running` or `waiting_for_approval` state
-2. Transition each to `failed` with a `JobFailed` event containing `reason: "process_restarted"`
+2. Transition each to `failed` with a `job.failed` event containing `reason: "process_restarted"`
 3. Log each recovered job as a warning
 
 The system does not attempt to reconnect to orphaned agent sessions. Asyncio tasks from a previous process cannot be reconstructed. The operator can rerun any recovered job using the rerun button.
@@ -1397,7 +1327,7 @@ The flow:
    - **GitHub MCP server** (if configured in `.vscode/mcp.json` or `tools.mcp` global config) — the agent uses the MCP `create_pull_request` tool
    - **`gh` CLI** (if available on `$PATH`) — the agent runs `gh pr create` with the branch name, prompt-derived title, and a summary body
 3. If neither `gh` CLI nor GitHub MCP tools are available, the step is skipped silently and the branch remains on disk for the operator to push manually
-4. The PR URL (if created) is included in the `JobReview` event payload and displayed on the Job Detail screen
+4. The PR URL (if created) is included in the `job.review` event payload and displayed on the Job Detail screen
 
 This is a best-effort operation — if PR creation fails (e.g., no remote configured, auth issues), the job is still considered successful. The failure is logged as a warning.
 
@@ -1792,122 +1722,144 @@ Provided in the job creation request body:
 
 ## 11. Canonical Internal Event Model
 
-All runtime activity is represented as structured domain events. Every event has a shared envelope:
+All runtime activity is represented as `traceforge.SessionEvent` objects — the single canonical event model, end to end (event bus, persistence, and the SSE wire). CodePlane defines no bespoke event dataclass; it uses TraceForge's `SessionEvent` + `EventMetadata` directly. Event `kind` is an open dotted string in TraceForge's grammar; CodePlane's own control-plane kinds are named constants in the `EventKind` StrEnum (TraceForge-canonical strings are reused where semantics match — e.g. `log`, `message.*`, `tool.call.*`, `permission.*`):
 
 ```python
-class DomainEventKind(str, Enum):
-    job_created = "JobCreated"
-    job_setup_progress = "JobSetupProgress"
-    workspace_prepared = "WorkspacePrepared"
-    agent_session_started = "AgentSessionStarted"
-    log_line_emitted = "LogLineEmitted"
-    transcript_updated = "TranscriptUpdated"
-    diff_updated = "DiffUpdated"
-    approval_requested = "ApprovalRequested"
-    approval_resolved = "ApprovalResolved"
-    batch_approval_requested = "BatchApprovalRequested"
-    batch_approval_resolved = "BatchApprovalResolved"
-    job_review = "JobReview"
-    job_completed = "JobCompleted"
-    job_failed = "JobFailed"
-    job_canceled = "JobCanceled"
-    job_state_changed = "JobStateChanged"
-    session_heartbeat = "SessionHeartbeat"
-    merge_completed = "MergeCompleted"
-    merge_conflict = "MergeConflict"
-    session_resumed = "SessionResumed"
-    job_resolved = "JobResolved"
-    job_archived = "JobArchived"
-    job_title_updated = "JobTitleUpdated"
-    progress_headline = "ProgressHeadline"
-    model_downgraded = "ModelDowngraded"
-    tool_group_summary = "ToolGroupSummary"
-    agent_plan_updated = "AgentPlanUpdated"
-    execution_phase_changed = "ExecutionPhaseChanged"
-    telemetry_updated = "TelemetryUpdated"
-    step_started = "StepStarted"
-    step_completed = "StepCompleted"
-    step_title_generated = "StepTitleGenerated"
-    step_group_updated = "StepGroupUpdated"
-    plan_step_updated = "PlanStepUpdated"
-    step_entries_reassigned = "StepEntriesReassigned"
-    turn_summary = "TurnSummary"
-    action_classified = "ActionClassified"
-    policy_settings_changed = "PolicySettingsChanged"
-    repo_index_progress = "RepoIndexProgress"
-    repo_index_complete = "RepoIndexComplete"
-    structural_warning = "StructuralWarning"
-    stall_detected = "StallDetected"
-    monitor_approved = "MonitorApproved"
-    monitor_rejected = "MonitorRejected"
-    monitor_escalated = "MonitorEscalated"
-    sidecar_transcript = "SidecarTranscript"
-    sidecar_agent_message = "SidecarAgentMessage"
-    sidecar_gate_verdict = "SidecarGateVerdict"
-    sidecar_metadata_update = "SidecarMetadataUpdate"
+from enum import StrEnum
 
-@dataclass
-class DomainEvent:
-    event_id: str       # UUID
-    job_id: str
-    timestamp: datetime
-    kind: DomainEventKind
-    payload: dict
+from traceforge.types import EventMetadata, SessionEvent
+
+
+class EventKind(StrEnum):
+    """CodePlane control-plane kinds as open dotted TraceForge kinds."""
+
+    # Job lifecycle
+    job_created = "job.created"
+    job_setup_progress = "job.setup_progress"
+    workspace_prepared = "workspace.prepared"
+    agent_session_started = "agent.session_started"
+    # Transcript family — one CP transcript event fans out per agent role
+    message_user = "message.user"
+    message_assistant = "message.assistant"
+    message_delta = "message.delta"
+    tool_call_started = "tool.call.started"
+    tool_call_completed = "tool.call.completed"
+    # Logs / diffs
+    log_line_emitted = "log"
+    diff_updated = "diff.updated"
+    # Approvals (TraceForge-canonical permission.* grammar)
+    approval_requested = "permission.requested"
+    approval_resolved = "permission.resolved"
+    batch_approval_requested = "permission.batch.requested"
+    batch_approval_resolved = "permission.batch.resolved"
+    # Job state / outcomes
+    job_review = "job.review"
+    job_completed = "job.completed"
+    job_failed = "job.failed"
+    job_canceled = "job.canceled"
+    job_state_changed = "job.state_changed"
+    session_heartbeat = "session.heartbeat"
+    merge_completed = "merge.completed"
+    merge_conflict = "merge.conflict"
+    session_resumed = "session.resumed"
+    job_resolved = "job.resolved"
+    job_archived = "job.archived"
+    job_title_updated = "job.title_updated"
+    progress_headline = "progress.headline"
+    model_downgraded = "model.downgraded"
+    tool_group_summary = "tool.group_summary"
+    agent_plan_updated = "plan.updated"
+    execution_phase_changed = "execution.phase_changed"
+    telemetry_updated = "telemetry.updated"
+    # Steps / plan
+    step_started = "step.started"
+    step_completed = "step.completed"
+    step_title_generated = "step.title_generated"
+    step_group_updated = "step.group_updated"
+    plan_step_updated = "plan.step_updated"
+    step_entries_reassigned = "step.entries_reassigned"
+    turn_summary = "turn.summary"
+    action_classified = "action.classified"
+    policy_settings_changed = "policy.settings_changed"
+    # Repo index
+    repo_index_progress = "repo.index_progress"
+    repo_index_complete = "repo.index_complete"
+    # Structural health
+    structural_warning = "structural.warning"
+    stall_detected = "stall.detected"
+    # Monitors
+    monitor_approved = "monitor.approved"
+    monitor_rejected = "monitor.rejected"
+    monitor_escalated = "monitor.escalated"
+    # Sidecars
+    sidecar_transcript = "sidecar.transcript"
+    sidecar_agent_message = "sidecar.agent_message"
+    sidecar_gate_verdict = "sidecar.gate_verdict"
+    sidecar_metadata_update = "sidecar.metadata_update"
+    # Secondary sessions (preflight, sidecars, monitors)
+    secondary_session_started = "secondary_session.started"
+    secondary_session_entry = "secondary_session.entry"
+    secondary_session_completed = "secondary_session.completed"
+    # Context handoff / mode
+    context_handoff = "context.handoff"
+    job_mode_changed = "job.mode_changed"
 ```
+
+The `SessionEvent` envelope (from `traceforge.types`) carries `session_id` (the CodePlane job id), `kind` (dotted string), `payload` (CodePlane's event-specific fields), and `metadata` (`EventMetadata`: `timestamp`, `sequence`, `turn_id`, `event_id`, plus TraceForge annotations). Fields that once lived on a bespoke `DomainEvent` now ride `payload`; `turn_id` lives on `metadata.turn_id`.
 
 ### 11.1 Event Types
 
 | Event Kind | Trigger | Key Payload Fields |
 |---|---|---|
-| `JobCreated` | Job creation request accepted | `repo`, `prompt`, `base_ref` |
-| `JobSetupProgress` | Workspace setup step progress | `step` |
-| `WorkspacePrepared` | Worktree and branch created | `worktree_path`, `branch` |
-| `AgentSessionStarted` | Agent session created | `session_id` |
-| `LogLineEmitted` | Agent or system log output | `seq`, `level`, `message`, `context` |
-| `TranscriptUpdated` | Agent reasoning or operator message | `seq`, `role`, `content` |
-| `DiffUpdated` | File changes detected in worktree | `changed_files` (list of DiffFile) |
-| `ApprovalRequested` | SDK permission request intercepted | `approval_id`, `description`, `proposed_action`, `tier` |
-| `ApprovalResolved` | Operator approves or rejects | `approval_id`, `resolution` |
-| `BatchApprovalRequested` | Action policy batch awaiting approval | `batch_id`, `actions` |
-| `BatchApprovalResolved` | Batch approved or rejected | `batch_id`, `resolution` |
-| `JobReview` | Session completed, awaiting operator review | `pr_url`, `merge_status`, `resolution` |
-| `JobCompleted` | Job resolved to terminal state | |
-| `JobFailed` | Session terminated with error | `reason` |
-| `JobCanceled` | Operator canceled the job | `reason` |
-| `JobStateChanged` | Job transitions between states | `previous_state`, `new_state` |
-| `SessionHeartbeat` | Periodic heartbeat from running session | `session_id` |
-| `MergeCompleted` | Merge-back succeeded | `branch`, `base_ref`, `strategy` |
-| `MergeConflict` | Merge-back hit conflicts | `branch`, `conflict_files`, `fallback` |
-| `SessionResumed` | Agent session resumed after failure | `session_number` |
-| `JobResolved` | Operator resolved a completed job | `resolution`, `pr_url`, `conflict_files` |
-| `JobArchived` | Job moved to archive | _(none)_ |
-| `JobTitleUpdated` | LLM generated or updated job title | `title`, `branch`, `description` |
-| `ProgressHeadline` | Agent progress summary | `headline` |
-| `ModelDowngraded` | Requested model unavailable, fallback used | `requested_model`, `actual_model` |
-| `ToolGroupSummary` | AI-generated summary for tool group | `turn_id`, `summary` |
-| `AgentPlanUpdated` | Agent plan steps updated | `steps` |
-| `ExecutionPhaseChanged` | Execution phase transition | `phase` |
-| `TelemetryUpdated` | Cost/token metrics updated | telemetry fields |
-| `StepStarted` | Plan step started | `step_id`, `step_number` |
-| `StepCompleted` | Plan step finished | `step_id` |
-| `StepTitleGenerated` | Step title generated by LLM | `step_id`, `title` |
-| `StepGroupUpdated` | Step grouping changed | `step_id` |
-| `PlanStepUpdated` | Plan step detail updated | `step_id` |
-| `StepEntriesReassigned` | Entries moved to different step | `old_step_id`, `new_step_id` |
-| `TurnSummary` | AI-generated turn summary | `turn_id`, `summary` |
-| `ActionClassified` | Action policy classification | `tier`, `kind`, `description` |
-| `PolicySettingsChanged` | Policy configuration changed | `preset` |
-| `RepoIndexProgress` | Repo structural indexing progress | `repo`, `progress` |
-| `RepoIndexComplete` | Repo structural indexing complete | `repo` |
-| `StructuralWarning` | Code structure warning detected | `warning` |
-| `StallDetected` | Agent stall detected by arbiter sidecar | |
-| `MonitorApproved` | Monitor sidecar auto-approved action | `action` |
-| `MonitorRejected` | Monitor sidecar auto-rejected action | `action` |
-| `MonitorEscalated` | Monitor sidecar escalated to human | `action` |
-| `SidecarTranscript` | Sidecar session output | `sidecar_name`, `content` |
-| `SidecarAgentMessage` | Sidecar agent message | `sidecar_name`, `message` |
-| `SidecarGateVerdict` | Sidecar gate decision | `sidecar_name`, `verdict` |
-| `SidecarMetadataUpdate` | Sidecar metadata changed | `sidecar_name`, `metadata` |
+| `job.created` | Job creation request accepted | `repo`, `prompt`, `base_ref` |
+| `job.setup_progress` | Workspace setup step progress | `step` |
+| `workspace.prepared` | Worktree and branch created | `worktree_path`, `branch` |
+| `agent.session_started` | Agent session created | `session_id` |
+| `log` | Agent or system log output | `seq`, `level`, `message`, `context` |
+| `message.user` / `message.assistant` / `message.delta` / `tool.call.started` / `tool.call.completed` | Agent/operator transcript, fanned out by role | `seq`, `role`, `content` |
+| `diff.updated` | File changes detected in worktree | `changed_files` (list of DiffFile) |
+| `permission.requested` | SDK permission request intercepted | `approval_id`, `description`, `proposed_action`, `tier` |
+| `permission.resolved` | Operator approves or rejects | `approval_id`, `resolution` |
+| `permission.batch.requested` | Action policy batch awaiting approval | `batch_id`, `actions` |
+| `permission.batch.resolved` | Batch approved or rejected | `batch_id`, `resolution` |
+| `job.review` | Session completed, awaiting operator review | `pr_url`, `merge_status`, `resolution` |
+| `job.completed` | Job resolved to terminal state | |
+| `job.failed` | Session terminated with error | `reason` |
+| `job.canceled` | Operator canceled the job | `reason` |
+| `job.state_changed` | Job transitions between states | `previous_state`, `new_state` |
+| `session.heartbeat` | Periodic heartbeat from running session | `session_id` |
+| `merge.completed` | Merge-back succeeded | `branch`, `base_ref`, `strategy` |
+| `merge.conflict` | Merge-back hit conflicts | `branch`, `conflict_files`, `fallback` |
+| `session.resumed` | Agent session resumed after failure | `session_number` |
+| `job.resolved` | Operator resolved a completed job | `resolution`, `pr_url`, `conflict_files` |
+| `job.archived` | Job moved to archive | _(none)_ |
+| `job.title_updated` | LLM generated or updated job title | `title`, `branch`, `description` |
+| `progress.headline` | Agent progress summary | `headline` |
+| `model.downgraded` | Requested model unavailable, fallback used | `requested_model`, `actual_model` |
+| `tool.group_summary` | AI-generated summary for tool group | `turn_id`, `summary` |
+| `plan.updated` | Agent plan steps updated | `steps` |
+| `execution.phase_changed` | Execution phase transition | `phase` |
+| `telemetry.updated` | Cost/token metrics updated | telemetry fields |
+| `step.started` | Plan step started | `step_id`, `step_number` |
+| `step.completed` | Plan step finished | `step_id` |
+| `step.title_generated` | Step title generated by LLM | `step_id`, `title` |
+| `step.group_updated` | Step grouping changed | `step_id` |
+| `plan.step_updated` | Plan step detail updated | `step_id` |
+| `step.entries_reassigned` | Entries moved to different step | `old_step_id`, `new_step_id` |
+| `turn.summary` | AI-generated turn summary | `turn_id`, `summary` |
+| `action.classified` | Action policy classification | `tier`, `kind`, `description` |
+| `policy.settings_changed` | Policy configuration changed | `preset` |
+| `repo.index_progress` | Repo structural indexing progress | `repo`, `progress` |
+| `repo.index_complete` | Repo structural indexing complete | `repo` |
+| `structural.warning` | Code structure warning detected | `warning` |
+| `stall.detected` | Agent stall detected by arbiter sidecar | |
+| `monitor.approved` | Monitor sidecar auto-approved action | `action` |
+| `monitor.rejected` | Monitor sidecar auto-rejected action | `action` |
+| `monitor.escalated` | Monitor sidecar escalated to human | `action` |
+| `sidecar.transcript` | Sidecar session output | `sidecar_name`, `content` |
+| `sidecar.agent_message` | Sidecar agent message | `sidecar_name`, `message` |
+| `sidecar.gate_verdict` | Sidecar gate decision | `sidecar_name`, `verdict` |
+| `sidecar.metadata_update` | Sidecar metadata changed | `sidecar_name`, `metadata` |
 
 ### 11.2 Event Consumers
 
@@ -1916,9 +1868,9 @@ class DomainEvent:
 | `JobStateMachine` | All state-relevant events | Applies state transitions |
 | `PersistenceSubscriber` | All events | Persists to SQLite event log |
 | `SSEManager` | All events | Pushes to connected SSE clients |
-| `ApprovalService` | `ApprovalRequested` | Persists request, awaits operator resolution |
-| `DiffService` | `WorkspacePrepared`, `JobReview` | Generates and stores diff snapshots |
-| `ArtifactService` | `JobReview` | Collects and stores artifacts |
+| `ApprovalService` | `permission.requested` | Persists request, awaits operator resolution |
+| `DiffService` | `workspace.prepared`, `job.review` | Generates and stores diff snapshots |
+| `ArtifactService` | `job.review` | Collects and stores artifacts |
 | `TimelineBuilder` | All events | Updates job timeline view |
 
 ---
@@ -1955,23 +1907,23 @@ Jobs in `review` carry a **resolution status** that tracks how the job's changes
 
 | From | Event | To |
 |---|---|---|
-| _(none)_ | `JobCreated` | `preparing` |
-| _(none)_ | `JobCreated` (external CLI session) | `running` or `queued` |
-| `preparing` | `WorkspacePrepared` + capacity available | `queued` |
+| _(none)_ | `job.created` | `preparing` |
+| _(none)_ | `job.created` (external CLI session) | `running` or `queued` |
+| `preparing` | `workspace.prepared` + capacity available | `queued` |
 | `preparing` | Workspace creation failed | `failed` |
-| `preparing` | `JobCanceled` | `canceled` |
+| `preparing` | `job.canceled` | `canceled` |
 | `queued` | Capacity opens | `running` |
-| `queued` | `JobCanceled` | `canceled` |
-| `running` | `ApprovalRequested` | `waiting_for_approval` |
-| `running` | `JobReview` (agent done) | `review` |
-| `running` | `JobFailed` | `failed` |
-| `running` | `JobCanceled` | `canceled` |
-| `waiting_for_approval` | `ApprovalResolved` (approved) | `running` |
-| `waiting_for_approval` | `ApprovalResolved` (rejected) | `failed` |
-| `waiting_for_approval` | `JobCanceled` | `canceled` |
+| `queued` | `job.canceled` | `canceled` |
+| `running` | `permission.requested` | `waiting_for_approval` |
+| `running` | `job.review` (agent done) | `review` |
+| `running` | `job.failed` | `failed` |
+| `running` | `job.canceled` | `canceled` |
+| `waiting_for_approval` | `permission.resolved` (approved) | `running` |
+| `waiting_for_approval` | `permission.resolved` (rejected) | `failed` |
+| `waiting_for_approval` | `job.canceled` | `canceled` |
 | `review` | Operator resolves (merge/PR/discard) | `completed` |
 | `review` | Operator resumes with instructions | `running` |
-| `review` | `JobCanceled` | `canceled` |
+| `review` | `job.canceled` | `canceled` |
 
 Terminal states (`completed`, `failed`, `canceled`) can transition back to `running` for job resumption.
 
@@ -1987,10 +1939,10 @@ Rerunning a job creates a new job record. The original job is not mutated. The n
 
 | Phase | Description | Example events |
 |---|---|---|
-| `environment_setup` | Workspace creation, branch, dependency install | `WorkspacePrepared`, `LogLineEmitted` |
-| `agent_reasoning` | Agent reads code, thinks, plans, and writes changes | `TranscriptUpdated`, `DiffUpdated`, `ApprovalRequested` |
-| `verification` | Post-task verification and self-review passes | `TranscriptUpdated`, `DiffUpdated` |
-| `finalization` | Final diff snapshot, artifact collection | `DiffUpdated`, `JobReview` |
+| `environment_setup` | Workspace creation, branch, dependency install | `workspace.prepared`, `log` |
+| `agent_reasoning` | Agent reads code, thinks, plans, and writes changes | `message.assistant`, `diff.updated`, `permission.requested` |
+| `verification` | Post-task verification and self-review passes | `message.assistant`, `diff.updated` |
+| `finalization` | Final diff snapshot, artifact collection | `diff.updated`, `job.review` |
 | `post_completion` | Operator reviews, approves, or reruns | _(no agent events)_ |
 
 Artifacts and timeline entries carry the phase in which they were produced. The frontend uses phase labels to group the execution timeline.
@@ -2566,8 +2518,8 @@ class JobRepository:
     def update_state(self, job_id: str, new_state: str, updated_at: datetime) -> None: ...
 
 class EventRepository:
-    def append(self, event: DomainEvent) -> None: ...
-    def list_after(self, after_id: int, job_id: str | None = None) -> list[DomainEvent]: ...
+    def append(self, event: SessionEvent) -> None: ...
+    def list_after(self, after_id: int, job_id: str | None = None) -> list[SessionEvent]: ...
 
 class ArtifactRepository:
     def create(self, artifact: Artifact) -> Artifact: ...
@@ -3259,13 +3211,13 @@ The adapter normalizes whichever fields the SDK provides into this common shape.
    a. `ApprovalService` persists the request
    b. `approval_request` event emitted
    c. Job transitions to `waiting_for_approval`
-   d. `ApprovalRequested` SSE event sent to frontend
+   d. `permission.requested` SSE event sent to frontend
    e. Frontend renders approval banner on Job Detail screen
    f. Operator clicks Approve or Reject
    g. `POST /api/approvals/{id}/resolve` called
    h. `ApprovalService` persists the resolution and unblocks the adapter's Future
    i. Adapter returns the decision to the SDK
-   j. `ApprovalResolved` domain event published
+   j. `permission.resolved` domain event published
    k. Job transitions back to `running`
 
 The SDK's `on_permission_request` callback is **async** — it blocks the SDK at the callback level while waiting for the operator's response. This ensures the action does not proceed until approved.
@@ -3312,7 +3264,7 @@ Parser responsibilities:
 
 ### 19.3 Diff Updates
 
-`DiffUpdated` events are emitted:
+`diff.updated` events are emitted:
 
 - When the agent writes a file (debounced)
 - When a validation phase completes
@@ -3333,7 +3285,7 @@ Diff recalculation is triggered by the adapter's `file_changed` events (emitted 
 
 At job completion, a final diff snapshot is stored in the `diff_snapshots` table. This snapshot represents the full set of changes produced by the job.
 
-Diff snapshots are not exposed via a dedicated REST endpoint. The frontend receives live diffs via SSE `diff_update` events during execution, and the final diff is available as a `diff_snapshot` artifact via `GET /api/jobs/{job_id}/artifacts`. Historical intermediate snapshots are stored for future features (e.g., diff timeline playback) but are not served in v1.
+Diff snapshots are not exposed via a dedicated REST endpoint. The frontend receives live diffs via SSE `diff.updated` events during execution, and the final diff is available as a `diff_snapshot` artifact via `GET /api/jobs/{job_id}/artifacts`. Historical intermediate snapshots are stored for future features (e.g., diff timeline playback) but are not served in v1.
 
 ### 19.5 Frontend Diff Rendering
 
@@ -3403,7 +3355,7 @@ This provides an at-a-glance operational view without overwhelming the terminal.
 
 When a job enters `failed` state, the Job Detail screen shows:
 
-- The error message from the `JobFailed` event payload
+- The error message from the `job.failed` event payload
 - The traceback (if available)
 - The last log lines before failure
 - The last transcript entries
@@ -4005,7 +3957,7 @@ This section documents genuinely open questions that require further investigati
 
 **Resolved:** Session cancellation uses `session.abort()` which aborts the current message processing. The session remains valid after abort. Operator message injection uses `session.send(MessageOptions)` with `mode="immediate"` to send a follow-up message while the session is active.
 
-**Resolved:** Subprocess crash detection relies on EOF/broken pipe on the JSON-RPC stdout stream. The SDK's background read loop detects the closed stream, polls the process exit code, captures stderr, and raises `ProcessExitedError` on all pending futures. The adapter catches this exception and emits a `JobFailed` event with the error details. No heartbeat mechanism exists — crash detection is immediate via the broken pipe.
+**Resolved:** Subprocess crash detection relies on EOF/broken pipe on the JSON-RPC stdout stream. The SDK's background read loop detects the closed stream, polls the process exit code, captures stderr, and raises `ProcessExitedError` on all pending futures. The adapter catches this exception and emits a `job.failed` event with the error details. No heartbeat mechanism exists — crash detection is immediate via the broken pipe.
 
 ---
 
@@ -4017,7 +3969,7 @@ This section documents genuinely open questions that require further investigati
 
 ### 25.3 SSE Scalability Constraint
 
-**Resolved:** Documented as a known constraint. Beyond ~20 concurrent jobs, the SSE manager switches to selective streaming: only `job_state_changed` events are broadcast to the dashboard, while the currently open Job Detail screen continues to receive full event streaming. A "Refresh page for latest updates" banner is shown on the dashboard. See Section 5.6.
+**Resolved:** Documented as a known constraint. Beyond ~20 concurrent jobs, the SSE manager switches to selective streaming: only `job.state_changed` events are broadcast to the dashboard, while the currently open Job Detail screen continues to receive full event streaming. A "Refresh page for latest updates" banner is shown on the dashboard. See Section 5.6.
 
 ---
 

--- a/backend/api/analytics.py
+++ b/backend/api/analytics.py
@@ -667,7 +667,7 @@ async def analytics_executive_summary(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/analytics/export")
+@router.get("/analytics/export", response_model=None)
 async def analytics_export(
     svc: FromDishka[AnalyticsService],
     period: Annotated[int, Query(ge=1, le=365)] = 30,
@@ -764,7 +764,7 @@ async def analytics_export(
     )
 
 
-@router.get("/analytics/sidecar-costs")
+@router.get("/analytics/sidecar-costs", response_model=list[SidecarCostEntry])
 async def analytics_sidecar_costs(
     svc: FromDishka[AnalyticsService],
     period: Annotated[int, Query(ge=1, le=365)] = 30,

--- a/backend/api/artifacts.py
+++ b/backend/api/artifacts.py
@@ -38,7 +38,7 @@ async def list_artifacts(
     return ArtifactListResponse(items=items)
 
 
-@router.get("/artifacts/{artifact_id}", response_class=FileResponse)
+@router.get("/artifacts/{artifact_id}", response_class=FileResponse, response_model=None)
 async def download_artifact(
     artifact_id: str,
     svc: FromDishka[ArtifactService],

--- a/backend/api/hooks.py
+++ b/backend/api/hooks.py
@@ -19,7 +19,7 @@ from backend.services.watcher.claude import ClaudeSessionStateWatcher
 router = APIRouter(tags=["hooks"], route_class=DishkaRoute)
 
 
-@router.post("/hooks/claude")
+@router.post("/hooks/claude", response_model=None)
 async def claude_stop_hook(
     request: Request,
     watcher: FromDishka[ClaudeSessionStateWatcher],

--- a/backend/api/job_artifacts.py
+++ b/backend/api/job_artifacts.py
@@ -61,7 +61,7 @@ from backend.models.api_schemas import (
     TranscriptSearchResult,
 )
 from backend.models.domain import JobState, Resolution
-from backend.models.events import TRANSCRIPT_KINDS, CPEventKind
+from backend.models.events import TRANSCRIPT_KINDS, EventKind
 from backend.persistence.approval_repo import ApprovalRepository
 from backend.persistence.event_repo import EventRepository
 from backend.persistence.step_repo import StepRepository
@@ -209,7 +209,7 @@ async def get_job_logs(
     """
     _level_order = {"debug": 0, "info": 1, "warn": 2, "error": 3}
     min_priority = _level_order.get(level, 0)
-    events = await svc.list_events_by_job(job_id, [CPEventKind.log_line_emitted], limit=limit)
+    events = await svc.list_events_by_job(job_id, [EventKind.log_line_emitted], limit=limit)
     lines = []
     for event in events:
         payload = event.payload
@@ -265,7 +265,7 @@ async def get_job_diff(
 
     if not files:
         # Fallback: read from event store (completed/archived/failed jobs)
-        events = await svc.list_events_by_job(job_id, [CPEventKind.diff_updated])
+        events = await svc.list_events_by_job(job_id, [EventKind.diff_updated])
         if not events:
             return DiffListResponse(items=[])
         raw_files = cast("list[dict[str, Any]]", events[-1].payload.get("changed_files", []))
@@ -319,7 +319,7 @@ async def get_job_diff_file(
 
     if file is None:
         # Fallback: read from event store
-        events = await svc.list_events_by_job(job_id, [CPEventKind.diff_updated])
+        events = await svc.list_events_by_job(job_id, [EventKind.diff_updated])
         if events:
             raw_files = cast("list[dict[str, Any]]", events[-1].payload.get("changed_files", []))
             for raw in raw_files:
@@ -346,14 +346,14 @@ async def get_job_transcript(
     # Include persisted sidecar events so they survive page reload.
     sidecar_events = await svc.list_events_by_job(
         job_id,
-        [CPEventKind.sidecar_transcript, CPEventKind.sidecar_agent_message],
+        [EventKind.sidecar_transcript, EventKind.sidecar_agent_message],
         limit=limit,
     )
 
     # Build a turn_id → summary map from stored tool_group_summary events so
     # that restored transcripts include AI-generated group labels.
     summary_events = await svc.list_events_by_job(
-        job_id, [CPEventKind.tool_group_summary], limit=_EVENT_QUERY_CEILING
+        job_id, [EventKind.tool_group_summary], limit=_EVENT_QUERY_CEILING
     )
     group_summary_by_turn: dict[str, str] = {
         str(ev.payload.get("turn_id")): str(ev.payload.get("summary"))
@@ -419,7 +419,7 @@ async def get_job_steps(
     endpoint lets late-joining clients catch up on steps that were emitted
     before they connected.
     """
-    events = await svc.list_events_by_job(job_id, [CPEventKind.plan_step_updated], limit=_EVENT_QUERY_CEILING)
+    events = await svc.list_events_by_job(job_id, [EventKind.plan_step_updated], limit=_EVENT_QUERY_CEILING)
     # De-duplicate: keep the latest event per plan_step_id (events are ordered chronologically)
     latest_by_id: dict[str, dict[str, Any]] = {}
     for ev in events:
@@ -551,7 +551,7 @@ async def get_job_timeline(
     Events with ``replaces_count > 0`` retroactively collapse earlier entries,
     so the returned list is the final milestone timeline, not raw events.
     """
-    events = await svc.list_events_by_job(job_id, [CPEventKind.progress_headline], limit=limit)
+    events = await svc.list_events_by_job(job_id, [EventKind.progress_headline], limit=limit)
 
     # Replay events to reconstruct the collapsed milestone list
     milestones: list[ProgressHeadlinePayload] = []
@@ -1017,7 +1017,7 @@ async def get_job_multi_session(
     # session_resumed event timestamp.
     resumed_events = await event_repo.list_by_job(
         job_id,
-        [CPEventKind.session_resumed],
+        [EventKind.session_resumed],
         limit=100,
     )
     # Build boundary timestamps: session N starts at resumed_events[N-2].timestamp

--- a/backend/api/job_artifacts.py
+++ b/backend/api/job_artifacts.py
@@ -61,7 +61,7 @@ from backend.models.api_schemas import (
     TranscriptSearchResult,
 )
 from backend.models.domain import JobState, Resolution
-from backend.models.events import DomainEventKind
+from backend.models.events import TRANSCRIPT_KINDS, CPEventKind
 from backend.persistence.approval_repo import ApprovalRepository
 from backend.persistence.event_repo import EventRepository
 from backend.persistence.step_repo import StepRepository
@@ -209,7 +209,7 @@ async def get_job_logs(
     """
     _level_order = {"debug": 0, "info": 1, "warn": 2, "error": 3}
     min_priority = _level_order.get(level, 0)
-    events = await svc.list_events_by_job(job_id, [DomainEventKind.log_line_emitted], limit=limit)
+    events = await svc.list_events_by_job(job_id, [CPEventKind.log_line_emitted], limit=limit)
     lines = []
     for event in events:
         payload = event.payload
@@ -265,7 +265,7 @@ async def get_job_diff(
 
     if not files:
         # Fallback: read from event store (completed/archived/failed jobs)
-        events = await svc.list_events_by_job(job_id, [DomainEventKind.diff_updated])
+        events = await svc.list_events_by_job(job_id, [CPEventKind.diff_updated])
         if not events:
             return DiffListResponse(items=[])
         raw_files = cast("list[dict[str, Any]]", events[-1].payload.get("changed_files", []))
@@ -319,7 +319,7 @@ async def get_job_diff_file(
 
     if file is None:
         # Fallback: read from event store
-        events = await svc.list_events_by_job(job_id, [DomainEventKind.diff_updated])
+        events = await svc.list_events_by_job(job_id, [CPEventKind.diff_updated])
         if events:
             raw_files = cast("list[dict[str, Any]]", events[-1].payload.get("changed_files", []))
             for raw in raw_files:
@@ -341,19 +341,19 @@ async def get_job_transcript(
     limit: int = Query(default=_EVENT_QUERY_DEFAULT, ge=1, le=_EVENT_QUERY_CEILING),
 ) -> TranscriptListResponse:
     """Return historical transcript entries for a job from the event store."""
-    events = await svc.list_events_by_job(job_id, [DomainEventKind.transcript_updated], limit=limit)
+    events = await svc.list_events_by_job(job_id, list(TRANSCRIPT_KINDS), limit=limit)
 
     # Include persisted sidecar events so they survive page reload.
     sidecar_events = await svc.list_events_by_job(
         job_id,
-        [DomainEventKind.sidecar_transcript, DomainEventKind.sidecar_agent_message],
+        [CPEventKind.sidecar_transcript, CPEventKind.sidecar_agent_message],
         limit=limit,
     )
 
     # Build a turn_id → summary map from stored tool_group_summary events so
     # that restored transcripts include AI-generated group labels.
     summary_events = await svc.list_events_by_job(
-        job_id, [DomainEventKind.tool_group_summary], limit=_EVENT_QUERY_CEILING
+        job_id, [CPEventKind.tool_group_summary], limit=_EVENT_QUERY_CEILING
     )
     group_summary_by_turn: dict[str, str] = {
         str(ev.payload.get("turn_id")): str(ev.payload.get("summary"))
@@ -419,7 +419,7 @@ async def get_job_steps(
     endpoint lets late-joining clients catch up on steps that were emitted
     before they connected.
     """
-    events = await svc.list_events_by_job(job_id, [DomainEventKind.plan_step_updated], limit=_EVENT_QUERY_CEILING)
+    events = await svc.list_events_by_job(job_id, [CPEventKind.plan_step_updated], limit=_EVENT_QUERY_CEILING)
     # De-duplicate: keep the latest event per plan_step_id (events are ordered chronologically)
     latest_by_id: dict[str, dict[str, Any]] = {}
     for ev in events:
@@ -551,7 +551,7 @@ async def get_job_timeline(
     Events with ``replaces_count > 0`` retroactively collapse earlier entries,
     so the returned list is the final milestone timeline, not raw events.
     """
-    events = await svc.list_events_by_job(job_id, [DomainEventKind.progress_headline], limit=limit)
+    events = await svc.list_events_by_job(job_id, [CPEventKind.progress_headline], limit=limit)
 
     # Replay events to reconstruct the collapsed milestone list
     milestones: list[ProgressHeadlinePayload] = []
@@ -1017,7 +1017,7 @@ async def get_job_multi_session(
     # session_resumed event timestamp.
     resumed_events = await event_repo.list_by_job(
         job_id,
-        [DomainEventKind.session_resumed],
+        [CPEventKind.session_resumed],
         limit=100,
     )
     # Build boundary timestamps: session N starts at resumed_events[N-2].timestamp

--- a/backend/api/job_artifacts.py
+++ b/backend/api/job_artifacts.py
@@ -212,7 +212,7 @@ async def get_job_logs(
     events = await svc.list_events_by_job(job_id, [DomainEventKind.log_line_emitted], limit=limit)
     lines = []
     for event in events:
-        payload = cast("dict[str, Any]", event.payload)
+        payload = event.payload
         event_level = payload.get("level", "info")
         if _level_order.get(event_level, 1) < min_priority:
             continue
@@ -221,7 +221,7 @@ async def get_job_logs(
             continue
         lines.append(
             LogLinePayload(
-                job_id=event.job_id,
+                job_id=event.session_id,
                 seq=payload.get("seq", 0),
                 timestamp=payload.get("timestamp", event.timestamp),
                 level=event_level,
@@ -363,8 +363,8 @@ async def get_job_transcript(
 
     items: list[TranscriptPayload] = [
         TranscriptPayload(
-            job_id=event.job_id,
-            seq=(p := cast("dict[str, Any]", event.payload)).get("seq", 0),
+            job_id=event.session_id,
+            seq=(p := event.payload).get("seq", 0),
             timestamp=p.get("timestamp", event.timestamp),
             role=p.get("role", "agent"),
             content=p.get("content", ""),
@@ -387,10 +387,10 @@ async def get_job_transcript(
 
     # Append sidecar entries with role="sidecar"
     for event in sidecar_events:
-        p = cast("dict[str, Any]", event.payload)
+        p = event.payload
         items.append(
             TranscriptPayload(
-                job_id=event.job_id,
+                job_id=event.session_id,
                 seq=p.get("seq", 0),
                 timestamp=p.get("timestamp", event.timestamp),
                 role="sidecar",
@@ -423,7 +423,7 @@ async def get_job_steps(
     # De-duplicate: keep the latest event per plan_step_id (events are ordered chronologically)
     latest_by_id: dict[str, dict[str, Any]] = {}
     for ev in events:
-        p = cast("dict[str, Any]", ev.payload)
+        p = ev.payload
         step_id = p.get("plan_step_id", "")
         if step_id:
             latest_by_id[step_id] = p
@@ -431,7 +431,7 @@ async def get_job_steps(
     # Build response preserving insertion order (first-seen order = plan order)
     seen_order: list[str] = []
     for ev in events:
-        p = cast("dict[str, Any]", ev.payload)
+        p = ev.payload
         sid = p.get("plan_step_id", "")
         if sid and sid not in seen_order:
             seen_order.append(sid)
@@ -496,7 +496,7 @@ async def search_transcript(
     events = await event_repo.search_transcript(job_id, q, roles=roles, step_id=step_id, limit=limit)
     results = []
     for evt in events:
-        payload = cast("dict[str, Any]", evt.payload)
+        payload = evt.payload
         results.append(
             TranscriptSearchResult(
                 seq=int(payload.get("seq", 0)),
@@ -556,13 +556,13 @@ async def get_job_timeline(
     # Replay events to reconstruct the collapsed milestone list
     milestones: list[ProgressHeadlinePayload] = []
     for event in events:
-        ep = cast("dict[str, Any]", event.payload)
+        ep = event.payload
         replaces = int(ep.get("replaces_count", 0) or 0)
         if replaces > 0:
             milestones = milestones[:-replaces] if replaces < len(milestones) else []
         milestones.append(
             ProgressHeadlinePayload(
-                job_id=event.job_id,
+                job_id=event.session_id,
                 headline=ep.get("headline", ""),
                 headline_past=ep.get("headline_past", ""),
                 summary=ep.get("summary", ""),

--- a/backend/api/policy_settings.py
+++ b/backend/api/policy_settings.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, HTTPException
 from pydantic import Field
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from backend.models.events import CPEventKind, new_event
+from backend.models.events import EventKind, new_event
 from backend.models.schemas.base import CamelModel
 from backend.persistence.policy_repo import PolicyRepository
 from backend.services.events.event_bus import EventBus
@@ -22,7 +22,7 @@ log = structlog.get_logger()
 async def _notify_policy_changed(event_bus: EventBus) -> None:
     """Publish a policy_settings_changed event so running jobs reload policy."""
     await event_bus.publish(
-        new_event(session_id="", timestamp=datetime.now(UTC), kind=CPEventKind.policy_settings_changed, payload={})
+        new_event(session_id="", timestamp=datetime.now(UTC), kind=EventKind.policy_settings_changed, payload={})
     )
 
 

--- a/backend/api/policy_settings.py
+++ b/backend/api/policy_settings.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, HTTPException
 from pydantic import Field
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from backend.models.events import DomainEventKind, new_event
+from backend.models.events import CPEventKind, new_event
 from backend.models.schemas.base import CamelModel
 from backend.persistence.policy_repo import PolicyRepository
 from backend.services.events.event_bus import EventBus
@@ -22,7 +22,7 @@ log = structlog.get_logger()
 async def _notify_policy_changed(event_bus: EventBus) -> None:
     """Publish a policy_settings_changed event so running jobs reload policy."""
     await event_bus.publish(
-        new_event(session_id="", timestamp=datetime.now(UTC), kind=DomainEventKind.policy_settings_changed, payload={})
+        new_event(session_id="", timestamp=datetime.now(UTC), kind=CPEventKind.policy_settings_changed, payload={})
     )
 
 

--- a/backend/api/policy_settings.py
+++ b/backend/api/policy_settings.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, HTTPException
 from pydantic import Field
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, new_event
 from backend.models.schemas.base import CamelModel
 from backend.persistence.policy_repo import PolicyRepository
 from backend.services.events.event_bus import EventBus
@@ -22,13 +22,7 @@ log = structlog.get_logger()
 async def _notify_policy_changed(event_bus: EventBus) -> None:
     """Publish a policy_settings_changed event so running jobs reload policy."""
     await event_bus.publish(
-        DomainEvent(
-            event_id=DomainEvent.make_event_id(),
-            job_id="",
-            timestamp=datetime.now(UTC),
-            kind=DomainEventKind.policy_settings_changed,
-            payload={},
-        )
+        new_event(session_id="", timestamp=datetime.now(UTC), kind=DomainEventKind.policy_settings_changed, payload={})
     )
 
 

--- a/backend/api/preview.py
+++ b/backend/api/preview.py
@@ -44,6 +44,7 @@ _BLOCKED_RESPONSE_HEADERS = frozenset({"transfer-encoding", "connection", "conte
     "/preview/{port:int}/{path:path}",
     methods=["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD"],
     response_class=Response,
+    response_model=None,
 )
 async def preview_proxy(port: int, path: str, request: Request, client: FromDishka[PreviewHttpClient]) -> Response:
     """Reverse-proxy a request to a local development server."""

--- a/backend/api/workspace.py
+++ b/backend/api/workspace.py
@@ -98,7 +98,7 @@ async def get_workspace_file(
     return WorkspaceFileResponse(path=path, content=content)
 
 
-@router.get("/jobs/{job_id}/workspace/file/raw", response_class=FileResponse)
+@router.get("/jobs/{job_id}/workspace/file/raw", response_class=FileResponse, response_model=None)
 async def get_workspace_file_raw(
     job_id: str,
     svc: FromDishka[JobService],

--- a/backend/console_dashboard.py
+++ b/backend/console_dashboard.py
@@ -36,7 +36,7 @@ from typing import TYPE_CHECKING
 from rich.console import Console
 from rich.text import Text
 
-from backend.models.events import CPEventKind
+from backend.models.events import EventKind
 
 if TYPE_CHECKING:
     from backend.models.events import SessionEvent
@@ -214,24 +214,24 @@ class ConsoleLog:
         if not job_id:
             return
 
-        if kind == CPEventKind.job_created:
+        if kind == EventKind.job_created:
             self._jobs[job_id] = _JobInfo(job_id)
 
-        elif kind == CPEventKind.job_state_changed:
+        elif kind == EventKind.job_state_changed:
             new_state = str(event.payload.get("new_state", ""))
             if job_id not in self._jobs:
                 self._jobs[job_id] = _JobInfo(job_id)
 
         elif kind in (
-            CPEventKind.job_completed,
-            CPEventKind.job_failed,
-            CPEventKind.job_canceled,
+            EventKind.job_completed,
+            EventKind.job_failed,
+            EventKind.job_canceled,
         ):
             new_state = {
-                CPEventKind.job_completed: "completed",
-                CPEventKind.job_failed: "failed",
-                CPEventKind.job_canceled: "canceled",
-            }[CPEventKind(kind)]
+                EventKind.job_completed: "completed",
+                EventKind.job_failed: "failed",
+                EventKind.job_canceled: "canceled",
+            }[EventKind(kind)]
             job = self._jobs.get(job_id)
             elapsed = f"  ({job.elapsed()})" if job else ""
             title = f'  "{job.title}"' if job and job.title else ""
@@ -239,16 +239,16 @@ class ConsoleLog:
             self._print_event(ts, icon, new_state, job_id, new_state + elapsed + title)
             self._jobs.pop(job_id, None)
 
-        elif kind == CPEventKind.job_title_updated:
+        elif kind == EventKind.job_title_updated:
             updated_title: str | None = str(event.payload.get("title")) if event.payload.get("title") else None
             if updated_title and job_id in self._jobs:
                 self._jobs[job_id].title = updated_title
 
-        elif kind == CPEventKind.progress_headline:
+        elif kind == EventKind.progress_headline:
             # Shown in the UI kanban board; suppress from terminal.
             pass
 
-        elif kind == CPEventKind.approval_requested:
+        elif kind == EventKind.approval_requested:
             desc = str(event.payload.get("description") or "approval needed")
             self._print_event(ts, "⏸", "waiting_for_approval", job_id, f"approval needed · {desc}")
 

--- a/backend/console_dashboard.py
+++ b/backend/console_dashboard.py
@@ -39,7 +39,7 @@ from rich.text import Text
 from backend.models.events import DomainEventKind
 
 if TYPE_CHECKING:
-    from backend.models.events import DomainEvent
+    from backend.models.events import SessionEvent
 
 # ---------------------------------------------------------------------------
 # Display constants
@@ -176,7 +176,7 @@ class ConsoleLog:
     # EventBus subscriber
     # ------------------------------------------------------------------
 
-    async def handle_event(self, event: DomainEvent) -> None:
+    async def handle_event(self, event: SessionEvent) -> None:
         """Async EventBus subscriber — prints one line per significant event."""
         self._apply_event(event)
 
@@ -207,10 +207,10 @@ class ConsoleLog:
     # Internal: map domain event → printed line
     # ------------------------------------------------------------------
 
-    def _apply_event(self, event: DomainEvent) -> None:
+    def _apply_event(self, event: SessionEvent) -> None:
         ts = datetime.now(UTC).strftime("%H:%M:%S")
         kind = event.kind
-        job_id = event.job_id
+        job_id = event.session_id
         if not job_id:
             return
 
@@ -231,7 +231,7 @@ class ConsoleLog:
                 DomainEventKind.job_completed: "completed",
                 DomainEventKind.job_failed: "failed",
                 DomainEventKind.job_canceled: "canceled",
-            }[kind]
+            }[DomainEventKind(kind)]
             job = self._jobs.get(job_id)
             elapsed = f"  ({job.elapsed()})" if job else ""
             title = f'  "{job.title}"' if job and job.title else ""

--- a/backend/console_dashboard.py
+++ b/backend/console_dashboard.py
@@ -36,7 +36,7 @@ from typing import TYPE_CHECKING
 from rich.console import Console
 from rich.text import Text
 
-from backend.models.events import DomainEventKind
+from backend.models.events import CPEventKind
 
 if TYPE_CHECKING:
     from backend.models.events import SessionEvent
@@ -214,24 +214,24 @@ class ConsoleLog:
         if not job_id:
             return
 
-        if kind == DomainEventKind.job_created:
+        if kind == CPEventKind.job_created:
             self._jobs[job_id] = _JobInfo(job_id)
 
-        elif kind == DomainEventKind.job_state_changed:
+        elif kind == CPEventKind.job_state_changed:
             new_state = str(event.payload.get("new_state", ""))
             if job_id not in self._jobs:
                 self._jobs[job_id] = _JobInfo(job_id)
 
         elif kind in (
-            DomainEventKind.job_completed,
-            DomainEventKind.job_failed,
-            DomainEventKind.job_canceled,
+            CPEventKind.job_completed,
+            CPEventKind.job_failed,
+            CPEventKind.job_canceled,
         ):
             new_state = {
-                DomainEventKind.job_completed: "completed",
-                DomainEventKind.job_failed: "failed",
-                DomainEventKind.job_canceled: "canceled",
-            }[DomainEventKind(kind)]
+                CPEventKind.job_completed: "completed",
+                CPEventKind.job_failed: "failed",
+                CPEventKind.job_canceled: "canceled",
+            }[CPEventKind(kind)]
             job = self._jobs.get(job_id)
             elapsed = f"  ({job.elapsed()})" if job else ""
             title = f'  "{job.title}"' if job and job.title else ""
@@ -239,16 +239,16 @@ class ConsoleLog:
             self._print_event(ts, icon, new_state, job_id, new_state + elapsed + title)
             self._jobs.pop(job_id, None)
 
-        elif kind == DomainEventKind.job_title_updated:
+        elif kind == CPEventKind.job_title_updated:
             updated_title: str | None = str(event.payload.get("title")) if event.payload.get("title") else None
             if updated_title and job_id in self._jobs:
                 self._jobs[job_id].title = updated_title
 
-        elif kind == DomainEventKind.progress_headline:
+        elif kind == CPEventKind.progress_headline:
             # Shown in the UI kanban board; suppress from terminal.
             pass
 
-        elif kind == DomainEventKind.approval_requested:
+        elif kind == CPEventKind.approval_requested:
             desc = str(event.payload.get("description") or "approval needed")
             self._print_event(ts, "⏸", "waiting_for_approval", job_id, f"approval needed · {desc}")
 

--- a/backend/lifespan.py
+++ b/backend/lifespan.py
@@ -22,7 +22,7 @@ from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from backend.config import MCP_PATH, VOICE_MAX_AUDIO_SIZE_MB, CPLConfig, get_codeplane_dir, load_config
 from backend.di import AppProvider, CachedModelsBySdk, RequestProvider, VoiceMaxBytes
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, EventMetadata, SessionEvent, new_event
 from backend.persistence.database import create_engine, create_session_factory, serialized_write
 from backend.persistence.event_repo import EventRepository
 from backend.persistence.step_repo import StepRepository
@@ -294,11 +294,11 @@ def _init_event_infrastructure(
     """
     event_bus = EventBus()
     sse_manager = SSEManager()
-    dead_letter: asyncio.Queue[tuple[DomainEvent, int]] = asyncio.Queue()
+    dead_letter: asyncio.Queue[tuple[SessionEvent, int]] = asyncio.Queue()
 
-    # Persist-then-broadcast subscriber: ensures event.db_id is set
-    # (monotonic autoincrement) before SSE frames are built.
-    async def _persist_and_broadcast(event: DomainEvent) -> None:
+    # Persist-then-broadcast subscriber: stamps the autoincrement DB id onto
+    # metadata.sequence (the SSE resume cursor) before SSE frames are built.
+    async def _persist_and_broadcast(event: SessionEvent) -> None:
         # agent_delta events are ephemeral streaming chunks — broadcast
         # immediately without writing to DB (the complete agent message
         # that follows is the canonical persisted record).
@@ -308,28 +308,33 @@ def _init_event_infrastructure(
 
         # System-level events (no job association) cannot be persisted to the
         # events table (job_id FK constraint). Broadcast only.
-        if event.job_id is None:
+        if not event.session_id:
             await sse_manager.broadcast_domain_event(event)
             return
 
         try:
-            await _persist_event_with_retry(
+            db_id = await _persist_event_with_retry(
                 event=event,
                 session_factory=session_factory,
             )
         except OperationalError:
             log.error(
                 "event_persist_failed_queued_for_retry",
-                event_id=event.event_id,
-                job_id=event.job_id,
-                kind=event.kind.value,
+                event_id=event.id,
+                job_id=event.session_id,
+                kind=str(event.kind),
             )
             dead_letter.put_nowait((event, 0))
             # Broadcast anyway so the SSE stream doesn't silently drop the
-            # event; the client will get it without a db_id which means the
+            # event; the client will get it without a sequence which means the
             # replay cursor won't cover it, but it's better than silence.
             await sse_manager.broadcast_domain_event(event)
             return
+        # Stamp the SSE resume cursor (autoincrement id) onto metadata.sequence
+        # before broadcasting so clients receive a monotonic Last-Event-ID.
+        if db_id is not None:
+            metadata = event.metadata or EventMetadata()
+            event = event.model_copy(update={"metadata": metadata.model_copy(update={"sequence": db_id})})
         await sse_manager.broadcast_domain_event(event)
 
     async def _dead_letter_retry_loop() -> None:
@@ -349,8 +354,8 @@ def _init_event_infrastructure(
                 )
                 log.info(
                     "dead_letter_event_persisted",
-                    event_id=event.event_id,
-                    job_id=event.job_id,
+                    event_id=event.id,
+                    job_id=event.session_id,
                     retry_attempt=attempt + 1,
                 )
             except OperationalError:
@@ -359,16 +364,16 @@ def _init_event_infrastructure(
                     dead_letter.put_nowait((event, next_attempt))
                     log.warning(
                         "dead_letter_retry_failed",
-                        event_id=event.event_id,
-                        job_id=event.job_id,
+                        event_id=event.id,
+                        job_id=event.session_id,
                         attempt=next_attempt,
                     )
                 else:
                     log.error(
                         "dead_letter_event_permanently_lost",
-                        event_id=event.event_id,
-                        job_id=event.job_id,
-                        kind=event.kind.value,
+                        event_id=event.id,
+                        job_id=event.session_id,
+                        kind=str(event.kind),
                     )
 
     event_bus.subscribe(_persist_and_broadcast)
@@ -388,27 +393,28 @@ def _is_sqlite_lock_error(exc: OperationalError) -> bool:
 
 async def _persist_event_with_retry(
     *,
-    event: DomainEvent,
+    event: SessionEvent,
     session_factory: async_sessionmaker[AsyncSession],
     max_attempts: int = _EVENT_PERSIST_MAX_ATTEMPTS,
     retry_delay_s: float = _EVENT_PERSIST_RETRY_DELAY_S,
-) -> None:
+) -> int | None:
+    """Persist *event*, returning its autoincrement DB id (the SSE resume cursor)."""
     for attempt in range(max_attempts):
         try:
             async with serialized_write(session_factory) as session:
                 repo = EventRepository(session)
-                await repo.append(event)
-            return
+                return await repo.append(event)
         except OperationalError as exc:
             if not _is_sqlite_lock_error(exc) or attempt == max_attempts - 1:
                 raise
             log.warning(
                 "event_persist_retrying_after_sqlite_lock",
-                event_id=event.event_id,
-                job_id=event.job_id,
+                event_id=event.id,
+                job_id=event.session_id,
                 attempt=attempt + 1,
             )
             await asyncio.sleep(retry_delay_s * (attempt + 1))
+    return None
 
 
 async def _wire_core_services(
@@ -755,30 +761,30 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         vapid_public_key=vapid_keys["public_key"],
     )
 
-    async def _push_subscriber(event: DomainEvent) -> None:
+    async def _push_subscriber(event: SessionEvent) -> None:
         """Send push notifications for approval requests and terminal job states."""
         if event.kind == DomainEventKind.approval_requested:
             desc = event.payload.get("description", "Action requires your approval")
             await push_service.notify(
                 title="Approval needed",
                 body=str(desc),
-                tag=f"approval-{event.payload.get('approval_id', event.job_id)}",
-                url=f"/jobs/{event.job_id}",
+                tag=f"approval-{event.payload.get('approval_id', event.session_id)}",
+                url=f"/jobs/{event.session_id}",
             )
         elif event.kind == DomainEventKind.job_completed:
             await push_service.notify(
                 title="Job completed",
                 body=str(event.payload.get("resolution", "done")),
-                tag=f"job-{event.job_id}",
-                url=f"/jobs/{event.job_id}",
+                tag=f"job-{event.session_id}",
+                url=f"/jobs/{event.session_id}",
             )
         elif event.kind == DomainEventKind.job_failed:
             reason = event.payload.get("reason", "unknown error")
             await push_service.notify(
                 title="Job failed",
                 body=str(reason),
-                tag=f"job-{event.job_id}",
-                url=f"/jobs/{event.job_id}",
+                tag=f"job-{event.session_id}",
+                url=f"/jobs/{event.session_id}",
             )
 
     event_bus.subscribe(_push_subscriber)
@@ -873,7 +879,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         )
 
     # Structural health subscriber — emits warnings at step boundaries (§7.2)
-    async def _structural_health_on_step(event: DomainEvent) -> None:
+    async def _structural_health_on_step(event: SessionEvent) -> None:
         if event.kind != DomainEventKind.step_completed:
             return
         if not coderecon_service.available:
@@ -881,7 +887,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         worktree_path = str(event.payload.get("worktree_path", ""))
         if not worktree_path:
             return
-        job_id = event.job_id
+        job_id = event.session_id
         if not job_id:
             return
         raw_files = event.payload.get("files_written", [])
@@ -909,9 +915,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
                 warnings = await coderecon_service.check_step_structural_health(repo_name, worktree=worktree_path)
                 for w in warnings:
                     await event_bus.publish(
-                        DomainEvent(
-                            event_id=DomainEvent.make_event_id(),
-                            job_id=job_id,
+                        new_event(
+                            session_id=job_id,
                             timestamp=datetime.now(UTC),
                             kind=DomainEventKind.structural_warning,
                             payload=w,
@@ -927,12 +932,12 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     # Review story prefetch subscriber — pre-generates and caches review story
     # when a job enters review state so the frontend load is instant.
-    async def _prefetch_review_story(event: DomainEvent) -> None:
+    async def _prefetch_review_story(event: SessionEvent) -> None:
         if event.kind != DomainEventKind.job_review:
             return
         if not coderecon_service.available:
             return
-        job_id = event.job_id
+        job_id = event.session_id
         if not job_id:
             return
 
@@ -972,7 +977,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     event_bus.subscribe(_prefetch_review_story)
 
     # --- §11.11 Persist review story as approval artifact on merge ---
-    async def _persist_review_story_on_resolve(event: DomainEvent) -> None:
+    async def _persist_review_story_on_resolve(event: SessionEvent) -> None:
         if event.kind != DomainEventKind.job_resolved:
             return
         resolution = event.payload.get("resolution")
@@ -980,7 +985,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             return
         if not coderecon_service.available:
             return
-        job_id = event.job_id
+        job_id = event.session_id
         if not job_id:
             return
 
@@ -1021,7 +1026,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     event_bus.subscribe(_persist_review_story_on_resolve)
 
     # --- §7.5 Post-resolution structural analytics ---
-    async def _persist_structural_analytics(event: DomainEvent) -> None:
+    async def _persist_structural_analytics(event: SessionEvent) -> None:
         if event.kind != DomainEventKind.job_resolved:
             return
         resolution = event.payload.get("resolution")
@@ -1029,7 +1034,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             return
         if not coderecon_service.available:
             return
-        job_id = event.job_id
+        job_id = event.session_id
         if not job_id:
             return
 

--- a/backend/lifespan.py
+++ b/backend/lifespan.py
@@ -22,7 +22,7 @@ from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from backend.config import MCP_PATH, VOICE_MAX_AUDIO_SIZE_MB, CPLConfig, get_codeplane_dir, load_config
 from backend.di import AppProvider, CachedModelsBySdk, RequestProvider, VoiceMaxBytes
-from backend.models.events import CPEventKind, EventMetadata, SessionEvent, new_event
+from backend.models.events import EventKind, EventMetadata, SessionEvent, new_event
 from backend.persistence.database import create_engine, create_session_factory, serialized_write
 from backend.persistence.event_repo import EventRepository
 from backend.persistence.step_repo import StepRepository
@@ -302,7 +302,7 @@ def _init_event_infrastructure(
         # agent_delta events are ephemeral streaming chunks — broadcast
         # immediately without writing to DB (the complete agent message
         # that follows is the canonical persisted record).
-        if event.kind == CPEventKind.message_delta and event.payload.get("role") == "agent_delta":
+        if event.kind == EventKind.message_delta and event.payload.get("role") == "agent_delta":
             await sse_manager.broadcast_domain_event(event)
             return
 
@@ -763,7 +763,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     async def _push_subscriber(event: SessionEvent) -> None:
         """Send push notifications for approval requests and terminal job states."""
-        if event.kind == CPEventKind.approval_requested:
+        if event.kind == EventKind.approval_requested:
             desc = event.payload.get("description", "Action requires your approval")
             await push_service.notify(
                 title="Approval needed",
@@ -771,14 +771,14 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
                 tag=f"approval-{event.payload.get('approval_id', event.session_id)}",
                 url=f"/jobs/{event.session_id}",
             )
-        elif event.kind == CPEventKind.job_completed:
+        elif event.kind == EventKind.job_completed:
             await push_service.notify(
                 title="Job completed",
                 body=str(event.payload.get("resolution", "done")),
                 tag=f"job-{event.session_id}",
                 url=f"/jobs/{event.session_id}",
             )
-        elif event.kind == CPEventKind.job_failed:
+        elif event.kind == EventKind.job_failed:
             reason = event.payload.get("reason", "unknown error")
             await push_service.notify(
                 title="Job failed",
@@ -880,7 +880,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     # Structural health subscriber — emits warnings at step boundaries (§7.2)
     async def _structural_health_on_step(event: SessionEvent) -> None:
-        if event.kind != CPEventKind.step_completed:
+        if event.kind != EventKind.step_completed:
             return
         if not coderecon_service.available:
             return
@@ -918,7 +918,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
                         new_event(
                             session_id=job_id,
                             timestamp=datetime.now(UTC),
-                            kind=CPEventKind.structural_warning,
+                            kind=EventKind.structural_warning,
                             payload=w,
                         )
                     )
@@ -933,7 +933,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # Review story prefetch subscriber — pre-generates and caches review story
     # when a job enters review state so the frontend load is instant.
     async def _prefetch_review_story(event: SessionEvent) -> None:
-        if event.kind != CPEventKind.job_review:
+        if event.kind != EventKind.job_review:
             return
         if not coderecon_service.available:
             return
@@ -978,7 +978,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     # --- §11.11 Persist review story as approval artifact on merge ---
     async def _persist_review_story_on_resolve(event: SessionEvent) -> None:
-        if event.kind != CPEventKind.job_resolved:
+        if event.kind != EventKind.job_resolved:
             return
         resolution = event.payload.get("resolution")
         if resolution not in ("merged", "pr_created", "smart_merged"):
@@ -1027,7 +1027,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     # --- §7.5 Post-resolution structural analytics ---
     async def _persist_structural_analytics(event: SessionEvent) -> None:
-        if event.kind != CPEventKind.job_resolved:
+        if event.kind != EventKind.job_resolved:
             return
         resolution = event.payload.get("resolution")
         if resolution not in ("merged", "pr_created", "smart_merged"):

--- a/backend/lifespan.py
+++ b/backend/lifespan.py
@@ -22,7 +22,7 @@ from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from backend.config import MCP_PATH, VOICE_MAX_AUDIO_SIZE_MB, CPLConfig, get_codeplane_dir, load_config
 from backend.di import AppProvider, CachedModelsBySdk, RequestProvider, VoiceMaxBytes
-from backend.models.events import DomainEventKind, EventMetadata, SessionEvent, new_event
+from backend.models.events import CPEventKind, EventMetadata, SessionEvent, new_event
 from backend.persistence.database import create_engine, create_session_factory, serialized_write
 from backend.persistence.event_repo import EventRepository
 from backend.persistence.step_repo import StepRepository
@@ -302,7 +302,7 @@ def _init_event_infrastructure(
         # agent_delta events are ephemeral streaming chunks — broadcast
         # immediately without writing to DB (the complete agent message
         # that follows is the canonical persisted record).
-        if event.kind == DomainEventKind.transcript_updated and event.payload.get("role") == "agent_delta":
+        if event.kind == CPEventKind.message_delta and event.payload.get("role") == "agent_delta":
             await sse_manager.broadcast_domain_event(event)
             return
 
@@ -763,7 +763,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     async def _push_subscriber(event: SessionEvent) -> None:
         """Send push notifications for approval requests and terminal job states."""
-        if event.kind == DomainEventKind.approval_requested:
+        if event.kind == CPEventKind.approval_requested:
             desc = event.payload.get("description", "Action requires your approval")
             await push_service.notify(
                 title="Approval needed",
@@ -771,14 +771,14 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
                 tag=f"approval-{event.payload.get('approval_id', event.session_id)}",
                 url=f"/jobs/{event.session_id}",
             )
-        elif event.kind == DomainEventKind.job_completed:
+        elif event.kind == CPEventKind.job_completed:
             await push_service.notify(
                 title="Job completed",
                 body=str(event.payload.get("resolution", "done")),
                 tag=f"job-{event.session_id}",
                 url=f"/jobs/{event.session_id}",
             )
-        elif event.kind == DomainEventKind.job_failed:
+        elif event.kind == CPEventKind.job_failed:
             reason = event.payload.get("reason", "unknown error")
             await push_service.notify(
                 title="Job failed",
@@ -880,7 +880,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     # Structural health subscriber — emits warnings at step boundaries (§7.2)
     async def _structural_health_on_step(event: SessionEvent) -> None:
-        if event.kind != DomainEventKind.step_completed:
+        if event.kind != CPEventKind.step_completed:
             return
         if not coderecon_service.available:
             return
@@ -918,7 +918,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
                         new_event(
                             session_id=job_id,
                             timestamp=datetime.now(UTC),
-                            kind=DomainEventKind.structural_warning,
+                            kind=CPEventKind.structural_warning,
                             payload=w,
                         )
                     )
@@ -933,7 +933,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # Review story prefetch subscriber — pre-generates and caches review story
     # when a job enters review state so the frontend load is instant.
     async def _prefetch_review_story(event: SessionEvent) -> None:
-        if event.kind != DomainEventKind.job_review:
+        if event.kind != CPEventKind.job_review:
             return
         if not coderecon_service.available:
             return
@@ -978,7 +978,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     # --- §11.11 Persist review story as approval artifact on merge ---
     async def _persist_review_story_on_resolve(event: SessionEvent) -> None:
-        if event.kind != DomainEventKind.job_resolved:
+        if event.kind != CPEventKind.job_resolved:
             return
         resolution = event.payload.get("resolution")
         if resolution not in ("merged", "pr_created", "smart_merged"):
@@ -1027,7 +1027,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     # --- §7.5 Post-resolution structural analytics ---
     async def _persist_structural_analytics(event: SessionEvent) -> None:
-        if event.kind != DomainEventKind.job_resolved:
+        if event.kind != CPEventKind.job_resolved:
             return
         resolution = event.payload.get("resolution")
         if resolution not in ("merged", "pr_created", "smart_merged"):

--- a/backend/models/events.py
+++ b/backend/models/events.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "TRANSCRIPT_KINDS",
-    "CPEventKind",
+    "EventKind",
     "EventMetadata",
     "EventPayload",
     "SessionEvent",
@@ -28,7 +28,7 @@ __all__ = [
 ]
 
 
-class CPEventKind(StrEnum):
+class EventKind(StrEnum):
     """CodePlane control-plane event kinds as open dotted TraceForge kinds.
 
     These are CodePlane's own kinds expressed in TraceForge's open dotted-string
@@ -113,18 +113,18 @@ class CPEventKind(StrEnum):
 # dotted kind. Role is retained in ``payload["role"]`` so consumers that branch
 # on role continue to work; kind-level "is this a transcript event" checks use
 # this set.
-TRANSCRIPT_KINDS: frozenset[CPEventKind] = frozenset(
+TRANSCRIPT_KINDS: frozenset[EventKind] = frozenset(
     {
-        CPEventKind.message_user,
-        CPEventKind.message_assistant,
-        CPEventKind.message_delta,
-        CPEventKind.tool_call_started,
-        CPEventKind.tool_call_completed,
+        EventKind.message_user,
+        EventKind.message_assistant,
+        EventKind.message_delta,
+        EventKind.tool_call_started,
+        EventKind.tool_call_completed,
     }
 )
 
 
-def transcript_kind_for_role(role: str) -> CPEventKind:
+def transcript_kind_for_role(role: str) -> EventKind:
     """Map a transcript ``role`` to its dotted CodePlane event kind.
 
     Roles emitted by the adapters/watchers: ``operator``/``user`` (human input),
@@ -132,17 +132,17 @@ def transcript_kind_for_role(role: str) -> CPEventKind:
     partial), ``tool_running`` (a tool began), ``tool_call`` (a tool completed).
     """
     if role in ("operator", "user"):
-        return CPEventKind.message_user
+        return EventKind.message_user
     if role in ("agent", "assistant"):
-        return CPEventKind.message_assistant
+        return EventKind.message_assistant
     if role == "agent_delta":
-        return CPEventKind.message_delta
+        return EventKind.message_delta
     if role == "tool_running":
-        return CPEventKind.tool_call_started
+        return EventKind.tool_call_started
     if role == "tool_call":
-        return CPEventKind.tool_call_completed
+        return EventKind.tool_call_completed
     # Unknown roles default to a full assistant message (safest for display).
-    return CPEventKind.message_assistant
+    return EventKind.message_assistant
 
 
 # ---------------------------------------------------------------------------
@@ -421,7 +421,7 @@ EventPayload = (
 
 def new_event(
     session_id: str | None,
-    kind: CPEventKind | str,
+    kind: EventKind | str,
     payload: EventPayload | dict[str, Any],
     *,
     timestamp: datetime | None = None,

--- a/backend/models/events.py
+++ b/backend/models/events.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-import uuid
-from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, TypedDict
+
+from traceforge.types import EventMetadata, SessionEvent
 
 if TYPE_CHECKING:
     from backend.models.api_schemas import ExecutionPhase
@@ -16,6 +16,14 @@ if TYPE_CHECKING:
         JobState,
         Resolution,
     )
+
+__all__ = [
+    "DomainEventKind",
+    "EventMetadata",
+    "EventPayload",
+    "SessionEvent",
+    "new_event",
+]
 
 
 class DomainEventKind(StrEnum):
@@ -351,32 +359,35 @@ EventPayload = (
 )
 
 
-@dataclass
-class DomainEvent:
-    event_id: str
-    job_id: str | None
-    timestamp: datetime
-    kind: DomainEventKind
-    payload: EventPayload
-    db_id: int | None = None  # autoincrement ID from EventRow; set after persistence
+def new_event(
+    session_id: str | None,
+    kind: DomainEventKind | str,
+    payload: EventPayload | dict[str, Any],
+    *,
+    timestamp: datetime | None = None,
+    metadata: EventMetadata | None = None,
+    sequence: int | None = None,
+    event_id: str | None = None,
+) -> SessionEvent:
+    """Construct a canonical ``traceforge.SessionEvent`` for a CodePlane job.
 
-    @staticmethod
-    def make_event_id() -> str:
-        """Generate a unique event ID."""
-        return f"evt-{uuid.uuid4().hex[:12]}"
-
-    @classmethod
-    def for_job(
-        cls,
-        job_id: str,
-        kind: DomainEventKind,
-        payload: EventPayload,
-    ) -> DomainEvent:
-        """Convenience factory that fills ``event_id`` and ``timestamp`` automatically."""
-        return cls(
-            event_id=cls.make_event_id(),
-            job_id=job_id,
-            timestamp=datetime.now(UTC),
-            kind=kind,
-            payload=payload,
-        )
+    Single construction point that replaces the retired ``DomainEvent`` dataclass.
+    ``session_id`` carries the CodePlane job id (``""`` for job-less/global events).
+    The persisted autoincrement id (the SSE resume cursor, formerly ``DomainEvent.db_id``)
+    rides on ``metadata.sequence``. ``timestamp`` and event ``id`` are auto-filled when
+    omitted, matching the old ``DomainEvent.for_job`` convenience.
+    """
+    if metadata is None:
+        metadata = EventMetadata(sequence=sequence)
+    elif sequence is not None:
+        metadata = metadata.model_copy(update={"sequence": sequence})
+    fields: dict[str, Any] = {
+        "kind": str(kind),
+        "session_id": session_id or "",
+        "timestamp": timestamp if timestamp is not None else datetime.now(UTC),
+        "payload": dict(payload),
+        "metadata": metadata,
+    }
+    if event_id is not None:
+        fields["id"] = event_id
+    return SessionEvent(**fields)

--- a/backend/models/events.py
+++ b/backend/models/events.py
@@ -18,71 +18,131 @@ if TYPE_CHECKING:
     )
 
 __all__ = [
-    "DomainEventKind",
+    "TRANSCRIPT_KINDS",
+    "CPEventKind",
     "EventMetadata",
     "EventPayload",
     "SessionEvent",
     "new_event",
+    "transcript_kind_for_role",
 ]
 
 
-class DomainEventKind(StrEnum):
-    job_created = "JobCreated"
-    job_setup_progress = "JobSetupProgress"
-    workspace_prepared = "WorkspacePrepared"
-    agent_session_started = "AgentSessionStarted"
-    log_line_emitted = "LogLineEmitted"
-    transcript_updated = "TranscriptUpdated"
-    diff_updated = "DiffUpdated"
-    approval_requested = "ApprovalRequested"
-    approval_resolved = "ApprovalResolved"
-    batch_approval_requested = "BatchApprovalRequested"
-    batch_approval_resolved = "BatchApprovalResolved"
-    job_review = "JobReview"
-    job_completed = "JobCompleted"
-    job_failed = "JobFailed"
-    job_canceled = "JobCanceled"
-    job_state_changed = "JobStateChanged"
-    session_heartbeat = "SessionHeartbeat"
-    merge_completed = "MergeCompleted"
-    merge_conflict = "MergeConflict"
-    session_resumed = "SessionResumed"
-    job_resolved = "JobResolved"
-    job_archived = "JobArchived"
-    job_title_updated = "JobTitleUpdated"
-    progress_headline = "ProgressHeadline"
-    model_downgraded = "ModelDowngraded"
-    tool_group_summary = "ToolGroupSummary"
-    agent_plan_updated = "AgentPlanUpdated"
-    execution_phase_changed = "ExecutionPhaseChanged"
-    telemetry_updated = "TelemetryUpdated"
-    step_started = "StepStarted"
-    step_completed = "StepCompleted"
-    step_title_generated = "StepTitleGenerated"
-    step_group_updated = "StepGroupUpdated"
-    plan_step_updated = "PlanStepUpdated"
-    step_entries_reassigned = "StepEntriesReassigned"
-    turn_summary = "TurnSummary"
-    action_classified = "ActionClassified"
-    policy_settings_changed = "PolicySettingsChanged"
-    repo_index_progress = "RepoIndexProgress"
-    repo_index_complete = "RepoIndexComplete"
-    structural_warning = "StructuralWarning"
-    stall_detected = "StallDetected"
-    monitor_approved = "MonitorApproved"
-    monitor_rejected = "MonitorRejected"
-    monitor_escalated = "MonitorEscalated"
-    sidecar_transcript = "SidecarTranscript"
-    sidecar_agent_message = "SidecarAgentMessage"
-    sidecar_gate_verdict = "SidecarGateVerdict"
-    sidecar_metadata_update = "SidecarMetadataUpdate"
-    # Unified secondary session events (preflight, sidecars, monitors)
-    secondary_session_started = "SecondarySessionStarted"
-    secondary_session_entry = "SecondarySessionEntry"
-    secondary_session_completed = "SecondarySessionCompleted"
-    # Context handoff — emitted when context crosses a session boundary
-    context_handoff = "ContextHandoff"
-    job_mode_changed = "JobModeChanged"
+class CPEventKind(StrEnum):
+    """CodePlane control-plane event kinds as open dotted TraceForge kinds.
+
+    These are CodePlane's own kinds expressed in TraceForge's open dotted-string
+    ``kind`` grammar. ``traceforge.SessionEvent.kind`` is a free-form string; this
+    enum is just symbol-safe named constants for the kinds CodePlane emits — not a
+    translation layer. The wire/persistence carry these dotted values verbatim.
+    """
+
+    # --- Job lifecycle ---
+    job_created = "job.created"
+    job_setup_progress = "job.setup_progress"
+    workspace_prepared = "workspace.prepared"
+    agent_session_started = "agent.session_started"
+    # --- Transcript family (one CP transcript event per agent role) ---
+    message_user = "message.user"
+    message_assistant = "message.assistant"
+    message_delta = "message.delta"
+    tool_call_started = "tool.call.started"
+    tool_call_completed = "tool.call.completed"
+    # --- Logs / diffs ---
+    log_line_emitted = "log"
+    diff_updated = "diff.updated"
+    # --- Approvals (permissions) ---
+    approval_requested = "permission.requested"
+    approval_resolved = "permission.resolved"
+    batch_approval_requested = "permission.batch.requested"
+    batch_approval_resolved = "permission.batch.resolved"
+    # --- Job state / outcomes ---
+    job_review = "job.review"
+    job_completed = "job.completed"
+    job_failed = "job.failed"
+    job_canceled = "job.canceled"
+    job_state_changed = "job.state_changed"
+    session_heartbeat = "session.heartbeat"
+    merge_completed = "merge.completed"
+    merge_conflict = "merge.conflict"
+    session_resumed = "session.resumed"
+    job_resolved = "job.resolved"
+    job_archived = "job.archived"
+    job_title_updated = "job.title_updated"
+    progress_headline = "progress.headline"
+    model_downgraded = "model.downgraded"
+    tool_group_summary = "tool.group_summary"
+    agent_plan_updated = "plan.updated"
+    execution_phase_changed = "execution.phase_changed"
+    telemetry_updated = "telemetry.updated"
+    # --- Steps / plan ---
+    step_started = "step.started"
+    step_completed = "step.completed"
+    step_title_generated = "step.title_generated"
+    step_group_updated = "step.group_updated"
+    plan_step_updated = "plan.step_updated"
+    step_entries_reassigned = "step.entries_reassigned"
+    turn_summary = "turn.summary"
+    action_classified = "action.classified"
+    policy_settings_changed = "policy.settings_changed"
+    # --- Repo index ---
+    repo_index_progress = "repo.index_progress"
+    repo_index_complete = "repo.index_complete"
+    # --- Structural health ---
+    structural_warning = "structural.warning"
+    stall_detected = "stall.detected"
+    # --- Monitors ---
+    monitor_approved = "monitor.approved"
+    monitor_rejected = "monitor.rejected"
+    monitor_escalated = "monitor.escalated"
+    # --- Sidecars ---
+    sidecar_transcript = "sidecar.transcript"
+    sidecar_agent_message = "sidecar.agent_message"
+    sidecar_gate_verdict = "sidecar.gate_verdict"
+    sidecar_metadata_update = "sidecar.metadata_update"
+    # --- Unified secondary session events (preflight, sidecars, monitors) ---
+    secondary_session_started = "secondary_session.started"
+    secondary_session_entry = "secondary_session.entry"
+    secondary_session_completed = "secondary_session.completed"
+    # --- Context handoff — emitted when context crosses a session boundary ---
+    context_handoff = "context.handoff"
+    job_mode_changed = "job.mode_changed"
+
+
+# The transcript family: one CP "transcript" event fans out to a role-specific
+# dotted kind. Role is retained in ``payload["role"]`` so consumers that branch
+# on role continue to work; kind-level "is this a transcript event" checks use
+# this set.
+TRANSCRIPT_KINDS: frozenset[CPEventKind] = frozenset(
+    {
+        CPEventKind.message_user,
+        CPEventKind.message_assistant,
+        CPEventKind.message_delta,
+        CPEventKind.tool_call_started,
+        CPEventKind.tool_call_completed,
+    }
+)
+
+
+def transcript_kind_for_role(role: str) -> CPEventKind:
+    """Map a transcript ``role`` to its dotted CodePlane event kind.
+
+    Roles emitted by the adapters/watchers: ``operator``/``user`` (human input),
+    ``agent``/``assistant`` (complete agent message), ``agent_delta`` (streaming
+    partial), ``tool_running`` (a tool began), ``tool_call`` (a tool completed).
+    """
+    if role in ("operator", "user"):
+        return CPEventKind.message_user
+    if role in ("agent", "assistant"):
+        return CPEventKind.message_assistant
+    if role == "agent_delta":
+        return CPEventKind.message_delta
+    if role == "tool_running":
+        return CPEventKind.tool_call_started
+    if role == "tool_call":
+        return CPEventKind.tool_call_completed
+    # Unknown roles default to a full assistant message (safest for display).
+    return CPEventKind.message_assistant
 
 
 # ---------------------------------------------------------------------------
@@ -361,7 +421,7 @@ EventPayload = (
 
 def new_event(
     session_id: str | None,
-    kind: DomainEventKind | str,
+    kind: CPEventKind | str,
     payload: EventPayload | dict[str, Any],
     *,
     timestamp: datetime | None = None,

--- a/backend/persistence/event_repo.py
+++ b/backend/persistence/event_repo.py
@@ -7,7 +7,7 @@ import json
 from sqlalchemy import func, select
 
 from backend.models.db import EventRow
-from backend.models.events import DomainEventKind, SessionEvent, new_event
+from backend.models.events import TRANSCRIPT_KINDS, CPEventKind, SessionEvent, new_event
 from backend.persistence.repository import BaseRepository
 
 
@@ -22,7 +22,7 @@ class EventRepository(BaseRepository):
             event_id=row.event_id,
             session_id=row.job_id,
             timestamp=row.timestamp,
-            kind=DomainEventKind(row.kind),
+            kind=CPEventKind(row.kind),
             payload=json.loads(row.payload),
             sequence=row.id,
         )
@@ -57,7 +57,7 @@ class EventRepository(BaseRepository):
     async def list_by_job(
         self,
         job_id: str,
-        kinds: list[DomainEventKind],
+        kinds: list[CPEventKind],
         limit: int = 2000,
     ) -> list[SessionEvent]:
         """List events for a job filtered by kind, ordered by db id."""
@@ -74,7 +74,7 @@ class EventRepository(BaseRepository):
     async def list_all_by_job(
         self,
         job_id: str,
-        kinds: list[DomainEventKind],
+        kinds: list[CPEventKind],
     ) -> list[SessionEvent]:
         """List all events for a job filtered by kind, without an upper bound."""
         stmt = (
@@ -102,7 +102,7 @@ class EventRepository(BaseRepository):
                 func.max(EventRow.id).label("latest_id"),
             )
             .where(EventRow.job_id.in_(job_ids))
-            .where(EventRow.kind == DomainEventKind.progress_headline.value)
+            .where(EventRow.kind == CPEventKind.progress_headline.value)
             .group_by(EventRow.job_id)
             .subquery()
         )
@@ -133,7 +133,7 @@ class EventRepository(BaseRepository):
 
         stmt = select(EventRow).where(
             EventRow.job_id == job_id,
-            EventRow.kind == DomainEventKind.transcript_updated.value,
+            EventRow.kind.in_([k.value for k in TRANSCRIPT_KINDS]),
         )
         if roles:
             role_conditions = [EventRow.payload.contains(f'"role": "{role}"') for role in roles]

--- a/backend/persistence/event_repo.py
+++ b/backend/persistence/event_repo.py
@@ -7,7 +7,7 @@ import json
 from sqlalchemy import func, select
 
 from backend.models.db import EventRow
-from backend.models.events import TRANSCRIPT_KINDS, CPEventKind, SessionEvent, new_event
+from backend.models.events import TRANSCRIPT_KINDS, EventKind, SessionEvent, new_event
 from backend.persistence.repository import BaseRepository
 
 
@@ -22,7 +22,7 @@ class EventRepository(BaseRepository):
             event_id=row.event_id,
             session_id=row.job_id,
             timestamp=row.timestamp,
-            kind=CPEventKind(row.kind),
+            kind=EventKind(row.kind),
             payload=json.loads(row.payload),
             sequence=row.id,
         )
@@ -57,7 +57,7 @@ class EventRepository(BaseRepository):
     async def list_by_job(
         self,
         job_id: str,
-        kinds: list[CPEventKind],
+        kinds: list[EventKind],
         limit: int = 2000,
     ) -> list[SessionEvent]:
         """List events for a job filtered by kind, ordered by db id."""
@@ -74,7 +74,7 @@ class EventRepository(BaseRepository):
     async def list_all_by_job(
         self,
         job_id: str,
-        kinds: list[CPEventKind],
+        kinds: list[EventKind],
     ) -> list[SessionEvent]:
         """List all events for a job filtered by kind, without an upper bound."""
         stmt = (
@@ -102,7 +102,7 @@ class EventRepository(BaseRepository):
                 func.max(EventRow.id).label("latest_id"),
             )
             .where(EventRow.job_id.in_(job_ids))
-            .where(EventRow.kind == CPEventKind.progress_headline.value)
+            .where(EventRow.kind == EventKind.progress_headline.value)
             .group_by(EventRow.job_id)
             .subquery()
         )

--- a/backend/persistence/event_repo.py
+++ b/backend/persistence/event_repo.py
@@ -7,7 +7,7 @@ import json
 from sqlalchemy import func, select
 
 from backend.models.db import EventRow
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, SessionEvent, new_event
 from backend.persistence.repository import BaseRepository
 
 
@@ -17,37 +17,35 @@ class EventRepository(BaseRepository):
     TrailNodeRepository projections. See internal-docs/design/unified-trail-service.md §6."""
 
     @staticmethod
-    def _to_domain(row: EventRow) -> DomainEvent:
-        return DomainEvent(
+    def _to_domain(row: EventRow) -> SessionEvent:
+        return new_event(
             event_id=row.event_id,
-            job_id=row.job_id,
+            session_id=row.job_id,
             timestamp=row.timestamp,
             kind=DomainEventKind(row.kind),
             payload=json.loads(row.payload),
-            db_id=row.id,
+            sequence=row.id,
         )
 
-    async def append(self, event: DomainEvent) -> int:
+    async def append(self, event: SessionEvent) -> int:
         """Persist a domain event. Returns the autoincrement DB id."""
         row = EventRow(
-            event_id=event.event_id,
-            job_id=event.job_id,
-            kind=event.kind.value,
+            event_id=event.id,
+            job_id=event.session_id or None,
+            kind=str(event.kind),
             timestamp=event.timestamp,
-            payload=json.dumps(event.payload),
+            payload=json.dumps(dict(event.payload)),
         )
         self._session.add(row)
         await self._session.flush()
-        db_id = row.id
-        event.db_id = db_id
-        return db_id
+        return row.id
 
     async def list_after(
         self,
         after_id: int,
         job_id: str | None = None,
         limit: int = 500,
-    ) -> list[DomainEvent]:
+    ) -> list[SessionEvent]:
         """List events with auto-increment id > after_id, optionally scoped to a job."""
         stmt = select(EventRow).where(EventRow.id > after_id).order_by(EventRow.id)
         if job_id is not None:
@@ -61,7 +59,7 @@ class EventRepository(BaseRepository):
         job_id: str,
         kinds: list[DomainEventKind],
         limit: int = 2000,
-    ) -> list[DomainEvent]:
+    ) -> list[SessionEvent]:
         """List events for a job filtered by kind, ordered by db id."""
         stmt = (
             select(EventRow)
@@ -77,7 +75,7 @@ class EventRepository(BaseRepository):
         self,
         job_id: str,
         kinds: list[DomainEventKind],
-    ) -> list[DomainEvent]:
+    ) -> list[SessionEvent]:
         """List all events for a job filtered by kind, without an upper bound."""
         stmt = (
             select(EventRow)
@@ -129,7 +127,7 @@ class EventRepository(BaseRepository):
         roles: list[str] | None = None,
         step_id: str | None = None,
         limit: int = 50,
-    ) -> list[DomainEvent]:
+    ) -> list[SessionEvent]:
         """Full-text search within a job's transcript events."""
         from sqlalchemy import func, or_
 

--- a/backend/services/action_policy/batcher.py
+++ b/backend/services/action_policy/batcher.py
@@ -190,7 +190,7 @@ class ApprovalBatcher:
 
     async def _on_window_close(self, batch: Batch) -> None:
         """Emit a batch_ready event when the accumulation window closes."""
-        from backend.models.events import CPEventKind, new_event
+        from backend.models.events import EventKind, new_event
 
         if batch.id not in self._batches:
             return  # Already resolved
@@ -200,7 +200,7 @@ class ApprovalBatcher:
             new_event(
                 session_id=batch.job_id,
                 timestamp=datetime.now(UTC),
-                kind=CPEventKind.batch_approval_requested,
+                kind=EventKind.batch_approval_requested,
                 payload={
                     "batch_id": batch.id,
                     "batch_size": len(batch.actions),

--- a/backend/services/action_policy/batcher.py
+++ b/backend/services/action_policy/batcher.py
@@ -190,16 +190,15 @@ class ApprovalBatcher:
 
     async def _on_window_close(self, batch: Batch) -> None:
         """Emit a batch_ready event when the accumulation window closes."""
-        from backend.models.events import DomainEvent, DomainEventKind
+        from backend.models.events import DomainEventKind, new_event
 
         if batch.id not in self._batches:
             return  # Already resolved
 
         summary = self._summarize(batch)
         await self._event_bus.publish(
-            DomainEvent(
-                event_id=DomainEvent.make_event_id(),
-                job_id=batch.job_id,
+            new_event(
+                session_id=batch.job_id,
                 timestamp=datetime.now(UTC),
                 kind=DomainEventKind.batch_approval_requested,
                 payload={

--- a/backend/services/action_policy/batcher.py
+++ b/backend/services/action_policy/batcher.py
@@ -190,7 +190,7 @@ class ApprovalBatcher:
 
     async def _on_window_close(self, batch: Batch) -> None:
         """Emit a batch_ready event when the accumulation window closes."""
-        from backend.models.events import DomainEventKind, new_event
+        from backend.models.events import CPEventKind, new_event
 
         if batch.id not in self._batches:
             return  # Already resolved
@@ -200,7 +200,7 @@ class ApprovalBatcher:
             new_event(
                 session_id=batch.job_id,
                 timestamp=datetime.now(UTC),
-                kind=DomainEventKind.batch_approval_requested,
+                kind=CPEventKind.batch_approval_requested,
                 payload={
                     "batch_id": batch.id,
                     "batch_size": len(batch.actions),

--- a/backend/services/adapters/base_adapter.py
+++ b/backend/services/adapters/base_adapter.py
@@ -227,7 +227,7 @@ class BaseAgentAdapter(AgentAdapterInterface):
         totals: dict[str, float | int] | None = None,
     ) -> None:
         """Publish telemetry_updated if debounce interval has elapsed."""
-        from backend.models.events import DomainEvent, DomainEventKind
+        from backend.models.events import DomainEventKind, new_event
 
         if self._event_bus is None:
             return
@@ -243,12 +243,8 @@ class BaseAgentAdapter(AgentAdapterInterface):
             payload["input_tokens"] = totals.get("input_tokens", 0)
             payload["output_tokens"] = totals.get("output_tokens", 0)
         await self._event_bus.publish(
-            DomainEvent(
-                event_id=DomainEvent.make_event_id(),
-                job_id=job_id,
-                timestamp=datetime.now(UTC),
-                kind=DomainEventKind.telemetry_updated,
-                payload=payload,
+            new_event(
+                session_id=job_id, timestamp=datetime.now(UTC), kind=DomainEventKind.telemetry_updated, payload=payload
             )
         )
 
@@ -465,13 +461,12 @@ class BaseAgentAdapter(AgentAdapterInterface):
         # Emit action_classified event for timeline tier indicators
         tier_str = decision.tier.value if decision.tier else None
         if tier_str and self._event_bus is not None:
-            from backend.models.events import DomainEvent, DomainEventKind
+            from backend.models.events import DomainEventKind, new_event
 
             cls = decision.classification
             await self._event_bus.publish(
-                DomainEvent(
-                    event_id=DomainEvent.make_event_id(),
-                    job_id=job_id,
+                new_event(
+                    session_id=job_id,
                     timestamp=datetime.now(UTC),
                     kind=DomainEventKind.action_classified,
                     payload={

--- a/backend/services/adapters/base_adapter.py
+++ b/backend/services/adapters/base_adapter.py
@@ -227,7 +227,7 @@ class BaseAgentAdapter(AgentAdapterInterface):
         totals: dict[str, float | int] | None = None,
     ) -> None:
         """Publish telemetry_updated if debounce interval has elapsed."""
-        from backend.models.events import CPEventKind, new_event
+        from backend.models.events import EventKind, new_event
 
         if self._event_bus is None:
             return
@@ -244,7 +244,7 @@ class BaseAgentAdapter(AgentAdapterInterface):
             payload["output_tokens"] = totals.get("output_tokens", 0)
         await self._event_bus.publish(
             new_event(
-                session_id=job_id, timestamp=datetime.now(UTC), kind=CPEventKind.telemetry_updated, payload=payload
+                session_id=job_id, timestamp=datetime.now(UTC), kind=EventKind.telemetry_updated, payload=payload
             )
         )
 
@@ -461,14 +461,14 @@ class BaseAgentAdapter(AgentAdapterInterface):
         # Emit action_classified event for timeline tier indicators
         tier_str = decision.tier.value if decision.tier else None
         if tier_str and self._event_bus is not None:
-            from backend.models.events import CPEventKind, new_event
+            from backend.models.events import EventKind, new_event
 
             cls = decision.classification
             await self._event_bus.publish(
                 new_event(
                     session_id=job_id,
                     timestamp=datetime.now(UTC),
-                    kind=CPEventKind.action_classified,
+                    kind=EventKind.action_classified,
                     payload={
                         "tier": tier_str,
                         "tool_name": tool_name or request.kind,

--- a/backend/services/adapters/base_adapter.py
+++ b/backend/services/adapters/base_adapter.py
@@ -227,7 +227,7 @@ class BaseAgentAdapter(AgentAdapterInterface):
         totals: dict[str, float | int] | None = None,
     ) -> None:
         """Publish telemetry_updated if debounce interval has elapsed."""
-        from backend.models.events import DomainEventKind, new_event
+        from backend.models.events import CPEventKind, new_event
 
         if self._event_bus is None:
             return
@@ -244,7 +244,7 @@ class BaseAgentAdapter(AgentAdapterInterface):
             payload["output_tokens"] = totals.get("output_tokens", 0)
         await self._event_bus.publish(
             new_event(
-                session_id=job_id, timestamp=datetime.now(UTC), kind=DomainEventKind.telemetry_updated, payload=payload
+                session_id=job_id, timestamp=datetime.now(UTC), kind=CPEventKind.telemetry_updated, payload=payload
             )
         )
 
@@ -461,14 +461,14 @@ class BaseAgentAdapter(AgentAdapterInterface):
         # Emit action_classified event for timeline tier indicators
         tier_str = decision.tier.value if decision.tier else None
         if tier_str and self._event_bus is not None:
-            from backend.models.events import DomainEventKind, new_event
+            from backend.models.events import CPEventKind, new_event
 
             cls = decision.classification
             await self._event_bus.publish(
                 new_event(
                     session_id=job_id,
                     timestamp=datetime.now(UTC),
-                    kind=DomainEventKind.action_classified,
+                    kind=CPEventKind.action_classified,
                     payload={
                         "tier": tier_str,
                         "tool_name": tool_name or request.kind,

--- a/backend/services/artifacts/diff_service.py
+++ b/backend/services/artifacts/diff_service.py
@@ -21,7 +21,7 @@ from backend.models.api_schemas import (
     DiffLineType,
     DiffUpdatePayload,
 )
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, new_event
 from backend.services.git.git_service import GitError
 
 if TYPE_CHECKING:
@@ -217,9 +217,9 @@ class DiffService:
         # SSE manager re-serializes to camelCase for the wire.
         payload = DiffUpdatePayload(job_id=job_id, changed_files=files)
         await self._event_bus.publish(
-            DomainEvent(
+            new_event(
                 event_id=f"evt-{uuid.uuid4().hex[:12]}",
-                job_id=job_id,
+                session_id=job_id,
                 timestamp=datetime.now(UTC),
                 kind=DomainEventKind.diff_updated,
                 payload=json.loads(payload.model_dump_json()),

--- a/backend/services/artifacts/diff_service.py
+++ b/backend/services/artifacts/diff_service.py
@@ -21,7 +21,7 @@ from backend.models.api_schemas import (
     DiffLineType,
     DiffUpdatePayload,
 )
-from backend.models.events import CPEventKind, new_event
+from backend.models.events import EventKind, new_event
 from backend.services.git.git_service import GitError
 
 if TYPE_CHECKING:
@@ -221,7 +221,7 @@ class DiffService:
                 event_id=f"evt-{uuid.uuid4().hex[:12]}",
                 session_id=job_id,
                 timestamp=datetime.now(UTC),
-                kind=CPEventKind.diff_updated,
+                kind=EventKind.diff_updated,
                 payload=json.loads(payload.model_dump_json()),
             )
         )

--- a/backend/services/artifacts/diff_service.py
+++ b/backend/services/artifacts/diff_service.py
@@ -21,7 +21,7 @@ from backend.models.api_schemas import (
     DiffLineType,
     DiffUpdatePayload,
 )
-from backend.models.events import DomainEventKind, new_event
+from backend.models.events import CPEventKind, new_event
 from backend.services.git.git_service import GitError
 
 if TYPE_CHECKING:
@@ -221,7 +221,7 @@ class DiffService:
                 event_id=f"evt-{uuid.uuid4().hex[:12]}",
                 session_id=job_id,
                 timestamp=datetime.now(UTC),
-                kind=DomainEventKind.diff_updated,
+                kind=CPEventKind.diff_updated,
                 payload=json.loads(payload.model_dump_json()),
             )
         )

--- a/backend/services/artifacts/snapshot_helpers.py
+++ b/backend/services/artifacts/snapshot_helpers.py
@@ -25,7 +25,7 @@ from backend.models.api_schemas import (
     TurnSummaryPayload,
 )
 from backend.models.domain import JobState
-from backend.models.events import DomainEventKind
+from backend.models.events import TRANSCRIPT_KINDS, CPEventKind
 from backend.services.git.git_service import GitError
 from backend.services.steps.tracker import hydrate_plan_steps
 
@@ -156,7 +156,7 @@ async def _build_diff(
         with contextlib.suppress(GitError, OSError):
             diff = await diff_service.calculate_diff(job.worktree_path, job.base_ref)
     if not diff:
-        diff_events = await svc.list_events_by_job(job.id, [DomainEventKind.diff_updated])
+        diff_events = await svc.list_events_by_job(job.id, [CPEventKind.diff_updated])
         if diff_events:
             raw_files = cast("list[Any]", diff_events[-1].payload.get("changed_files", []))
             diff = [DiffFileModel.model_validate(f) for f in raw_files]
@@ -287,14 +287,14 @@ async def assemble_snapshot(
         turn_summary_events,
         handoff_events,
     ) = await asyncio.gather(
-        svc.list_events_by_job(job_id, [DomainEventKind.log_line_emitted], limit=EVENT_QUERY_DEFAULT),
-        svc.list_events_by_job(job_id, [DomainEventKind.transcript_updated], limit=EVENT_QUERY_DEFAULT),
-        svc.list_events_by_job(job_id, [DomainEventKind.progress_headline], limit=HEADLINE_QUERY_LIMIT),
-        svc.list_events_by_job(job_id, [DomainEventKind.tool_group_summary], limit=EVENT_QUERY_CEILING),
-        svc.list_events_by_job(job_id, [DomainEventKind.plan_step_updated], limit=EVENT_QUERY_CEILING),
-        svc.list_events_by_job(job_id, [DomainEventKind.step_entries_reassigned], limit=EVENT_QUERY_CEILING),
-        svc.list_events_by_job(job_id, [DomainEventKind.turn_summary], limit=EVENT_QUERY_CEILING),
-        svc.list_events_by_job(job_id, [DomainEventKind.context_handoff], limit=EVENT_QUERY_CEILING),
+        svc.list_events_by_job(job_id, [CPEventKind.log_line_emitted], limit=EVENT_QUERY_DEFAULT),
+        svc.list_events_by_job(job_id, list(TRANSCRIPT_KINDS), limit=EVENT_QUERY_DEFAULT),
+        svc.list_events_by_job(job_id, [CPEventKind.progress_headline], limit=HEADLINE_QUERY_LIMIT),
+        svc.list_events_by_job(job_id, [CPEventKind.tool_group_summary], limit=EVENT_QUERY_CEILING),
+        svc.list_events_by_job(job_id, [CPEventKind.plan_step_updated], limit=EVENT_QUERY_CEILING),
+        svc.list_events_by_job(job_id, [CPEventKind.step_entries_reassigned], limit=EVENT_QUERY_CEILING),
+        svc.list_events_by_job(job_id, [CPEventKind.turn_summary], limit=EVENT_QUERY_CEILING),
+        svc.list_events_by_job(job_id, [CPEventKind.context_handoff], limit=EVENT_QUERY_CEILING),
     )
 
     logs = _build_logs(log_events)

--- a/backend/services/artifacts/snapshot_helpers.py
+++ b/backend/services/artifacts/snapshot_helpers.py
@@ -51,7 +51,7 @@ HEADLINE_QUERY_LIMIT = 200
 def _build_logs(log_events: list[Any]) -> list[LogLinePayload]:
     return [
         LogLinePayload(
-            job_id=e.job_id,
+            job_id=e.session_id,
             seq=e.payload.get("seq", 0),
             timestamp=e.payload.get("timestamp", e.timestamp),
             level=e.payload.get("level", "info"),
@@ -77,7 +77,7 @@ def _build_transcript(
     }
     result = [
         TranscriptPayload(
-            job_id=e.job_id,
+            job_id=e.session_id,
             seq=e.payload.get("seq", 0),
             timestamp=e.payload.get("timestamp", e.timestamp),
             role=e.payload.get("role", "agent"),
@@ -136,7 +136,7 @@ def _build_timeline(timeline_events: list[Any]) -> list[ProgressHeadlinePayload]
             milestones = milestones[:-replaces] if replaces < len(milestones) else []
         milestones.append(
             ProgressHeadlinePayload(
-                job_id=event.job_id,
+                job_id=event.session_id,
                 headline=event.payload.get("headline", ""),
                 headline_past=event.payload.get("headline_past", ""),
                 summary=event.payload.get("summary", ""),

--- a/backend/services/artifacts/snapshot_helpers.py
+++ b/backend/services/artifacts/snapshot_helpers.py
@@ -25,7 +25,7 @@ from backend.models.api_schemas import (
     TurnSummaryPayload,
 )
 from backend.models.domain import JobState
-from backend.models.events import TRANSCRIPT_KINDS, CPEventKind
+from backend.models.events import TRANSCRIPT_KINDS, EventKind
 from backend.services.git.git_service import GitError
 from backend.services.steps.tracker import hydrate_plan_steps
 
@@ -156,7 +156,7 @@ async def _build_diff(
         with contextlib.suppress(GitError, OSError):
             diff = await diff_service.calculate_diff(job.worktree_path, job.base_ref)
     if not diff:
-        diff_events = await svc.list_events_by_job(job.id, [CPEventKind.diff_updated])
+        diff_events = await svc.list_events_by_job(job.id, [EventKind.diff_updated])
         if diff_events:
             raw_files = cast("list[Any]", diff_events[-1].payload.get("changed_files", []))
             diff = [DiffFileModel.model_validate(f) for f in raw_files]
@@ -287,14 +287,14 @@ async def assemble_snapshot(
         turn_summary_events,
         handoff_events,
     ) = await asyncio.gather(
-        svc.list_events_by_job(job_id, [CPEventKind.log_line_emitted], limit=EVENT_QUERY_DEFAULT),
+        svc.list_events_by_job(job_id, [EventKind.log_line_emitted], limit=EVENT_QUERY_DEFAULT),
         svc.list_events_by_job(job_id, list(TRANSCRIPT_KINDS), limit=EVENT_QUERY_DEFAULT),
-        svc.list_events_by_job(job_id, [CPEventKind.progress_headline], limit=HEADLINE_QUERY_LIMIT),
-        svc.list_events_by_job(job_id, [CPEventKind.tool_group_summary], limit=EVENT_QUERY_CEILING),
-        svc.list_events_by_job(job_id, [CPEventKind.plan_step_updated], limit=EVENT_QUERY_CEILING),
-        svc.list_events_by_job(job_id, [CPEventKind.step_entries_reassigned], limit=EVENT_QUERY_CEILING),
-        svc.list_events_by_job(job_id, [CPEventKind.turn_summary], limit=EVENT_QUERY_CEILING),
-        svc.list_events_by_job(job_id, [CPEventKind.context_handoff], limit=EVENT_QUERY_CEILING),
+        svc.list_events_by_job(job_id, [EventKind.progress_headline], limit=HEADLINE_QUERY_LIMIT),
+        svc.list_events_by_job(job_id, [EventKind.tool_group_summary], limit=EVENT_QUERY_CEILING),
+        svc.list_events_by_job(job_id, [EventKind.plan_step_updated], limit=EVENT_QUERY_CEILING),
+        svc.list_events_by_job(job_id, [EventKind.step_entries_reassigned], limit=EVENT_QUERY_CEILING),
+        svc.list_events_by_job(job_id, [EventKind.turn_summary], limit=EVENT_QUERY_CEILING),
+        svc.list_events_by_job(job_id, [EventKind.context_handoff], limit=EVENT_QUERY_CEILING),
     )
 
     logs = _build_logs(log_events)

--- a/backend/services/coderecon/coderecon_service.py
+++ b/backend/services/coderecon/coderecon_service.py
@@ -174,13 +174,13 @@ class CodeReconService:
         """Publish a repo_index_progress event."""
         if self._event_bus is None:
             return
-        from backend.models.events import DomainEventKind, new_event
+        from backend.models.events import CPEventKind, new_event
 
         await self._event_bus.publish(
             new_event(
                 session_id=None,
                 timestamp=datetime.now(UTC),
-                kind=DomainEventKind.repo_index_progress,
+                kind=CPEventKind.repo_index_progress,
                 payload={"repo": repo, "indexed": indexed, "total": total, "phase": "indexing"},
             )
         )
@@ -189,13 +189,13 @@ class CodeReconService:
         """Publish a repo_index_complete event."""
         if self._event_bus is None:
             return
-        from backend.models.events import DomainEventKind, new_event
+        from backend.models.events import CPEventKind, new_event
 
         await self._event_bus.publish(
             new_event(
                 session_id=None,
                 timestamp=datetime.now(UTC),
-                kind=DomainEventKind.repo_index_complete,
+                kind=CPEventKind.repo_index_complete,
                 payload={"repo": repo},
             )
         )

--- a/backend/services/coderecon/coderecon_service.py
+++ b/backend/services/coderecon/coderecon_service.py
@@ -174,12 +174,11 @@ class CodeReconService:
         """Publish a repo_index_progress event."""
         if self._event_bus is None:
             return
-        from backend.models.events import DomainEvent, DomainEventKind
+        from backend.models.events import DomainEventKind, new_event
 
         await self._event_bus.publish(
-            DomainEvent(
-                event_id=DomainEvent.make_event_id(),
-                job_id=None,
+            new_event(
+                session_id=None,
                 timestamp=datetime.now(UTC),
                 kind=DomainEventKind.repo_index_progress,
                 payload={"repo": repo, "indexed": indexed, "total": total, "phase": "indexing"},
@@ -190,12 +189,11 @@ class CodeReconService:
         """Publish a repo_index_complete event."""
         if self._event_bus is None:
             return
-        from backend.models.events import DomainEvent, DomainEventKind
+        from backend.models.events import DomainEventKind, new_event
 
         await self._event_bus.publish(
-            DomainEvent(
-                event_id=DomainEvent.make_event_id(),
-                job_id=None,
+            new_event(
+                session_id=None,
                 timestamp=datetime.now(UTC),
                 kind=DomainEventKind.repo_index_complete,
                 payload={"repo": repo},

--- a/backend/services/coderecon/coderecon_service.py
+++ b/backend/services/coderecon/coderecon_service.py
@@ -174,13 +174,13 @@ class CodeReconService:
         """Publish a repo_index_progress event."""
         if self._event_bus is None:
             return
-        from backend.models.events import CPEventKind, new_event
+        from backend.models.events import EventKind, new_event
 
         await self._event_bus.publish(
             new_event(
                 session_id=None,
                 timestamp=datetime.now(UTC),
-                kind=CPEventKind.repo_index_progress,
+                kind=EventKind.repo_index_progress,
                 payload={"repo": repo, "indexed": indexed, "total": total, "phase": "indexing"},
             )
         )
@@ -189,13 +189,13 @@ class CodeReconService:
         """Publish a repo_index_complete event."""
         if self._event_bus is None:
             return
-        from backend.models.events import CPEventKind, new_event
+        from backend.models.events import EventKind, new_event
 
         await self._event_bus.publish(
             new_event(
                 session_id=None,
                 timestamp=datetime.now(UTC),
-                kind=CPEventKind.repo_index_complete,
+                kind=EventKind.repo_index_complete,
                 payload={"repo": repo},
             )
         )

--- a/backend/services/completers/summarization_service.py
+++ b/backend/services/completers/summarization_service.py
@@ -25,7 +25,7 @@ class TranscriptTurn(TypedDict):
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-    from backend.models.events import DomainEvent
+    from backend.models.events import SessionEvent
     from backend.services.completers.naming_service import Completable
 
 log = structlog.get_logger()
@@ -318,7 +318,7 @@ class SummarizationService:
 # ---------------------------------------------------------------------------
 
 
-def _clean_transcript(events: list[DomainEvent]) -> list[TranscriptTurn]:
+def _clean_transcript(events: list[SessionEvent]) -> list[TranscriptTurn]:
     """Filter and deduplicate transcript events, keeping only agent+operator turns."""
     seen: set[str] = set()
     result: list[TranscriptTurn] = []
@@ -397,7 +397,7 @@ def _format_transcript(turns: list[TranscriptTurn]) -> str:
     return "\n---\n".join(parts) if parts else "(no transcript recorded)"
 
 
-def extract_changed_files(diff_events: list[DomainEvent]) -> list[str]:
+def extract_changed_files(diff_events: list[SessionEvent]) -> list[str]:
     """Extract unique changed file paths from diff_updated events."""
     paths: set[str] = set()
     for ev in diff_events:

--- a/backend/services/events/event_bus.py
+++ b/backend/services/events/event_bus.py
@@ -8,17 +8,16 @@ from collections.abc import Callable, Coroutine
 from typing import Any
 
 import structlog
-
-from backend.models.events import DomainEvent
+from traceforge.types import SessionEvent
 
 log = structlog.get_logger()
 
-# Subscriber signature: async callable accepting a DomainEvent
-Subscriber = Callable[[DomainEvent], Coroutine[Any, Any, None]]
+# Subscriber signature: async callable accepting a traceforge SessionEvent
+Subscriber = Callable[[SessionEvent], Coroutine[Any, Any, None]]
 
 
 class EventBus:
-    """In-process async pub/sub for domain events.
+    """In-process async pub/sub for canonical ``traceforge.SessionEvent``s.
 
     Subscribers are async callables. Publishing fans out to all subscribers
     concurrently via ``asyncio.gather``. Subscriber exceptions are logged
@@ -41,7 +40,7 @@ class EventBus:
         with contextlib.suppress(ValueError):
             self._subscribers.remove(handler)
 
-    async def publish(self, event: DomainEvent) -> None:
+    async def publish(self, event: SessionEvent) -> None:
         """Fan-out *event* to every subscriber concurrently."""
         if self._muted or not self._subscribers:
             return

--- a/backend/services/events/event_processor.py
+++ b/backend/services/events/event_processor.py
@@ -22,7 +22,13 @@ import structlog
 
 from backend.models.domain import SessionEvent as CPSessionEvent
 from backend.models.domain import SessionEventKind
-from backend.models.events import DomainEventKind, SessionEvent, new_event
+from backend.models.events import (
+    TRANSCRIPT_KINDS,
+    CPEventKind,
+    SessionEvent,
+    new_event,
+    transcript_kind_for_role,
+)
 
 if TYPE_CHECKING:
     from backend.services.artifacts.diff_service import DiffService
@@ -99,7 +105,7 @@ class EventProcessor:
         # Managed sessions (via CopilotAdapter) already include one; discovered
         # sessions from the watchers don't.  Synthesize one here and rotate it
         # on each completed agent message (role=="agent") to mark turn boundaries.
-        if domain_event.kind == DomainEventKind.transcript_updated:
+        if domain_event.kind in TRANSCRIPT_KINDS:
             payload = domain_event.payload
             if not payload.get("turn_id"):
                 tid = self._turn_ids.get(job_id)
@@ -113,7 +119,7 @@ class EventProcessor:
                 self._turn_ids[job_id] = str(uuid.uuid4())
 
         # Step tracking — annotate transcript events with step boundaries
-        if domain_event.kind == DomainEventKind.transcript_updated and self._step_tracker is not None:
+        if domain_event.kind in TRANSCRIPT_KINDS and self._step_tracker is not None:
             role = str(domain_event.payload.get("role", ""))
             if role != "agent_delta":
                 await self._step_tracker.on_transcript_event(job_id, domain_event)
@@ -145,14 +151,17 @@ class EventProcessor:
     @staticmethod
     def _translate_event(job_id: str, event: CPSessionEvent) -> SessionEvent | None:
         """Translate a SessionEvent into a DomainEvent."""
-        mapping: dict[SessionEventKind, DomainEventKind] = {
-            SessionEventKind.log: DomainEventKind.log_line_emitted,
-            SessionEventKind.transcript: DomainEventKind.transcript_updated,
-            SessionEventKind.approval_request: DomainEventKind.approval_requested,
-            SessionEventKind.error: DomainEventKind.job_failed,
-            SessionEventKind.model_downgraded: DomainEventKind.model_downgraded,
+        mapping: dict[SessionEventKind, CPEventKind] = {
+            SessionEventKind.log: CPEventKind.log_line_emitted,
+            SessionEventKind.approval_request: CPEventKind.approval_requested,
+            SessionEventKind.error: CPEventKind.job_failed,
+            SessionEventKind.model_downgraded: CPEventKind.model_downgraded,
         }
-        kind = mapping.get(event.kind)
+        kind: CPEventKind | None
+        if event.kind == SessionEventKind.transcript:
+            kind = transcript_kind_for_role(str(event.payload.get("role", "")))
+        else:
+            kind = mapping.get(event.kind)
         if kind is None:
             return None
         return new_event(

--- a/backend/services/events/event_processor.py
+++ b/backend/services/events/event_processor.py
@@ -20,8 +20,9 @@ from typing import TYPE_CHECKING, Any, cast
 
 import structlog
 
-from backend.models.domain import SessionEvent, SessionEventKind
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.domain import SessionEvent as CPSessionEvent
+from backend.models.domain import SessionEventKind
+from backend.models.events import DomainEventKind, SessionEvent, new_event
 
 if TYPE_CHECKING:
     from backend.services.artifacts.diff_service import DiffService
@@ -62,10 +63,10 @@ class EventProcessor:
     async def process_event(
         self,
         job_id: str,
-        session_event: SessionEvent,
+        session_event: CPSessionEvent,
         worktree_path: str | None = None,
         base_ref: str | None = None,
-    ) -> DomainEvent | None:
+    ) -> SessionEvent | None:
         """Process a SessionEvent through the standard pipeline.
 
         Returns the published DomainEvent, or None if the event was consumed
@@ -142,7 +143,7 @@ class EventProcessor:
             self._diff_service.cleanup(job_id)
 
     @staticmethod
-    def _translate_event(job_id: str, event: SessionEvent) -> DomainEvent | None:
+    def _translate_event(job_id: str, event: CPSessionEvent) -> SessionEvent | None:
         """Translate a SessionEvent into a DomainEvent."""
         mapping: dict[SessionEventKind, DomainEventKind] = {
             SessionEventKind.log: DomainEventKind.log_line_emitted,
@@ -154,9 +155,8 @@ class EventProcessor:
         kind = mapping.get(event.kind)
         if kind is None:
             return None
-        return DomainEvent(
-            event_id=DomainEvent.make_event_id(),
-            job_id=job_id,
+        return new_event(
+            session_id=job_id,
             timestamp=datetime.now(UTC),
             kind=kind,
             payload=cast("dict[str, Any]", event.payload),

--- a/backend/services/events/event_processor.py
+++ b/backend/services/events/event_processor.py
@@ -24,7 +24,7 @@ from backend.models.domain import SessionEvent as CPSessionEvent
 from backend.models.domain import SessionEventKind
 from backend.models.events import (
     TRANSCRIPT_KINDS,
-    CPEventKind,
+    EventKind,
     SessionEvent,
     new_event,
     transcript_kind_for_role,
@@ -151,13 +151,13 @@ class EventProcessor:
     @staticmethod
     def _translate_event(job_id: str, event: CPSessionEvent) -> SessionEvent | None:
         """Translate a SessionEvent into a DomainEvent."""
-        mapping: dict[SessionEventKind, CPEventKind] = {
-            SessionEventKind.log: CPEventKind.log_line_emitted,
-            SessionEventKind.approval_request: CPEventKind.approval_requested,
-            SessionEventKind.error: CPEventKind.job_failed,
-            SessionEventKind.model_downgraded: CPEventKind.model_downgraded,
+        mapping: dict[SessionEventKind, EventKind] = {
+            SessionEventKind.log: EventKind.log_line_emitted,
+            SessionEventKind.approval_request: EventKind.approval_requested,
+            SessionEventKind.error: EventKind.job_failed,
+            SessionEventKind.model_downgraded: EventKind.model_downgraded,
         }
-        kind: CPEventKind | None
+        kind: EventKind | None
         if event.kind == SessionEventKind.transcript:
             kind = transcript_kind_for_role(str(event.payload.get("role", "")))
         else:

--- a/backend/services/events/sse_manager.py
+++ b/backend/services/events/sse_manager.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import json
-from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
@@ -14,39 +12,8 @@ if TYPE_CHECKING:
 
 import structlog
 
-from backend.models.api_schemas import (
-    ApprovalRequestedPayload,
-    ApprovalResolvedPayload,
-    ApprovalResponse,
-    ContextHandoffPayload,
-    DiffUpdatePayload,
-    JobArchivedPayload,
-    JobCompletedPayload,
-    JobFailedPayload,
-    JobResolvedPayload,
-    JobReviewPayload,
-    JobStateChangedPayload,
-    JobTitleUpdatedPayload,
-    LogLinePayload,
-    MergeCompletedPayload,
-    MergeConflictPayload,
-    ModelDowngradedPayload,
-    PlanStepPayload,
-    RepoIndexCompletePayload,
-    RepoIndexProgressPayload,
-    SessionHeartbeatPayload,
-    SessionResumedPayload,
-    SnapshotPayload,
-    StallDetectedPayload,
-    StepEntriesReassignedPayload,
-    StructuralWarningPayload,
-    TelemetryUpdatedPayload,
-    ToolGroupSummaryPayload,
-    TranscriptPayload,
-    TurnSummaryPayload,
-)
-from backend.models.domain import JobState, Resolution
-from backend.models.events import DomainEventKind, SessionEvent
+from backend.models.api_schemas import ApprovalResponse, SnapshotPayload
+from backend.models.events import TRANSCRIPT_KINDS, CPEventKind, SessionEvent
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -57,89 +24,71 @@ if TYPE_CHECKING:
 
 log = structlog.get_logger()
 
-# SSE event type mapping from domain event kinds
-_SSE_EVENT_TYPE: dict[str, str | None] = {
-    DomainEventKind.job_created: "job_state_changed",
-    DomainEventKind.job_setup_progress: "job_setup_progress",
-    DomainEventKind.workspace_prepared: None,  # internal only
-    DomainEventKind.agent_session_started: None,  # internal only
-    DomainEventKind.log_line_emitted: "log_line",
-    DomainEventKind.transcript_updated: "transcript_update",
-    DomainEventKind.diff_updated: "diff_update",
-    DomainEventKind.approval_requested: "approval_requested",
-    DomainEventKind.approval_resolved: "approval_resolved",
-    DomainEventKind.batch_approval_requested: "batch_approval_requested",
-    DomainEventKind.batch_approval_resolved: "batch_approval_resolved",
-    DomainEventKind.job_review: "job_review",
-    DomainEventKind.job_completed: "job_completed",
-    DomainEventKind.job_failed: "job_failed",
-    DomainEventKind.job_canceled: "job_state_changed",
-    DomainEventKind.job_state_changed: "job_state_changed",
-    DomainEventKind.session_heartbeat: "session_heartbeat",
-    DomainEventKind.merge_completed: "merge_completed",
-    DomainEventKind.merge_conflict: "merge_conflict",
-    DomainEventKind.session_resumed: "session_resumed",
-    DomainEventKind.job_resolved: "job_resolved",
-    DomainEventKind.job_archived: "job_archived",
-    DomainEventKind.job_title_updated: "job_title_updated",
-    DomainEventKind.progress_headline: None,  # dead — replaced by plan_step_updated
-    DomainEventKind.model_downgraded: "model_downgraded",
-    DomainEventKind.tool_group_summary: "tool_group_summary",
-    DomainEventKind.agent_plan_updated: None,  # dead — replaced by plan_step_updated
-    DomainEventKind.telemetry_updated: "telemetry_updated",
-    # Step system — internal SDK-turn tracking, not sent to frontend
-    DomainEventKind.step_started: None,
-    DomainEventKind.step_completed: None,
-    DomainEventKind.step_title_generated: None,
-    DomainEventKind.step_group_updated: None,
-    # Plan steps — the only step-level event the frontend sees
-    DomainEventKind.plan_step_updated: "plan_step_updated",
-    DomainEventKind.step_entries_reassigned: "step_entries_reassigned",
-    DomainEventKind.turn_summary: "turn_summary",
-    DomainEventKind.action_classified: "action_classified",
-    DomainEventKind.policy_settings_changed: "policy_settings_changed",
-    DomainEventKind.repo_index_progress: "repo_index_progress",
-    DomainEventKind.repo_index_complete: "repo_index_complete",
-    DomainEventKind.structural_warning: "structural_warning",
-    DomainEventKind.stall_detected: "stall_detected",
-    DomainEventKind.sidecar_transcript: None,  # replaced by secondary_session_completed
-    DomainEventKind.sidecar_agent_message: None,  # replaced by secondary_session_completed
-    DomainEventKind.sidecar_gate_verdict: None,  # internal — handled by dispatcher
-    DomainEventKind.sidecar_metadata_update: None,  # internal — handled by dispatcher
-    # Unified secondary session events
-    DomainEventKind.secondary_session_started: "secondary_session_started",
-    DomainEventKind.secondary_session_entry: "secondary_session_entry",
-    DomainEventKind.secondary_session_completed: "secondary_session_completed",
-    # Context handoff visibility
-    DomainEventKind.context_handoff: "context_handoff",
-}
-
-# State implied by each domain event kind (for job_state_changed payloads)
-_KIND_TO_STATE: dict[str, str] = {
-    DomainEventKind.job_created: JobState.running,
-    DomainEventKind.job_review: JobState.review,
-    DomainEventKind.job_completed: JobState.completed,
-    DomainEventKind.job_failed: JobState.failed,
-    DomainEventKind.job_canceled: JobState.canceled,
-}
-
-# High-frequency event types suppressed in selective mode (>20 active jobs)
-_SELECTIVE_SUPPRESSED: frozenset[str] = frozenset(
+# Dotted TF kinds delivered to the frontend. Kinds NOT in this allowlist are
+# internal-only (steps, sidecar internals, workspace prep, dead kinds) and are
+# never broadcast. The wire ``event:`` type IS the dotted kind and ``data:`` is
+# the TF event serialized as-is — no translation to any legacy wire vocabulary.
+# Derived job-state transitions (e.g. permission.requested ⇒ waiting_for_approval)
+# are computed by the frontend from these dotted kinds, not synthesized here.
+_BROADCAST_KINDS: frozenset[str] = frozenset(
     {
-        "log_line",
-        "transcript_update",
-        "diff_update",
-        "session_heartbeat",
+        CPEventKind.job_created,
+        CPEventKind.job_setup_progress,
+        CPEventKind.log_line_emitted,
+        CPEventKind.diff_updated,
+        CPEventKind.approval_requested,
+        CPEventKind.approval_resolved,
+        CPEventKind.batch_approval_requested,
+        CPEventKind.batch_approval_resolved,
+        CPEventKind.job_review,
+        CPEventKind.job_completed,
+        CPEventKind.job_failed,
+        CPEventKind.job_canceled,
+        CPEventKind.job_state_changed,
+        CPEventKind.session_heartbeat,
+        CPEventKind.merge_completed,
+        CPEventKind.merge_conflict,
+        CPEventKind.session_resumed,
+        CPEventKind.job_resolved,
+        CPEventKind.job_archived,
+        CPEventKind.job_title_updated,
+        CPEventKind.model_downgraded,
+        CPEventKind.tool_group_summary,
+        CPEventKind.telemetry_updated,
+        CPEventKind.plan_step_updated,
+        CPEventKind.step_entries_reassigned,
+        CPEventKind.turn_summary,
+        CPEventKind.action_classified,
+        CPEventKind.policy_settings_changed,
+        CPEventKind.repo_index_progress,
+        CPEventKind.repo_index_complete,
+        CPEventKind.structural_warning,
+        CPEventKind.stall_detected,
+        CPEventKind.secondary_session_started,
+        CPEventKind.secondary_session_entry,
+        CPEventKind.secondary_session_completed,
+        CPEventKind.context_handoff,
     }
+    | TRANSCRIPT_KINDS
 )
 
-# Event types delivered only to job-scoped connections, never to global/dashboard.
+# High-frequency dotted kinds suppressed in selective mode (>20 active jobs)
+_SELECTIVE_SUPPRESSED: frozenset[str] = frozenset(
+    {
+        CPEventKind.log_line_emitted,
+        CPEventKind.diff_updated,
+        CPEventKind.session_heartbeat,
+    }
+    | TRANSCRIPT_KINDS
+)
+
+# Dotted kinds delivered only to job-scoped connections, never to global/dashboard.
 # These are high-frequency during execution and only relevant to a user viewing
 # a specific job's detail panel.
 _JOB_SCOPED_ONLY: frozenset[str] = frozenset(
     {
-        "telemetry_updated",
-        "secondary_session_entry",
+        CPEventKind.telemetry_updated,
+        CPEventKind.secondary_session_entry,
     }
 )
 
@@ -184,472 +133,18 @@ def _format_sse(event_id: str | None, event_type: str, data: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Generic field-map builder
+# TraceForge event serialization
 # ---------------------------------------------------------------------------
-# Sentinels for timestamp handling in field maps
-_TS_FALLBACK = object()  # event.payload.get(key, event.timestamp)
-_TS_EVENT = object()  # always event.timestamp
-
-# FieldMap: model kwarg → (payload_key, default)
-# When default is _TS_FALLBACK, falls back to event.timestamp if missing.
-# When default is _TS_EVENT, always uses event.timestamp (payload_key ignored).
-FieldMap = dict[str, tuple[str, object]]
 
 
-def _build_from_fields(event: SessionEvent, model_cls: type, fields: FieldMap) -> str:
-    """Build a Pydantic SSE payload from a declarative field map.
+def _serialize_tf_event(event: SessionEvent) -> str:
+    """Serialize a traceforge ``SessionEvent`` to the SSE ``data:`` field as-is.
 
-    Every model receives ``job_id=event.session_id`` automatically.
+    The wire carries the event's own shape — its dotted ``kind``, ``payload``,
+    and ``metadata`` — with no translation to any legacy payload model. The
+    frontend consumes this shape directly.
     """
-    kwargs: dict[str, object] = {"job_id": event.session_id}
-    for kwarg_name, (payload_key, default) in fields.items():
-        if default is _TS_FALLBACK:
-            kwargs[kwarg_name] = event.payload.get(payload_key, event.timestamp)
-        elif default is _TS_EVENT:
-            kwargs[kwarg_name] = event.timestamp
-        else:
-            kwargs[kwarg_name] = event.payload.get(payload_key, default)
-    result: str = model_cls(**kwargs).model_dump_json(by_alias=True)
-    return result
-
-
-# ---------------------------------------------------------------------------
-# Custom builders for event types with non-trivial extraction logic
-# ---------------------------------------------------------------------------
-
-_BuilderFn = Callable[[SessionEvent], str]
-
-
-def _build_job_state_changed(event: SessionEvent) -> str:
-    new_state = _KIND_TO_STATE.get(
-        event.kind, event.payload.get("state", event.payload.get("new_state", JobState.queued))
-    )
-    return JobStateChangedPayload(
-        job_id=event.session_id,
-        previous_state=event.payload.get("previous_state"),
-        new_state=new_state,
-        timestamp=event.timestamp,
-    ).model_dump_json(by_alias=True)
-
-
-def _build_job_review(event: SessionEvent) -> str:
-    return JobReviewPayload(
-        job_id=event.session_id,
-        pr_url=event.payload.get("pr_url"),
-        merge_status=event.payload.get("merge_status"),
-        resolution=event.payload.get("resolution"),
-        model_downgraded=bool(event.payload.get("model_downgraded", False)),
-        requested_model=event.payload.get("requested_model"),
-        actual_model=event.payload.get("actual_model"),
-        timestamp=event.timestamp,
-    ).model_dump_json(by_alias=True)
-
-
-def _build_plan_step_updated(event: SessionEvent) -> str:
-    p = event.payload
-    return PlanStepPayload(
-        job_id=event.session_id,
-        plan_step_id=p.get("plan_step_id", ""),
-        label=p.get("label", ""),
-        summary=p.get("summary"),
-        status=p.get("status", "pending"),
-        order=p.get("order", 0),
-        tool_count=p.get("tool_count", 0),
-        files_written=p.get("files_written"),
-        started_at=p.get("started_at"),
-        completed_at=p.get("completed_at"),
-        duration_ms=p.get("duration_ms"),
-        start_sha=p.get("start_sha"),
-        end_sha=p.get("end_sha"),
-    ).model_dump_json(by_alias=True)
-
-
-def _build_batch_approval_requested(event: SessionEvent) -> str:
-    import json
-
-    p = event.payload
-    return json.dumps(
-        {
-            "jobId": event.session_id,
-            "batch_id": p.get("batch_id", ""),
-            "batch_size": p.get("batch_size", 0),
-            "summary": p.get("summary", ""),
-            "actions": p.get("actions", []),
-            "timestamp": event.timestamp.isoformat() if hasattr(event.timestamp, "isoformat") else str(event.timestamp),
-        }
-    )
-
-
-def _build_batch_approval_resolved(event: SessionEvent) -> str:
-    import json
-
-    p = event.payload
-    return json.dumps(
-        {
-            "jobId": event.session_id,
-            "batch_id": p.get("batch_id", ""),
-            "resolution": p.get("resolution", ""),
-            "timestamp": event.timestamp.isoformat() if hasattr(event.timestamp, "isoformat") else str(event.timestamp),
-        }
-    )
-
-
-# -- Unified secondary session builders --
-
-
-def _build_secondary_session_started(event: SessionEvent) -> str:
-    import json
-
-    p = event.payload
-    return json.dumps(
-        {
-            "sessionId": p.get("session_id", ""),
-            "jobId": event.session_id,
-            "kind": p.get("kind", ""),
-            "name": p.get("name", ""),
-            "icon": p.get("icon", "bot"),
-        }
-    )
-
-
-def _build_secondary_session_entry(event: SessionEvent) -> str:
-    import json
-
-    p = event.payload
-    entry = p.get("entry", {})
-    if not isinstance(entry, dict):
-        entry = {}
-    return json.dumps(
-        {
-            "sessionId": p.get("session_id", ""),
-            "jobId": event.session_id,
-            "entry": {
-                "seq": entry.get("seq", 0),
-                "kind": entry.get("kind", ""),
-                "content": entry.get("content", ""),
-                "toolName": entry.get("tool_name"),
-                "toolArgs": entry.get("tool_args"),
-                "durationMs": entry.get("duration_ms"),
-                "toolResult": entry.get("tool_result"),
-                "toolDisplay": entry.get("tool_display"),
-                "toolDisplayFull": entry.get("tool_display_full"),
-                "toolSuccess": entry.get("tool_success"),
-                "toolIssue": entry.get("tool_issue"),
-                "toolVisibility": entry.get("tool_visibility"),
-            },
-        }
-    )
-
-
-def _build_secondary_session_completed(event: SessionEvent) -> str:
-    import json
-
-    p = event.payload
-    return json.dumps(
-        {
-            "sessionId": p.get("session_id", ""),
-            "jobId": event.session_id,
-            "status": p.get("status", "completed"),
-            "output": p.get("output"),
-            "inputTokens": p.get("input_tokens", 0),
-            "outputTokens": p.get("output_tokens", 0),
-            "costUsd": p.get("cost_usd", 0.0),
-            "metadata": p.get("metadata", {}),
-        }
-    )
-
-
-# ---------------------------------------------------------------------------
-# Unified SSE payload registry
-# ---------------------------------------------------------------------------
-# Each entry is either a (ModelClass, FieldMap) tuple handled generically by
-# ``_build_from_fields``, or a custom callable for event types that need
-# non-trivial extraction logic.
-
-_SSE_PAYLOAD_REGISTRY: dict[str, tuple[type, FieldMap] | _BuilderFn] = {
-    # --- Custom builders (non-trivial extraction) ---
-    "job_state_changed": _build_job_state_changed,
-    "job_review": _build_job_review,
-    "plan_step_updated": _build_plan_step_updated,
-    "batch_approval_requested": _build_batch_approval_requested,
-    "batch_approval_resolved": _build_batch_approval_resolved,
-    # Unified secondary session events
-    "secondary_session_started": _build_secondary_session_started,
-    "secondary_session_entry": _build_secondary_session_entry,
-    "secondary_session_completed": _build_secondary_session_completed,
-    # --- Field-map builders (declarative) ---
-    "log_line": (
-        LogLinePayload,
-        {
-            "seq": ("seq", 0),
-            "timestamp": ("timestamp", _TS_FALLBACK),
-            "level": ("level", "info"),
-            "message": ("message", ""),
-            "context": ("context", None),
-        },
-    ),
-    "transcript_update": (
-        TranscriptPayload,
-        {
-            "seq": ("seq", 0),
-            "timestamp": ("timestamp", _TS_FALLBACK),
-            "role": ("role", "agent"),
-            "content": ("content", ""),
-            "title": ("title", None),
-            "turn_id": ("turn_id", None),
-            "tool_name": ("tool_name", None),
-            "tool_args": ("tool_args", None),
-            "tool_result": ("tool_result", None),
-            "tool_success": ("tool_success", None),
-            "tool_issue": ("tool_issue", None),
-            "tool_intent": ("tool_intent", None),
-            "tool_title": ("tool_title", None),
-            "tool_display": ("tool_display", None),
-            "tool_display_full": ("tool_display_full", None),
-            "tool_duration_ms": ("tool_duration_ms", None),
-            "tool_visibility": ("tool_visibility", None),
-            "step_id": ("step_id", None),
-            "step_number": ("step_number", None),
-        },
-    ),
-    "diff_update": (
-        DiffUpdatePayload,
-        {
-            "changed_files": ("changed_files", []),
-        },
-    ),
-    "approval_requested": (
-        ApprovalRequestedPayload,
-        {
-            "approval_id": ("approval_id", ""),
-            "description": ("description", ""),
-            "proposed_action": ("proposed_action", None),
-            "timestamp": ("timestamp", _TS_FALLBACK),
-            "requires_explicit_approval": ("requires_explicit_approval", False),
-        },
-    ),
-    "approval_resolved": (
-        ApprovalResolvedPayload,
-        {
-            "approval_id": ("approval_id", ""),
-            "resolution": ("resolution", ""),
-            "timestamp": ("timestamp", _TS_FALLBACK),
-        },
-    ),
-    "session_heartbeat": (
-        SessionHeartbeatPayload,
-        {
-            "session_id": ("session_id", ""),
-            "timestamp": ("timestamp", _TS_FALLBACK),
-            "last_activity_at": ("last_activity_at", None),
-            "active_tool_name": ("active_tool_name", None),
-            "active_tool_since": ("active_tool_since", None),
-        },
-    ),
-    "merge_completed": (
-        MergeCompletedPayload,
-        {
-            "branch": ("branch", ""),
-            "base_ref": ("base_ref", ""),
-            "strategy": ("strategy", ""),
-            "timestamp": ("timestamp", _TS_FALLBACK),
-        },
-    ),
-    "merge_conflict": (
-        MergeConflictPayload,
-        {
-            "branch": ("branch", ""),
-            "base_ref": ("base_ref", ""),
-            "conflict_files": ("conflict_files", []),
-            "fallback": ("fallback", "none"),
-            "pr_url": ("pr_url", None),
-            "timestamp": ("timestamp", _TS_FALLBACK),
-        },
-    ),
-    "session_resumed": (
-        SessionResumedPayload,
-        {
-            "session_number": ("session_number", 1),
-            "timestamp": ("timestamp", _TS_FALLBACK),
-        },
-    ),
-    "job_failed": (
-        JobFailedPayload,
-        {
-            "reason": ("reason", "Unknown error"),
-            "timestamp": ("timestamp", _TS_EVENT),
-        },
-    ),
-    "job_completed": (
-        JobCompletedPayload,
-        {
-            "resolution": ("resolution", None),
-            "pr_url": ("pr_url", None),
-            "timestamp": ("timestamp", _TS_EVENT),
-        },
-    ),
-    "job_resolved": (
-        JobResolvedPayload,
-        {
-            "resolution": ("resolution", Resolution.unresolved),
-            "pr_url": ("pr_url", None),
-            "conflict_files": ("conflict_files", None),
-            "error": ("error", None),
-            "timestamp": ("timestamp", _TS_EVENT),
-        },
-    ),
-    "job_archived": (
-        JobArchivedPayload,
-        {
-            "timestamp": ("timestamp", _TS_EVENT),
-        },
-    ),
-    "job_title_updated": (
-        JobTitleUpdatedPayload,
-        {
-            "title": ("title", None),
-            "description": ("description", None),
-            "branch": ("branch", None),
-            "timestamp": ("timestamp", _TS_EVENT),
-        },
-    ),
-    "model_downgraded": (
-        ModelDowngradedPayload,
-        {
-            "requested_model": ("requested_model", ""),
-            "actual_model": ("actual_model", ""),
-            "timestamp": ("timestamp", _TS_EVENT),
-        },
-    ),
-    "tool_group_summary": (
-        ToolGroupSummaryPayload,
-        {
-            "turn_id": ("turn_id", ""),
-            "summary": ("summary", ""),
-            "timestamp": ("timestamp", _TS_EVENT),
-        },
-    ),
-    "telemetry_updated": (
-        TelemetryUpdatedPayload,
-        {
-            "timestamp": ("timestamp", _TS_EVENT),
-            "total_cost_usd": ("total_cost_usd", 0.0),
-            "total_tokens": ("total_tokens", 0),
-            "input_tokens": ("input_tokens", 0),
-            "output_tokens": ("output_tokens", 0),
-        },
-    ),
-    "step_entries_reassigned": (
-        StepEntriesReassignedPayload,
-        {
-            "turn_id": ("turn_id", ""),
-            "old_step_id": ("old_step_id", ""),
-            "new_step_id": ("new_step_id", ""),
-        },
-    ),
-    "turn_summary": (
-        TurnSummaryPayload,
-        {
-            "turn_id": ("turn_id", ""),
-            "title": ("title", ""),
-            "activity_id": ("activity_id", ""),
-            "activity_label": ("activity_label", ""),
-            "activity_status": ("activity_status", "active"),
-            "is_new_activity": ("is_new_activity", False),
-            "plan_item_id": ("plan_item_id", None),
-            "replaces_turn_id": ("replaces_turn_id", None),
-        },
-    ),
-    "repo_index_progress": (
-        RepoIndexProgressPayload,
-        {
-            "repo": ("repo", ""),
-            "indexed": ("indexed", 0),
-            "total": ("total", 0),
-            "phase": ("phase", "indexing"),
-        },
-    ),
-    "repo_index_complete": (
-        RepoIndexCompletePayload,
-        {
-            "repo": ("repo", ""),
-        },
-    ),
-    "structural_warning": (
-        StructuralWarningPayload,
-        {
-            "repo": ("repo", ""),
-            "warning_type": ("warning_type", ""),
-            "detail": ("detail", ""),
-        },
-    ),
-    "stall_detected": (
-        StallDetectedPayload,
-        {
-            "job_id": ("job_id", ""),
-            "tool_name": ("tool_name", ""),
-            "elapsed": ("elapsed", ""),
-            "reason": ("reason", ""),
-        },
-    ),
-    "context_handoff": (
-        ContextHandoffPayload,
-        {
-            "source": ("source", ""),
-            "source_session_id": ("source_session_id", None),
-            "summary": ("summary", ""),
-            "content": ("content", None),
-            "timestamp": ("timestamp", _TS_EVENT),
-        },
-    ),
-}
-
-
-def _build_sse_data(event: SessionEvent, sse_type: str) -> str:
-    """Serialize the domain event payload via the appropriate Pydantic SSE model.
-
-    This ensures all SSE payloads use **camelCase** keys matching the API contract.
-    """
-    spec = _SSE_PAYLOAD_REGISTRY.get(sse_type)
-    if spec is None:
-        # Fallback (should not happen for known types)
-        return json.dumps(event.payload, default=str)
-    if callable(spec):
-        return spec(event)
-    model_cls, fields = spec
-    return _build_from_fields(event, model_cls, fields)
-
-
-def _build_derived_state_frame(event: SessionEvent, sse_id: str | None) -> str | None:
-    """Build a derived ``job_state_changed`` SSE frame for events that imply a state transition.
-
-    Returns ``None`` when *event* does not trigger a secondary frame.
-    """
-    if event.kind == DomainEventKind.approval_requested:
-        payload = JobStateChangedPayload(
-            job_id=event.session_id,
-            previous_state=event.payload.get("previous_state"),
-            new_state=JobState.waiting_for_approval,
-            timestamp=event.timestamp,
-        )
-    elif event.kind == DomainEventKind.approval_resolved:
-        new_state = JobState.running if event.payload.get("resolution") == "approved" else JobState.failed
-        payload = JobStateChangedPayload(
-            job_id=event.session_id,
-            previous_state=JobState.waiting_for_approval,
-            new_state=new_state,
-            timestamp=event.timestamp,
-        )
-    elif event.kind in (DomainEventKind.job_review, DomainEventKind.job_completed, DomainEventKind.job_failed):
-        payload = JobStateChangedPayload(
-            job_id=event.session_id,
-            previous_state=None,
-            new_state=_KIND_TO_STATE[event.kind],
-            timestamp=event.timestamp,
-        )
-    else:
-        return None
-    return _format_sse(sse_id, "job_state_changed", payload.model_dump_json(by_alias=True))
+    return event.model_dump_json()
 
 
 class SSEManager:
@@ -688,13 +183,17 @@ class SSEManager:
         self._active_job_count = count
 
     async def broadcast_domain_event(self, event: SessionEvent) -> None:
-        """Event bus subscriber — translate and broadcast a domain event."""
-        sse_type = _SSE_EVENT_TYPE.get(event.kind)
-        if sse_type is None:
+        """Event bus subscriber — serialize a TF event to the SSE wire as-is.
+
+        The ``event:`` type is the event's dotted ``kind`` and ``data:`` is the
+        TraceForge ``SessionEvent`` serialized verbatim. Kinds outside the
+        broadcast allowlist are internal-only and dropped here.
+        """
+        if event.kind not in _BROADCAST_KINDS:
             return  # internal-only event
 
         sse_id = str(event.metadata.sequence) if event.metadata.sequence is not None else event.id
-        frame = _format_sse(sse_id, sse_type, _build_sse_data(event, sse_type))
+        frame = _format_sse(sse_id, str(event.kind), _serialize_tf_event(event))
         selective = self._active_job_count > 20
 
         # Prune connections closed since last broadcast
@@ -713,27 +212,13 @@ class SSEManager:
                 continue
 
             # Global connections: skip job-scoped-only events entirely
-            if sse_type in _JOB_SCOPED_ONLY:
+            if event.kind in _JOB_SCOPED_ONLY:
                 continue
 
             # Global connections: apply selective streaming if needed
-            if selective and sse_type in _SELECTIVE_SUPPRESSED:
+            if selective and event.kind in _SELECTIVE_SUPPRESSED:
                 continue
 
-            conn.send(frame)
-
-        # Emit secondary SSE events per the mapping in §5.3.1
-        derived = _build_derived_state_frame(event, sse_id=None)
-        if derived is not None:
-            self._broadcast_frame(derived, event.session_id)
-
-    def _broadcast_frame(self, frame: str, job_id: str | None) -> None:
-        """Send a pre-formatted frame to all relevant connections."""
-        for conn in list(self._connections):
-            if conn.closed:
-                continue
-            if conn.job_id is not None and conn.job_id != job_id:
-                continue
             conn.send(frame)
 
     def send_snapshot(self, conn: SSEConnection, snapshot: SnapshotPayload) -> None:
@@ -842,20 +327,11 @@ class SSEManager:
 
         # Replay the events
         for event in events:
-            sse_type = _SSE_EVENT_TYPE.get(event.kind)
-            if sse_type is None:
+            if event.kind not in _BROADCAST_KINDS:
                 continue
             sse_id = str(event.metadata.sequence) if event.metadata.sequence is not None else event.id
-            frame = _format_sse(sse_id, sse_type, _build_sse_data(event, sse_type))
+            frame = _format_sse(sse_id, str(event.kind), _serialize_tf_event(event))
             conn.send(frame)
-
-            # Mirror broadcast_domain_event(): emit a derived
-            # job_state_changed frame so the client sees the state
-            # transition on reconnect.  Reuse the same SSE id so the
-            # replay cursor does not advance beyond the underlying event.
-            derived = _build_derived_state_frame(event, sse_id=sse_id)
-            if derived is not None:
-                conn.send(derived)
 
     async def replay_from_factory(
         self,

--- a/backend/services/events/sse_manager.py
+++ b/backend/services/events/sse_manager.py
@@ -46,7 +46,7 @@ from backend.models.api_schemas import (
     TurnSummaryPayload,
 )
 from backend.models.domain import JobState, Resolution
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, SessionEvent
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -58,7 +58,7 @@ if TYPE_CHECKING:
 log = structlog.get_logger()
 
 # SSE event type mapping from domain event kinds
-_SSE_EVENT_TYPE: dict[DomainEventKind, str | None] = {
+_SSE_EVENT_TYPE: dict[str, str | None] = {
     DomainEventKind.job_created: "job_state_changed",
     DomainEventKind.job_setup_progress: "job_setup_progress",
     DomainEventKind.workspace_prepared: None,  # internal only
@@ -115,7 +115,7 @@ _SSE_EVENT_TYPE: dict[DomainEventKind, str | None] = {
 }
 
 # State implied by each domain event kind (for job_state_changed payloads)
-_KIND_TO_STATE: dict[DomainEventKind, str] = {
+_KIND_TO_STATE: dict[str, str] = {
     DomainEventKind.job_created: JobState.running,
     DomainEventKind.job_review: JobState.review,
     DomainEventKind.job_completed: JobState.completed,
@@ -196,12 +196,12 @@ _TS_EVENT = object()  # always event.timestamp
 FieldMap = dict[str, tuple[str, object]]
 
 
-def _build_from_fields(event: DomainEvent, model_cls: type, fields: FieldMap) -> str:
+def _build_from_fields(event: SessionEvent, model_cls: type, fields: FieldMap) -> str:
     """Build a Pydantic SSE payload from a declarative field map.
 
-    Every model receives ``job_id=event.job_id`` automatically.
+    Every model receives ``job_id=event.session_id`` automatically.
     """
-    kwargs: dict[str, object] = {"job_id": event.job_id}
+    kwargs: dict[str, object] = {"job_id": event.session_id}
     for kwarg_name, (payload_key, default) in fields.items():
         if default is _TS_FALLBACK:
             kwargs[kwarg_name] = event.payload.get(payload_key, event.timestamp)
@@ -217,24 +217,24 @@ def _build_from_fields(event: DomainEvent, model_cls: type, fields: FieldMap) ->
 # Custom builders for event types with non-trivial extraction logic
 # ---------------------------------------------------------------------------
 
-_BuilderFn = Callable[[DomainEvent], str]
+_BuilderFn = Callable[[SessionEvent], str]
 
 
-def _build_job_state_changed(event: DomainEvent) -> str:
+def _build_job_state_changed(event: SessionEvent) -> str:
     new_state = _KIND_TO_STATE.get(
         event.kind, event.payload.get("state", event.payload.get("new_state", JobState.queued))
     )
     return JobStateChangedPayload(
-        job_id=event.job_id,
+        job_id=event.session_id,
         previous_state=event.payload.get("previous_state"),
         new_state=new_state,
         timestamp=event.timestamp,
     ).model_dump_json(by_alias=True)
 
 
-def _build_job_review(event: DomainEvent) -> str:
+def _build_job_review(event: SessionEvent) -> str:
     return JobReviewPayload(
-        job_id=event.job_id,
+        job_id=event.session_id,
         pr_url=event.payload.get("pr_url"),
         merge_status=event.payload.get("merge_status"),
         resolution=event.payload.get("resolution"),
@@ -245,10 +245,10 @@ def _build_job_review(event: DomainEvent) -> str:
     ).model_dump_json(by_alias=True)
 
 
-def _build_plan_step_updated(event: DomainEvent) -> str:
+def _build_plan_step_updated(event: SessionEvent) -> str:
     p = event.payload
     return PlanStepPayload(
-        job_id=event.job_id,
+        job_id=event.session_id,
         plan_step_id=p.get("plan_step_id", ""),
         label=p.get("label", ""),
         summary=p.get("summary"),
@@ -264,13 +264,13 @@ def _build_plan_step_updated(event: DomainEvent) -> str:
     ).model_dump_json(by_alias=True)
 
 
-def _build_batch_approval_requested(event: DomainEvent) -> str:
+def _build_batch_approval_requested(event: SessionEvent) -> str:
     import json
 
     p = event.payload
     return json.dumps(
         {
-            "jobId": event.job_id,
+            "jobId": event.session_id,
             "batch_id": p.get("batch_id", ""),
             "batch_size": p.get("batch_size", 0),
             "summary": p.get("summary", ""),
@@ -280,13 +280,13 @@ def _build_batch_approval_requested(event: DomainEvent) -> str:
     )
 
 
-def _build_batch_approval_resolved(event: DomainEvent) -> str:
+def _build_batch_approval_resolved(event: SessionEvent) -> str:
     import json
 
     p = event.payload
     return json.dumps(
         {
-            "jobId": event.job_id,
+            "jobId": event.session_id,
             "batch_id": p.get("batch_id", ""),
             "resolution": p.get("resolution", ""),
             "timestamp": event.timestamp.isoformat() if hasattr(event.timestamp, "isoformat") else str(event.timestamp),
@@ -297,14 +297,14 @@ def _build_batch_approval_resolved(event: DomainEvent) -> str:
 # -- Unified secondary session builders --
 
 
-def _build_secondary_session_started(event: DomainEvent) -> str:
+def _build_secondary_session_started(event: SessionEvent) -> str:
     import json
 
     p = event.payload
     return json.dumps(
         {
             "sessionId": p.get("session_id", ""),
-            "jobId": event.job_id,
+            "jobId": event.session_id,
             "kind": p.get("kind", ""),
             "name": p.get("name", ""),
             "icon": p.get("icon", "bot"),
@@ -312,7 +312,7 @@ def _build_secondary_session_started(event: DomainEvent) -> str:
     )
 
 
-def _build_secondary_session_entry(event: DomainEvent) -> str:
+def _build_secondary_session_entry(event: SessionEvent) -> str:
     import json
 
     p = event.payload
@@ -322,7 +322,7 @@ def _build_secondary_session_entry(event: DomainEvent) -> str:
     return json.dumps(
         {
             "sessionId": p.get("session_id", ""),
-            "jobId": event.job_id,
+            "jobId": event.session_id,
             "entry": {
                 "seq": entry.get("seq", 0),
                 "kind": entry.get("kind", ""),
@@ -341,14 +341,14 @@ def _build_secondary_session_entry(event: DomainEvent) -> str:
     )
 
 
-def _build_secondary_session_completed(event: DomainEvent) -> str:
+def _build_secondary_session_completed(event: SessionEvent) -> str:
     import json
 
     p = event.payload
     return json.dumps(
         {
             "sessionId": p.get("session_id", ""),
-            "jobId": event.job_id,
+            "jobId": event.session_id,
             "status": p.get("status", "completed"),
             "output": p.get("output"),
             "inputTokens": p.get("input_tokens", 0),
@@ -605,7 +605,7 @@ _SSE_PAYLOAD_REGISTRY: dict[str, tuple[type, FieldMap] | _BuilderFn] = {
 }
 
 
-def _build_sse_data(event: DomainEvent, sse_type: str) -> str:
+def _build_sse_data(event: SessionEvent, sse_type: str) -> str:
     """Serialize the domain event payload via the appropriate Pydantic SSE model.
 
     This ensures all SSE payloads use **camelCase** keys matching the API contract.
@@ -620,14 +620,14 @@ def _build_sse_data(event: DomainEvent, sse_type: str) -> str:
     return _build_from_fields(event, model_cls, fields)
 
 
-def _build_derived_state_frame(event: DomainEvent, sse_id: str | None) -> str | None:
+def _build_derived_state_frame(event: SessionEvent, sse_id: str | None) -> str | None:
     """Build a derived ``job_state_changed`` SSE frame for events that imply a state transition.
 
     Returns ``None`` when *event* does not trigger a secondary frame.
     """
     if event.kind == DomainEventKind.approval_requested:
         payload = JobStateChangedPayload(
-            job_id=event.job_id,
+            job_id=event.session_id,
             previous_state=event.payload.get("previous_state"),
             new_state=JobState.waiting_for_approval,
             timestamp=event.timestamp,
@@ -635,14 +635,14 @@ def _build_derived_state_frame(event: DomainEvent, sse_id: str | None) -> str | 
     elif event.kind == DomainEventKind.approval_resolved:
         new_state = JobState.running if event.payload.get("resolution") == "approved" else JobState.failed
         payload = JobStateChangedPayload(
-            job_id=event.job_id,
+            job_id=event.session_id,
             previous_state=JobState.waiting_for_approval,
             new_state=new_state,
             timestamp=event.timestamp,
         )
     elif event.kind in (DomainEventKind.job_review, DomainEventKind.job_completed, DomainEventKind.job_failed):
         payload = JobStateChangedPayload(
-            job_id=event.job_id,
+            job_id=event.session_id,
             previous_state=None,
             new_state=_KIND_TO_STATE[event.kind],
             timestamp=event.timestamp,
@@ -687,13 +687,13 @@ class SSEManager:
         """Update the active job count for selective streaming decisions."""
         self._active_job_count = count
 
-    async def broadcast_domain_event(self, event: DomainEvent) -> None:
+    async def broadcast_domain_event(self, event: SessionEvent) -> None:
         """Event bus subscriber — translate and broadcast a domain event."""
         sse_type = _SSE_EVENT_TYPE.get(event.kind)
         if sse_type is None:
             return  # internal-only event
 
-        sse_id = str(event.db_id) if event.db_id is not None else event.event_id
+        sse_id = str(event.metadata.sequence) if event.metadata.sequence is not None else event.id
         frame = _format_sse(sse_id, sse_type, _build_sse_data(event, sse_type))
         selective = self._active_job_count > 20
 
@@ -706,7 +706,7 @@ class SSEManager:
 
             # Job-scoped connection: only deliver events for this job
             if conn.job_id is not None:
-                if event.job_id != conn.job_id:
+                if event.session_id != conn.job_id:
                     continue
                 # Scoped connections always get full streaming
                 conn.send(frame)
@@ -725,7 +725,7 @@ class SSEManager:
         # Emit secondary SSE events per the mapping in §5.3.1
         derived = _build_derived_state_frame(event, sse_id=None)
         if derived is not None:
-            self._broadcast_frame(derived, event.job_id)
+            self._broadcast_frame(derived, event.session_id)
 
     def _broadcast_frame(self, frame: str, job_id: str | None) -> None:
         """Send a pre-formatted frame to all relevant connections."""
@@ -845,7 +845,7 @@ class SSEManager:
             sse_type = _SSE_EVENT_TYPE.get(event.kind)
             if sse_type is None:
                 continue
-            sse_id = str(event.db_id) if event.db_id is not None else event.event_id
+            sse_id = str(event.metadata.sequence) if event.metadata.sequence is not None else event.id
             frame = _format_sse(sse_id, sse_type, _build_sse_data(event, sse_type))
             conn.send(frame)
 

--- a/backend/services/events/sse_manager.py
+++ b/backend/services/events/sse_manager.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 import structlog
 
 from backend.models.api_schemas import ApprovalResponse, SnapshotPayload
-from backend.models.events import TRANSCRIPT_KINDS, CPEventKind, SessionEvent
+from backend.models.events import TRANSCRIPT_KINDS, EventKind, SessionEvent
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -32,42 +32,42 @@ log = structlog.get_logger()
 # are computed by the frontend from these dotted kinds, not synthesized here.
 _BROADCAST_KINDS: frozenset[str] = frozenset(
     {
-        CPEventKind.job_created,
-        CPEventKind.job_setup_progress,
-        CPEventKind.log_line_emitted,
-        CPEventKind.diff_updated,
-        CPEventKind.approval_requested,
-        CPEventKind.approval_resolved,
-        CPEventKind.batch_approval_requested,
-        CPEventKind.batch_approval_resolved,
-        CPEventKind.job_review,
-        CPEventKind.job_completed,
-        CPEventKind.job_failed,
-        CPEventKind.job_canceled,
-        CPEventKind.job_state_changed,
-        CPEventKind.session_heartbeat,
-        CPEventKind.merge_completed,
-        CPEventKind.merge_conflict,
-        CPEventKind.session_resumed,
-        CPEventKind.job_resolved,
-        CPEventKind.job_archived,
-        CPEventKind.job_title_updated,
-        CPEventKind.model_downgraded,
-        CPEventKind.tool_group_summary,
-        CPEventKind.telemetry_updated,
-        CPEventKind.plan_step_updated,
-        CPEventKind.step_entries_reassigned,
-        CPEventKind.turn_summary,
-        CPEventKind.action_classified,
-        CPEventKind.policy_settings_changed,
-        CPEventKind.repo_index_progress,
-        CPEventKind.repo_index_complete,
-        CPEventKind.structural_warning,
-        CPEventKind.stall_detected,
-        CPEventKind.secondary_session_started,
-        CPEventKind.secondary_session_entry,
-        CPEventKind.secondary_session_completed,
-        CPEventKind.context_handoff,
+        EventKind.job_created,
+        EventKind.job_setup_progress,
+        EventKind.log_line_emitted,
+        EventKind.diff_updated,
+        EventKind.approval_requested,
+        EventKind.approval_resolved,
+        EventKind.batch_approval_requested,
+        EventKind.batch_approval_resolved,
+        EventKind.job_review,
+        EventKind.job_completed,
+        EventKind.job_failed,
+        EventKind.job_canceled,
+        EventKind.job_state_changed,
+        EventKind.session_heartbeat,
+        EventKind.merge_completed,
+        EventKind.merge_conflict,
+        EventKind.session_resumed,
+        EventKind.job_resolved,
+        EventKind.job_archived,
+        EventKind.job_title_updated,
+        EventKind.model_downgraded,
+        EventKind.tool_group_summary,
+        EventKind.telemetry_updated,
+        EventKind.plan_step_updated,
+        EventKind.step_entries_reassigned,
+        EventKind.turn_summary,
+        EventKind.action_classified,
+        EventKind.policy_settings_changed,
+        EventKind.repo_index_progress,
+        EventKind.repo_index_complete,
+        EventKind.structural_warning,
+        EventKind.stall_detected,
+        EventKind.secondary_session_started,
+        EventKind.secondary_session_entry,
+        EventKind.secondary_session_completed,
+        EventKind.context_handoff,
     }
     | TRANSCRIPT_KINDS
 )
@@ -75,9 +75,9 @@ _BROADCAST_KINDS: frozenset[str] = frozenset(
 # High-frequency dotted kinds suppressed in selective mode (>20 active jobs)
 _SELECTIVE_SUPPRESSED: frozenset[str] = frozenset(
     {
-        CPEventKind.log_line_emitted,
-        CPEventKind.diff_updated,
-        CPEventKind.session_heartbeat,
+        EventKind.log_line_emitted,
+        EventKind.diff_updated,
+        EventKind.session_heartbeat,
     }
     | TRANSCRIPT_KINDS
 )
@@ -87,8 +87,8 @@ _SELECTIVE_SUPPRESSED: frozenset[str] = frozenset(
 # a specific job's detail panel.
 _JOB_SCOPED_ONLY: frozenset[str] = frozenset(
     {
-        CPEventKind.telemetry_updated,
-        CPEventKind.secondary_session_entry,
+        EventKind.telemetry_updated,
+        EventKind.secondary_session_entry,
     }
 )
 

--- a/backend/services/job/job_service.py
+++ b/backend/services/job/job_service.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
     from backend.config import CPLConfig
-    from backend.models.events import CPEventKind, SessionEvent
+    from backend.models.events import EventKind, SessionEvent
     from backend.persistence.event_repo import EventRepository
     from backend.persistence.job_repo import JobRepository
     from backend.services.coderecon.coderecon_service import CodeReconService
@@ -126,7 +126,7 @@ class JobService:
     async def list_events_by_job(
         self,
         job_id: str,
-        kinds: list[CPEventKind],
+        kinds: list[EventKind],
         limit: int = 2000,
     ) -> list[SessionEvent]:
         """Query domain events for a job, filtered by kind.
@@ -410,7 +410,7 @@ class JobService:
         Returns the updated Job.
         Raises JobNotFoundError / StateConflictError on bad state.
         """
-        from backend.models.events import CPEventKind, new_event
+        from backend.models.events import EventKind, new_event
 
         if self._git is None:
             raise ServiceInitError("GitService required for workspace setup")
@@ -427,7 +427,7 @@ class JobService:
                     new_event(
                         session_id=job_id,
                         timestamp=datetime.now(UTC),
-                        kind=CPEventKind.job_setup_progress,
+                        kind=EventKind.job_setup_progress,
                         payload={"step": step},
                     )
                 )
@@ -663,7 +663,7 @@ class JobService:
         Returns (resolution, pr_url, conflict_files, error, events_to_publish).
         The caller should commit the session and then publish the events.
         """
-        from backend.models.events import CPEventKind, new_event
+        from backend.models.events import EventKind, new_event
 
         resolution, pr_url, conflict_files, error = await self.execute_resolve(
             job=job,
@@ -686,7 +686,7 @@ class JobService:
                 new_event(
                     session_id=job.id,
                     timestamp=datetime.now(UTC),
-                    kind=CPEventKind.job_completed,
+                    kind=EventKind.job_completed,
                     payload={
                         "resolution": resolution,
                         "merge_status": resolution,
@@ -703,11 +703,11 @@ class JobService:
         Fetches the latest merge_conflict event for the job to identify
         conflicting files, then constructs a structured resolution prompt.
         """
-        from backend.models.events import CPEventKind
+        from backend.models.events import EventKind
 
         conflict_events = await self.list_events_by_job(
             job_id,
-            kinds=[CPEventKind.merge_conflict],
+            kinds=[EventKind.merge_conflict],
         )
         conflict_files: list[str] = []
         if conflict_events:
@@ -740,7 +740,7 @@ class JobService:
         error: str | None = None,
     ) -> SessionEvent:
         """Build a job_resolved event for publication after the caller commits."""
-        from backend.models.events import CPEventKind, new_event
+        from backend.models.events import EventKind, new_event
 
         payload: dict[str, object] = {"resolution": resolution}
         if pr_url:
@@ -751,7 +751,7 @@ class JobService:
             payload["error"] = error
 
         return new_event(
-            session_id=job_id, timestamp=datetime.now(UTC), kind=CPEventKind.job_resolved, payload=payload
+            session_id=job_id, timestamp=datetime.now(UTC), kind=EventKind.job_resolved, payload=payload
         )
 
     async def archive_job(self, job_id: str) -> Job:
@@ -787,6 +787,6 @@ class JobService:
 
     def build_job_archived_event(self, job_id: str) -> SessionEvent:
         """Build a job_archived event for publication after the caller commits."""
-        from backend.models.events import CPEventKind, new_event
+        from backend.models.events import EventKind, new_event
 
-        return new_event(session_id=job_id, timestamp=datetime.now(UTC), kind=CPEventKind.job_archived, payload={})
+        return new_event(session_id=job_id, timestamp=datetime.now(UTC), kind=EventKind.job_archived, payload={})

--- a/backend/services/job/job_service.py
+++ b/backend/services/job/job_service.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
     from backend.config import CPLConfig
-    from backend.models.events import DomainEventKind, SessionEvent
+    from backend.models.events import CPEventKind, SessionEvent
     from backend.persistence.event_repo import EventRepository
     from backend.persistence.job_repo import JobRepository
     from backend.services.coderecon.coderecon_service import CodeReconService
@@ -126,7 +126,7 @@ class JobService:
     async def list_events_by_job(
         self,
         job_id: str,
-        kinds: list[DomainEventKind],
+        kinds: list[CPEventKind],
         limit: int = 2000,
     ) -> list[SessionEvent]:
         """Query domain events for a job, filtered by kind.
@@ -410,7 +410,7 @@ class JobService:
         Returns the updated Job.
         Raises JobNotFoundError / StateConflictError on bad state.
         """
-        from backend.models.events import DomainEventKind, new_event
+        from backend.models.events import CPEventKind, new_event
 
         if self._git is None:
             raise ServiceInitError("GitService required for workspace setup")
@@ -427,7 +427,7 @@ class JobService:
                     new_event(
                         session_id=job_id,
                         timestamp=datetime.now(UTC),
-                        kind=DomainEventKind.job_setup_progress,
+                        kind=CPEventKind.job_setup_progress,
                         payload={"step": step},
                     )
                 )
@@ -663,7 +663,7 @@ class JobService:
         Returns (resolution, pr_url, conflict_files, error, events_to_publish).
         The caller should commit the session and then publish the events.
         """
-        from backend.models.events import DomainEventKind, new_event
+        from backend.models.events import CPEventKind, new_event
 
         resolution, pr_url, conflict_files, error = await self.execute_resolve(
             job=job,
@@ -686,7 +686,7 @@ class JobService:
                 new_event(
                     session_id=job.id,
                     timestamp=datetime.now(UTC),
-                    kind=DomainEventKind.job_completed,
+                    kind=CPEventKind.job_completed,
                     payload={
                         "resolution": resolution,
                         "merge_status": resolution,
@@ -703,11 +703,11 @@ class JobService:
         Fetches the latest merge_conflict event for the job to identify
         conflicting files, then constructs a structured resolution prompt.
         """
-        from backend.models.events import DomainEventKind
+        from backend.models.events import CPEventKind
 
         conflict_events = await self.list_events_by_job(
             job_id,
-            kinds=[DomainEventKind.merge_conflict],
+            kinds=[CPEventKind.merge_conflict],
         )
         conflict_files: list[str] = []
         if conflict_events:
@@ -740,7 +740,7 @@ class JobService:
         error: str | None = None,
     ) -> SessionEvent:
         """Build a job_resolved event for publication after the caller commits."""
-        from backend.models.events import DomainEventKind, new_event
+        from backend.models.events import CPEventKind, new_event
 
         payload: dict[str, object] = {"resolution": resolution}
         if pr_url:
@@ -751,7 +751,7 @@ class JobService:
             payload["error"] = error
 
         return new_event(
-            session_id=job_id, timestamp=datetime.now(UTC), kind=DomainEventKind.job_resolved, payload=payload
+            session_id=job_id, timestamp=datetime.now(UTC), kind=CPEventKind.job_resolved, payload=payload
         )
 
     async def archive_job(self, job_id: str) -> Job:
@@ -787,6 +787,6 @@ class JobService:
 
     def build_job_archived_event(self, job_id: str) -> SessionEvent:
         """Build a job_archived event for publication after the caller commits."""
-        from backend.models.events import DomainEventKind, new_event
+        from backend.models.events import CPEventKind, new_event
 
-        return new_event(session_id=job_id, timestamp=datetime.now(UTC), kind=DomainEventKind.job_archived, payload={})
+        return new_event(session_id=job_id, timestamp=datetime.now(UTC), kind=CPEventKind.job_archived, payload={})

--- a/backend/services/job/job_service.py
+++ b/backend/services/job/job_service.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
     from backend.config import CPLConfig
-    from backend.models.events import DomainEvent, DomainEventKind
+    from backend.models.events import DomainEventKind, SessionEvent
     from backend.persistence.event_repo import EventRepository
     from backend.persistence.job_repo import JobRepository
     from backend.services.coderecon.coderecon_service import CodeReconService
@@ -128,7 +128,7 @@ class JobService:
         job_id: str,
         kinds: list[DomainEventKind],
         limit: int = 2000,
-    ) -> list[DomainEvent]:
+    ) -> list[SessionEvent]:
         """Query domain events for a job, filtered by kind.
 
         Delegates to the event repository so that API routes never need
@@ -410,7 +410,7 @@ class JobService:
         Returns the updated Job.
         Raises JobNotFoundError / StateConflictError on bad state.
         """
-        from backend.models.events import DomainEvent, DomainEventKind
+        from backend.models.events import DomainEventKind, new_event
 
         if self._git is None:
             raise ServiceInitError("GitService required for workspace setup")
@@ -424,9 +424,8 @@ class JobService:
         async def _emit_progress(step: str) -> None:
             if self._event_bus is not None:
                 await self._event_bus.publish(
-                    DomainEvent(
-                        event_id=DomainEvent.make_event_id(),
-                        job_id=job_id,
+                    new_event(
+                        session_id=job_id,
                         timestamp=datetime.now(UTC),
                         kind=DomainEventKind.job_setup_progress,
                         payload={"step": step},
@@ -658,13 +657,13 @@ class JobService:
         job: Job,
         action: str,
         merge_service: MergeService,
-    ) -> tuple[Resolution, str | None, list[str] | None, str | None, list[DomainEvent]]:
+    ) -> tuple[Resolution, str | None, list[str] | None, str | None, list[SessionEvent]]:
         """Full resolve protocol: execute merge, persist result, build events.
 
         Returns (resolution, pr_url, conflict_files, error, events_to_publish).
         The caller should commit the session and then publish the events.
         """
-        from backend.models.events import DomainEvent, DomainEventKind
+        from backend.models.events import DomainEventKind, new_event
 
         resolution, pr_url, conflict_files, error = await self.execute_resolve(
             job=job,
@@ -672,7 +671,7 @@ class JobService:
             merge_service=merge_service,
         )
 
-        events: list[DomainEvent] = [
+        events: list[SessionEvent] = [
             self.build_job_resolved_event(
                 job.id,
                 resolution,
@@ -684,9 +683,8 @@ class JobService:
 
         if resolution in (Resolution.merged, Resolution.pr_created, Resolution.discarded):
             events.append(
-                DomainEvent(
-                    event_id=DomainEvent.make_event_id(),
-                    job_id=job.id,
+                new_event(
+                    session_id=job.id,
                     timestamp=datetime.now(UTC),
                     kind=DomainEventKind.job_completed,
                     payload={
@@ -740,9 +738,9 @@ class JobService:
         pr_url: str | None = None,
         conflict_files: list[str] | None = None,
         error: str | None = None,
-    ) -> DomainEvent:
+    ) -> SessionEvent:
         """Build a job_resolved event for publication after the caller commits."""
-        from backend.models.events import DomainEvent, DomainEventKind
+        from backend.models.events import DomainEventKind, new_event
 
         payload: dict[str, object] = {"resolution": resolution}
         if pr_url:
@@ -752,12 +750,8 @@ class JobService:
         if error:
             payload["error"] = error
 
-        return DomainEvent(
-            event_id=DomainEvent.make_event_id(),
-            job_id=job_id,
-            timestamp=datetime.now(UTC),
-            kind=DomainEventKind.job_resolved,
-            payload=payload,
+        return new_event(
+            session_id=job_id, timestamp=datetime.now(UTC), kind=DomainEventKind.job_resolved, payload=payload
         )
 
     async def archive_job(self, job_id: str) -> Job:
@@ -791,14 +785,8 @@ class JobService:
 
         return await self.get_job(job_id)
 
-    def build_job_archived_event(self, job_id: str) -> DomainEvent:
+    def build_job_archived_event(self, job_id: str) -> SessionEvent:
         """Build a job_archived event for publication after the caller commits."""
-        from backend.models.events import DomainEvent, DomainEventKind
+        from backend.models.events import DomainEventKind, new_event
 
-        return DomainEvent(
-            event_id=DomainEvent.make_event_id(),
-            job_id=job_id,
-            timestamp=datetime.now(UTC),
-            kind=DomainEventKind.job_archived,
-            payload={},
-        )
+        return new_event(session_id=job_id, timestamp=datetime.now(UTC), kind=DomainEventKind.job_archived, payload={})

--- a/backend/services/merge_service/_service.py
+++ b/backend/services/merge_service/_service.py
@@ -12,7 +12,7 @@ import structlog
 from sqlalchemy.exc import SQLAlchemyError
 
 from backend.models.domain import GitMergeOutcome
-from backend.models.events import DomainEventKind, new_event
+from backend.models.events import CPEventKind, new_event
 from backend.services.git.git_service import GitError
 from backend.services.merge_service._types import (
     _NOT_MERGED,
@@ -478,7 +478,7 @@ class MergeService:
             new_event(
                 session_id=job_id,
                 timestamp=datetime.now(UTC),
-                kind=DomainEventKind.merge_completed,
+                kind=CPEventKind.merge_completed,
                 payload={
                     "branch": branch,
                     "base_ref": base_ref,
@@ -501,7 +501,7 @@ class MergeService:
             new_event(
                 session_id=job_id,
                 timestamp=datetime.now(UTC),
-                kind=DomainEventKind.merge_conflict,
+                kind=CPEventKind.merge_conflict,
                 payload={
                     "branch": branch,
                     "base_ref": base_ref,

--- a/backend/services/merge_service/_service.py
+++ b/backend/services/merge_service/_service.py
@@ -12,7 +12,7 @@ import structlog
 from sqlalchemy.exc import SQLAlchemyError
 
 from backend.models.domain import GitMergeOutcome
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, new_event
 from backend.services.git.git_service import GitError
 from backend.services.merge_service._types import (
     _NOT_MERGED,
@@ -475,9 +475,8 @@ class MergeService:
         strategy: str,
     ) -> None:
         await self._event_bus.publish(
-            DomainEvent(
-                event_id=DomainEvent.make_event_id(),
-                job_id=job_id,
+            new_event(
+                session_id=job_id,
                 timestamp=datetime.now(UTC),
                 kind=DomainEventKind.merge_completed,
                 payload={
@@ -499,9 +498,8 @@ class MergeService:
         pr_url: str | None = None,
     ) -> None:
         await self._event_bus.publish(
-            DomainEvent(
-                event_id=DomainEvent.make_event_id(),
-                job_id=job_id,
+            new_event(
+                session_id=job_id,
                 timestamp=datetime.now(UTC),
                 kind=DomainEventKind.merge_conflict,
                 payload={

--- a/backend/services/merge_service/_service.py
+++ b/backend/services/merge_service/_service.py
@@ -12,7 +12,7 @@ import structlog
 from sqlalchemy.exc import SQLAlchemyError
 
 from backend.models.domain import GitMergeOutcome
-from backend.models.events import CPEventKind, new_event
+from backend.models.events import EventKind, new_event
 from backend.services.git.git_service import GitError
 from backend.services.merge_service._types import (
     _NOT_MERGED,
@@ -478,7 +478,7 @@ class MergeService:
             new_event(
                 session_id=job_id,
                 timestamp=datetime.now(UTC),
-                kind=CPEventKind.merge_completed,
+                kind=EventKind.merge_completed,
                 payload={
                     "branch": branch,
                     "base_ref": base_ref,
@@ -501,7 +501,7 @@ class MergeService:
             new_event(
                 session_id=job_id,
                 timestamp=datetime.now(UTC),
-                kind=CPEventKind.merge_conflict,
+                kind=EventKind.merge_conflict,
                 payload={
                     "branch": branch,
                     "base_ref": base_ref,

--- a/backend/services/runtime/resume.py
+++ b/backend/services/runtime/resume.py
@@ -26,7 +26,7 @@ from backend.models.domain import (
     Resolution,
     StateConflictError,
 )
-from backend.models.events import CPEventKind, new_event, transcript_kind_for_role
+from backend.models.events import EventKind, new_event, transcript_kind_for_role
 from backend.persistence.job_repo import JobRepository
 
 if TYPE_CHECKING:
@@ -204,7 +204,7 @@ async def recover_active_job(
         new_event(
             session_id=job_id,
             timestamp=now,
-            kind=CPEventKind.session_resumed,
+            kind=EventKind.session_resumed,
             payload={
                 "session_number": new_session_count,
                 "instruction": instruction,
@@ -426,7 +426,7 @@ async def resume_job(host: RuntimeService, job_id: str, instruction: str | None 
         new_event(
             session_id=job_id,
             timestamp=now,
-            kind=CPEventKind.session_resumed,
+            kind=EventKind.session_resumed,
             payload={
                 "session_number": new_session_count,
                 "instruction": normalized_instruction,
@@ -442,7 +442,7 @@ async def resume_job(host: RuntimeService, job_id: str, instruction: str | None 
             new_event(
                 session_id=job_id,
                 timestamp=now,
-                kind=CPEventKind.context_handoff,
+                kind=EventKind.context_handoff,
                 payload={
                     "source": "resume",
                     "summary": f"Carried forward context from session {previous_session_count}",
@@ -456,7 +456,7 @@ async def resume_job(host: RuntimeService, job_id: str, instruction: str | None 
             new_event(
                 session_id=job_id,
                 timestamp=now,
-                kind=CPEventKind.context_handoff,
+                kind=EventKind.context_handoff,
                 payload={
                     "source": "resume_native",
                     "summary": f"Resumed SDK session (full history from session {previous_session_count})",
@@ -550,7 +550,7 @@ async def create_followup_job(host: RuntimeService, job_id: str, instruction: st
             new_event(
                 session_id=followup.id,
                 timestamp=datetime.now(UTC),
-                kind=CPEventKind.context_handoff,
+                kind=EventKind.context_handoff,
                 payload={
                     "source": "followup",
                     "summary": f"Continuing from parent job '{parent_label}'",

--- a/backend/services/runtime/resume.py
+++ b/backend/services/runtime/resume.py
@@ -26,7 +26,7 @@ from backend.models.domain import (
     Resolution,
     StateConflictError,
 )
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, new_event
 from backend.persistence.job_repo import JobRepository
 
 if TYPE_CHECKING:
@@ -201,9 +201,8 @@ async def recover_active_job(
 
     now = datetime.now(UTC)
     await host._event_bus.publish(
-        DomainEvent(
-            event_id=DomainEvent.make_event_id(),
-            job_id=job_id,
+        new_event(
+            session_id=job_id,
             timestamp=now,
             kind=DomainEventKind.session_resumed,
             payload={
@@ -424,9 +423,8 @@ async def resume_job(host: RuntimeService, job_id: str, instruction: str | None 
     # see a false-positive resume when task initialization fails.
     now = datetime.now(UTC)
     await host._event_bus.publish(
-        DomainEvent(
-            event_id=DomainEvent.make_event_id(),
-            job_id=job_id,
+        new_event(
+            session_id=job_id,
             timestamp=now,
             kind=DomainEventKind.session_resumed,
             payload={
@@ -441,9 +439,8 @@ async def resume_job(host: RuntimeService, job_id: str, instruction: str | None 
     if resume_sdk_session_id is None:
         # Summarization-based resume — context was compiled from prior session
         await host._event_bus.publish(
-            DomainEvent(
-                event_id=DomainEvent.make_event_id(),
-                job_id=job_id,
+            new_event(
+                session_id=job_id,
                 timestamp=now,
                 kind=DomainEventKind.context_handoff,
                 payload={
@@ -456,9 +453,8 @@ async def resume_job(host: RuntimeService, job_id: str, instruction: str | None 
     else:
         # Native SDK resume — full conversation history intact
         await host._event_bus.publish(
-            DomainEvent(
-                event_id=DomainEvent.make_event_id(),
-                job_id=job_id,
+            new_event(
+                session_id=job_id,
                 timestamp=now,
                 kind=DomainEventKind.context_handoff,
                 payload={
@@ -470,9 +466,8 @@ async def resume_job(host: RuntimeService, job_id: str, instruction: str | None 
         )
 
     await host._event_bus.publish(
-        DomainEvent(
-            event_id=DomainEvent.make_event_id(),
-            job_id=job_id,
+        new_event(
+            session_id=job_id,
             timestamp=now,
             kind=DomainEventKind.transcript_updated,
             payload={
@@ -552,9 +547,8 @@ async def create_followup_job(host: RuntimeService, job_id: str, instruction: st
 
         # Emit context_handoff for the new follow-up job
         await host._event_bus.publish(
-            DomainEvent(
-                event_id=DomainEvent.make_event_id(),
-                job_id=followup.id,
+            new_event(
+                session_id=followup.id,
                 timestamp=datetime.now(UTC),
                 kind=DomainEventKind.context_handoff,
                 payload={

--- a/backend/services/runtime/resume.py
+++ b/backend/services/runtime/resume.py
@@ -26,7 +26,7 @@ from backend.models.domain import (
     Resolution,
     StateConflictError,
 )
-from backend.models.events import DomainEventKind, new_event
+from backend.models.events import CPEventKind, new_event, transcript_kind_for_role
 from backend.persistence.job_repo import JobRepository
 
 if TYPE_CHECKING:
@@ -204,7 +204,7 @@ async def recover_active_job(
         new_event(
             session_id=job_id,
             timestamp=now,
-            kind=DomainEventKind.session_resumed,
+            kind=CPEventKind.session_resumed,
             payload={
                 "session_number": new_session_count,
                 "instruction": instruction,
@@ -426,7 +426,7 @@ async def resume_job(host: RuntimeService, job_id: str, instruction: str | None 
         new_event(
             session_id=job_id,
             timestamp=now,
-            kind=DomainEventKind.session_resumed,
+            kind=CPEventKind.session_resumed,
             payload={
                 "session_number": new_session_count,
                 "instruction": normalized_instruction,
@@ -442,7 +442,7 @@ async def resume_job(host: RuntimeService, job_id: str, instruction: str | None 
             new_event(
                 session_id=job_id,
                 timestamp=now,
-                kind=DomainEventKind.context_handoff,
+                kind=CPEventKind.context_handoff,
                 payload={
                     "source": "resume",
                     "summary": f"Carried forward context from session {previous_session_count}",
@@ -456,7 +456,7 @@ async def resume_job(host: RuntimeService, job_id: str, instruction: str | None 
             new_event(
                 session_id=job_id,
                 timestamp=now,
-                kind=DomainEventKind.context_handoff,
+                kind=CPEventKind.context_handoff,
                 payload={
                     "source": "resume_native",
                     "summary": f"Resumed SDK session (full history from session {previous_session_count})",
@@ -469,7 +469,7 @@ async def resume_job(host: RuntimeService, job_id: str, instruction: str | None 
         new_event(
             session_id=job_id,
             timestamp=now,
-            kind=DomainEventKind.transcript_updated,
+            kind=transcript_kind_for_role(TranscriptRole.operator),
             payload={
                 "job_id": job_id,
                 "seq": 0,
@@ -550,7 +550,7 @@ async def create_followup_job(host: RuntimeService, job_id: str, instruction: st
             new_event(
                 session_id=followup.id,
                 timestamp=datetime.now(UTC),
-                kind=DomainEventKind.context_handoff,
+                kind=CPEventKind.context_handoff,
                 payload={
                     "source": "followup",
                     "summary": f"Continuing from parent job '{parent_label}'",

--- a/backend/services/runtime/service.py
+++ b/backend/services/runtime/service.py
@@ -39,10 +39,12 @@ from backend.models.domain import (
     Resolution,
     ServiceInitError,
     SessionConfig,
-    SessionEvent,
     SessionEventKind,
 )
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.domain import (
+    SessionEvent as CPSessionEvent,
+)
+from backend.models.events import DomainEventKind, SessionEvent, new_event
 from backend.persistence.job_repo import JobRepository
 from backend.services.job.job_service import JobService
 from backend.services.runtime.handoff import (
@@ -107,7 +109,7 @@ class AgentSession:
         self,
         config: SessionConfig,
         adapter: AgentAdapterInterface,
-    ) -> AsyncIterator[SessionEvent]:
+    ) -> AsyncIterator[CPSessionEvent]:
         self._adapter = adapter
         self._session_id = await adapter.create_session(config)
         async for event in adapter.stream_events(self._session_id):
@@ -209,7 +211,7 @@ Respond with ONLY one JSON object:
 """
 
 
-def _session_event_counts_as_resume_progress(event: SessionEvent) -> bool:
+def _session_event_counts_as_resume_progress(event: CPSessionEvent) -> bool:
     """Return True once a resumed session has produced real agent work."""
     if event.kind in (
         SessionEventKind.file_changed,
@@ -377,9 +379,8 @@ class RuntimeService:
                     async with serialized_write(self._session_factory) as ws:
                         await JobRepository(ws).update_title_and_branch(job_id, title=title)
                     await self._event_bus.publish(
-                        DomainEvent(
-                            event_id=DomainEvent.make_event_id(),
-                            job_id=job_id,
+                        new_event(
+                            session_id=job_id,
                             timestamp=datetime.now(UTC),
                             kind=DomainEventKind.job_title_updated,
                             payload={"title": title},
@@ -776,9 +777,8 @@ class RuntimeService:
         # Emit environment_setup phase
         self._resolve_adapter(config.sdk).set_execution_phase(job_id, ExecutionPhase.environment_setup)
         await self._event_bus.publish(
-            DomainEvent(
-                event_id=DomainEvent.make_event_id(),
-                job_id=job_id,
+            new_event(
+                session_id=job_id,
                 timestamp=datetime.now(UTC),
                 kind=DomainEventKind.execution_phase_changed,
                 payload={"phase": ExecutionPhase.environment_setup},
@@ -818,9 +818,8 @@ class RuntimeService:
             # Emit agent_reasoning phase before main session execution
             self._resolve_adapter(config.sdk).set_execution_phase(job_id, ExecutionPhase.agent_reasoning)
             await self._event_bus.publish(
-                DomainEvent(
-                    event_id=DomainEvent.make_event_id(),
-                    job_id=job_id,
+                new_event(
+                    session_id=job_id,
                     timestamp=datetime.now(UTC),
                     kind=DomainEventKind.execution_phase_changed,
                     payload={"phase": ExecutionPhase.agent_reasoning},
@@ -934,9 +933,8 @@ class RuntimeService:
             await session.commit()
 
         await self._event_bus.publish(
-            DomainEvent(
-                event_id=DomainEvent.make_event_id(),
-                job_id=job_id,
+            new_event(
+                session_id=job_id,
                 timestamp=datetime.now(UTC),
                 kind=DomainEventKind.job_review,
                 payload={
@@ -1041,9 +1039,8 @@ class RuntimeService:
 
         await self._set_step_terminal_state(job_id, final_state)
         await self._event_bus.publish(
-            DomainEvent(
-                event_id=DomainEvent.make_event_id(),
-                job_id=job_id,
+            new_event(
+                session_id=job_id,
                 timestamp=datetime.now(UTC),
                 kind=final_event_kind,
                 payload={
@@ -1196,7 +1193,7 @@ class RuntimeService:
             action_rules=len(action_rules),
         )
 
-    async def _on_policy_settings_changed(self, event: DomainEvent) -> None:
+    async def _on_policy_settings_changed(self, event: SessionEvent) -> None:
         """Reload action policy for all running jobs when settings change."""
         if event.kind != DomainEventKind.policy_settings_changed:
             return
@@ -1370,9 +1367,8 @@ class RuntimeService:
                     await session.commit()
                     await self._set_step_terminal_state(job_id, JobState.failed)
                     await self._event_bus.publish(
-                        DomainEvent(
-                            event_id=DomainEvent.make_event_id(),
-                            job_id=job_id,
+                        new_event(
+                            session_id=job_id,
                             timestamp=datetime.now(UTC),
                             kind=DomainEventKind.job_failed,
                             payload={"reason": "Job cleanup: previous error handlers failed to transition state"},
@@ -1384,7 +1380,7 @@ class RuntimeService:
     async def _handle_approval_request(
         self,
         job_id: str,
-        domain_event: DomainEvent,
+        domain_event: SessionEvent,
         rejection_message: str,
     ) -> ApprovalResolution:
         """Handle an approval_requested event: transition state, wait for operator, return resolution."""
@@ -1406,9 +1402,8 @@ class RuntimeService:
         resolution = await self._approval_service.wait_for_resolution(approval_id)
 
         await self._event_bus.publish(
-            DomainEvent(
-                event_id=DomainEvent.make_event_id(),
-                job_id=job_id,
+            new_event(
+                session_id=job_id,
                 timestamp=datetime.now(UTC),
                 kind=DomainEventKind.approval_resolved,
                 payload={
@@ -1479,9 +1474,8 @@ class RuntimeService:
                     await session.commit()
                     await self._set_step_terminal_state(job_id, JobState.canceled)
                     await self._event_bus.publish(
-                        DomainEvent(
-                            event_id=DomainEvent.make_event_id(),
-                            job_id=job_id,
+                        new_event(
+                            session_id=job_id,
                             timestamp=datetime.now(UTC),
                             kind=DomainEventKind.job_canceled,
                             payload={"reason": "operator_cancel"},
@@ -1545,10 +1539,10 @@ class RuntimeService:
     async def feed_external_event(
         self,
         job_id: str,
-        session_event: SessionEvent,
+        session_event: CPSessionEvent,
         worktree_path: str | None = None,
         base_ref: str | None = None,
-    ) -> DomainEvent | None:
+    ) -> SessionEvent | None:
         """Process a single event from an externally-managed session.
 
         Applies the full managed-session pipeline: tool tracking, diff
@@ -1679,12 +1673,12 @@ class RuntimeService:
     async def _process_agent_event(
         self,
         job_id: str,
-        session_event: SessionEvent,
+        session_event: CPSessionEvent,
         agent_session: AgentSession | None,
         worktree_path: str | None,
         base_ref: str | None,
         rejection_message: str,
-    ) -> tuple[EventAction, DomainEvent | None, str | None]:
+    ) -> tuple[EventAction, SessionEvent | None, str | None]:
         """Process a single agent session event (shared by main + follow-up loops).
 
         When *agent_session* is ``None`` (external/imported sessions), approval
@@ -1941,13 +1935,7 @@ class RuntimeService:
                     payload["active_tool_since"] = active[1]
 
                 await self._event_bus.publish(
-                    DomainEvent(
-                        event_id=DomainEvent.make_event_id(),
-                        job_id=job_id,
-                        timestamp=now,
-                        kind=DomainEventKind.session_heartbeat,
-                        payload=payload,
-                    )
+                    new_event(session_id=job_id, timestamp=now, kind=DomainEventKind.session_heartbeat, payload=payload)
                 )
 
                 # --- Stall detection via sidecar session ---
@@ -2044,9 +2032,8 @@ class RuntimeService:
         """Interrupt the stalled tool and re-prompt the agent."""
         # Publish stall event for UI visibility
         await self._event_bus.publish(
-            DomainEvent(
-                event_id=DomainEvent.make_event_id(),
-                job_id=job_id,
+            new_event(
+                session_id=job_id,
                 timestamp=datetime.now(UTC),
                 kind=DomainEventKind.stall_detected,
                 payload={
@@ -2133,9 +2120,8 @@ class RuntimeService:
         await agent_session.send_message(message)
         # Publish immediately so the operator message appears in the transcript
         # without waiting for the SDK to echo it back.
-        operator_event = DomainEvent(
-            event_id=DomainEvent.make_event_id(),
-            job_id=job_id,
+        operator_event = new_event(
+            session_id=job_id,
             timestamp=now,
             kind=DomainEventKind.transcript_updated,
             payload={
@@ -2200,9 +2186,8 @@ class RuntimeService:
 
         if resolved:
             await self._event_bus.publish(
-                DomainEvent(
-                    event_id=DomainEvent.make_event_id(),
-                    job_id=job_id,
+                new_event(
+                    session_id=job_id,
                     timestamp=datetime.now(UTC),
                     kind=DomainEventKind.batch_approval_resolved,
                     payload={
@@ -2423,9 +2408,8 @@ class RuntimeService:
         try:
             await asyncio.shield(_do_fail())
             await self._event_bus.publish(
-                DomainEvent(
-                    event_id=DomainEvent.make_event_id(),
-                    job_id=job_id,
+                new_event(
+                    session_id=job_id,
                     timestamp=datetime.now(UTC),
                     kind=DomainEventKind.job_failed,
                     payload={"reason": reason},
@@ -2555,9 +2539,8 @@ class RuntimeService:
     async def _publish_state_event(self, job_id: str, previous_state: str | None, new_state: str) -> None:
         """Publish a job state change event."""
         await self._event_bus.publish(
-            DomainEvent(
-                event_id=DomainEvent.make_event_id(),
-                job_id=job_id,
+            new_event(
+                session_id=job_id,
                 timestamp=datetime.now(UTC),
                 kind=DomainEventKind.job_state_changed,
                 payload={
@@ -2570,16 +2553,15 @@ class RuntimeService:
     async def _emit_setup_progress(self, job_id: str, step: str) -> None:
         """Emit a job_setup_progress event so the frontend can show sub-step text."""
         await self._event_bus.publish(
-            DomainEvent(
-                event_id=DomainEvent.make_event_id(),
-                job_id=job_id,
+            new_event(
+                session_id=job_id,
                 timestamp=datetime.now(UTC),
                 kind=DomainEventKind.job_setup_progress,
                 payload={"step": step},
             )
         )
 
-    def _translate_event(self, job_id: str, event: SessionEvent) -> DomainEvent | None:
+    def _translate_event(self, job_id: str, event: CPSessionEvent) -> SessionEvent | None:
         """Translate a SessionEvent into a DomainEvent."""
         mapping: dict[SessionEventKind, DomainEventKind] = {
             SessionEventKind.log: DomainEventKind.log_line_emitted,
@@ -2592,12 +2574,8 @@ class RuntimeService:
         if kind is None:
             # 'done' events are handled at the _run_job level
             return None
-        return DomainEvent(
-            event_id=DomainEvent.make_event_id(),
-            job_id=job_id,
-            timestamp=datetime.now(UTC),
-            kind=kind,
-            payload=cast("dict[str, Any]", event.payload),
+        return new_event(
+            session_id=job_id, timestamp=datetime.now(UTC), kind=kind, payload=cast("dict[str, Any]", event.payload)
         )
 
     async def recover_on_startup(self) -> None:
@@ -2764,9 +2742,8 @@ class RuntimeService:
         self._waiting_for_approval.add(job_id)
 
         await self._event_bus.publish(
-            DomainEvent(
-                event_id=DomainEvent.make_event_id(),
-                job_id=job_id,
+            new_event(
+                session_id=job_id,
                 timestamp=datetime.now(UTC),
                 kind=DomainEventKind.approval_requested,
                 payload={
@@ -2786,9 +2763,8 @@ class RuntimeService:
         operator_notes = (resolved_approval.notes if resolved_approval else None) or ""
 
         await self._event_bus.publish(
-            DomainEvent(
-                event_id=DomainEvent.make_event_id(),
-                job_id=job_id,
+            new_event(
+                session_id=job_id,
                 timestamp=datetime.now(UTC),
                 kind=DomainEventKind.approval_resolved,
                 payload={
@@ -2869,9 +2845,8 @@ class RuntimeService:
                 self._waiting_for_approval.add(job_id)
 
                 await self._event_bus.publish(
-                    DomainEvent(
-                        event_id=DomainEvent.make_event_id(),
-                        job_id=job_id,
+                    new_event(
+                        session_id=job_id,
                         timestamp=datetime.now(UTC),
                         kind=DomainEventKind.approval_requested,
                         payload={
@@ -2889,9 +2864,8 @@ class RuntimeService:
                 operator_notes = (resolved_approval.notes if resolved_approval else None) or ""
 
                 await self._event_bus.publish(
-                    DomainEvent(
-                        event_id=DomainEvent.make_event_id(),
-                        job_id=job_id,
+                    new_event(
+                        session_id=job_id,
                         timestamp=datetime.now(UTC),
                         kind=DomainEventKind.approval_resolved,
                         payload={
@@ -2933,9 +2907,8 @@ class RuntimeService:
             await job_repo.update_mode(job_id, JobMode.plan_implementing)
         await self._publish_state_event(job_id, JobState.waiting_for_approval, JobState.running)
         await self._event_bus.publish(
-            DomainEvent(
-                event_id=DomainEvent.make_event_id(),
-                job_id=job_id,
+            new_event(
+                session_id=job_id,
                 timestamp=datetime.now(UTC),
                 kind=DomainEventKind.job_mode_changed,
                 payload={
@@ -3033,9 +3006,8 @@ class RuntimeService:
                 started_at=started_at,
             )
             await self._event_bus.publish(
-                DomainEvent(
-                    event_id=DomainEvent.make_event_id(),
-                    job_id=job.id,
+                new_event(
+                    session_id=job.id,
                     timestamp=started_at,
                     kind=DomainEventKind.secondary_session_started,
                     payload={
@@ -3095,9 +3067,8 @@ class RuntimeService:
                     tool_visibility=enriched.get("tool_visibility"),
                 )
                 await self._event_bus.publish(
-                    DomainEvent(
-                        event_id=DomainEvent.make_event_id(),
-                        job_id=job.id,
+                    new_event(
+                        session_id=job.id,
                         timestamp=now,
                         kind=DomainEventKind.secondary_session_entry,
                         payload={"session_id": session_id, "entry": entry_payload},
@@ -3121,9 +3092,8 @@ class RuntimeService:
                     content=text,
                 )
                 await self._event_bus.publish(
-                    DomainEvent(
-                        event_id=DomainEvent.make_event_id(),
-                        job_id=job.id,
+                    new_event(
+                        session_id=job.id,
                         timestamp=now,
                         kind=DomainEventKind.secondary_session_entry,
                         payload={"session_id": session_id, "entry": entry_payload},
@@ -3148,9 +3118,8 @@ class RuntimeService:
                 output=report.brief or None,
             )
             await self._event_bus.publish(
-                DomainEvent(
-                    event_id=DomainEvent.make_event_id(),
-                    job_id=job.id,
+                new_event(
+                    session_id=job.id,
                     timestamp=completed_at,
                     kind=DomainEventKind.secondary_session_completed,
                     payload={
@@ -3170,9 +3139,8 @@ class RuntimeService:
                 )
                 # Emit context_handoff so the frontend can show what was passed
                 await self._event_bus.publish(
-                    DomainEvent(
-                        event_id=DomainEvent.make_event_id(),
-                        job_id=job.id,
+                    new_event(
+                        session_id=job.id,
                         timestamp=completed_at,
                         kind=DomainEventKind.context_handoff,
                         payload={
@@ -3195,9 +3163,8 @@ class RuntimeService:
                     completed_at=datetime.now(UTC),
                 )
                 await self._event_bus.publish(
-                    DomainEvent(
-                        event_id=DomainEvent.make_event_id(),
-                        job_id=job.id,
+                    new_event(
+                        session_id=job.id,
                         timestamp=datetime.now(UTC),
                         kind=DomainEventKind.secondary_session_completed,
                         payload={

--- a/backend/services/runtime/service.py
+++ b/backend/services/runtime/service.py
@@ -46,7 +46,7 @@ from backend.models.domain import (
 )
 from backend.models.events import (
     TRANSCRIPT_KINDS,
-    CPEventKind,
+    EventKind,
     SessionEvent,
     new_event,
     transcript_kind_for_role,
@@ -388,7 +388,7 @@ class RuntimeService:
                         new_event(
                             session_id=job_id,
                             timestamp=datetime.now(UTC),
-                            kind=CPEventKind.job_title_updated,
+                            kind=EventKind.job_title_updated,
                             payload={"title": title},
                         )
                     )
@@ -786,7 +786,7 @@ class RuntimeService:
             new_event(
                 session_id=job_id,
                 timestamp=datetime.now(UTC),
-                kind=CPEventKind.execution_phase_changed,
+                kind=EventKind.execution_phase_changed,
                 payload={"phase": ExecutionPhase.environment_setup},
             )
         )
@@ -827,7 +827,7 @@ class RuntimeService:
                 new_event(
                     session_id=job_id,
                     timestamp=datetime.now(UTC),
-                    kind=CPEventKind.execution_phase_changed,
+                    kind=EventKind.execution_phase_changed,
                     payload={"phase": ExecutionPhase.agent_reasoning},
                 )
             )
@@ -942,7 +942,7 @@ class RuntimeService:
             new_event(
                 session_id=job_id,
                 timestamp=datetime.now(UTC),
-                kind=CPEventKind.job_review,
+                kind=EventKind.job_review,
                 payload={
                     "resolution": Resolution.unresolved,
                     "model_downgraded": True,
@@ -1040,7 +1040,7 @@ class RuntimeService:
         if final_resolution in (Resolution.merged, Resolution.pr_created, Resolution.discarded):
             final_state = JobState.completed
         final_event_kind = (
-            CPEventKind.job_completed if final_state == JobState.completed else CPEventKind.job_review
+            EventKind.job_completed if final_state == JobState.completed else EventKind.job_review
         )
 
         await self._set_step_terminal_state(job_id, final_state)
@@ -1201,7 +1201,7 @@ class RuntimeService:
 
     async def _on_policy_settings_changed(self, event: SessionEvent) -> None:
         """Reload action policy for all running jobs when settings change."""
-        if event.kind != CPEventKind.policy_settings_changed:
+        if event.kind != EventKind.policy_settings_changed:
             return
 
         job_ids = list(self._policy_routers.keys())
@@ -1376,7 +1376,7 @@ class RuntimeService:
                         new_event(
                             session_id=job_id,
                             timestamp=datetime.now(UTC),
-                            kind=CPEventKind.job_failed,
+                            kind=EventKind.job_failed,
                             payload={"reason": "Job cleanup: previous error handlers failed to transition state"},
                         )
                     )
@@ -1411,7 +1411,7 @@ class RuntimeService:
             new_event(
                 session_id=job_id,
                 timestamp=datetime.now(UTC),
-                kind=CPEventKind.approval_resolved,
+                kind=EventKind.approval_resolved,
                 payload={
                     "approval_id": approval_id,
                     "resolution": resolution,
@@ -1483,7 +1483,7 @@ class RuntimeService:
                         new_event(
                             session_id=job_id,
                             timestamp=datetime.now(UTC),
-                            kind=CPEventKind.job_canceled,
+                            kind=EventKind.job_canceled,
                             payload={"reason": "operator_cancel"},
                         )
                     )
@@ -1753,7 +1753,7 @@ class RuntimeService:
                 self._turn_ids[job_id] = str(uuid.uuid4())
 
         error_reason: str | None = None
-        if domain_event.kind == CPEventKind.job_failed:
+        if domain_event.kind == EventKind.job_failed:
             error_reason = str(domain_event.payload.get("message", "Agent error"))
 
         # Suppress SDK echoes
@@ -1766,7 +1766,7 @@ class RuntimeService:
         # Handle approval requests (managed sessions only — external sessions
         # handle their own approvals; we just publish for UI visibility).
         if (
-            domain_event.kind == CPEventKind.approval_requested
+            domain_event.kind == EventKind.approval_requested
             and self._approval_service is not None
             and agent_session is not None
         ):
@@ -1827,7 +1827,7 @@ class RuntimeService:
                 await self._persist_sdk_session_id(job_id, session_id)
 
             # Model downgrade: publish event, abort session, signal caller
-            if domain_event.kind == CPEventKind.model_downgraded:
+            if domain_event.kind == EventKind.model_downgraded:
                 requested = str(domain_event.payload.get("requested_model", ""))
                 actual = str(domain_event.payload.get("actual_model", ""))
                 log.warning(
@@ -1861,7 +1861,7 @@ class RuntimeService:
 
             # Tag log lines with the current session number so callers can filter
             # by session when a job has been resumed one or more times.
-            if domain_event.kind == CPEventKind.log_line_emitted:
+            if domain_event.kind == EventKind.log_line_emitted:
                 domain_event.payload.setdefault("session_number", session_number)
 
             await self._event_bus.publish(domain_event)
@@ -1941,7 +1941,7 @@ class RuntimeService:
                     payload["active_tool_since"] = active[1]
 
                 await self._event_bus.publish(
-                    new_event(session_id=job_id, timestamp=now, kind=CPEventKind.session_heartbeat, payload=payload)
+                    new_event(session_id=job_id, timestamp=now, kind=EventKind.session_heartbeat, payload=payload)
                 )
 
                 # --- Stall detection via sidecar session ---
@@ -2041,7 +2041,7 @@ class RuntimeService:
             new_event(
                 session_id=job_id,
                 timestamp=datetime.now(UTC),
-                kind=CPEventKind.stall_detected,
+                kind=EventKind.stall_detected,
                 payload={
                     "job_id": job_id,
                     "tool_name": tool_name,
@@ -2195,7 +2195,7 @@ class RuntimeService:
                 new_event(
                     session_id=job_id,
                     timestamp=datetime.now(UTC),
-                    kind=CPEventKind.batch_approval_resolved,
+                    kind=EventKind.batch_approval_resolved,
                     payload={
                         "batch_id": batch_id,
                         "resolution": resolution,
@@ -2417,7 +2417,7 @@ class RuntimeService:
                 new_event(
                     session_id=job_id,
                     timestamp=datetime.now(UTC),
-                    kind=CPEventKind.job_failed,
+                    kind=EventKind.job_failed,
                     payload={"reason": reason},
                 )
             )
@@ -2548,7 +2548,7 @@ class RuntimeService:
             new_event(
                 session_id=job_id,
                 timestamp=datetime.now(UTC),
-                kind=CPEventKind.job_state_changed,
+                kind=EventKind.job_state_changed,
                 payload={
                     "previous_state": previous_state,
                     "new_state": new_state,
@@ -2562,20 +2562,20 @@ class RuntimeService:
             new_event(
                 session_id=job_id,
                 timestamp=datetime.now(UTC),
-                kind=CPEventKind.job_setup_progress,
+                kind=EventKind.job_setup_progress,
                 payload={"step": step},
             )
         )
 
     def _translate_event(self, job_id: str, event: CPSessionEvent) -> SessionEvent | None:
         """Translate a SessionEvent into a DomainEvent."""
-        mapping: dict[SessionEventKind, CPEventKind] = {
-            SessionEventKind.log: CPEventKind.log_line_emitted,
-            SessionEventKind.approval_request: CPEventKind.approval_requested,
-            SessionEventKind.error: CPEventKind.job_failed,
-            SessionEventKind.model_downgraded: CPEventKind.model_downgraded,
+        mapping: dict[SessionEventKind, EventKind] = {
+            SessionEventKind.log: EventKind.log_line_emitted,
+            SessionEventKind.approval_request: EventKind.approval_requested,
+            SessionEventKind.error: EventKind.job_failed,
+            SessionEventKind.model_downgraded: EventKind.model_downgraded,
         }
-        kind: CPEventKind | None
+        kind: EventKind | None
         if event.kind == SessionEventKind.transcript:
             kind = transcript_kind_for_role(str(event.payload.get("role", "")))
         else:
@@ -2754,7 +2754,7 @@ class RuntimeService:
             new_event(
                 session_id=job_id,
                 timestamp=datetime.now(UTC),
-                kind=CPEventKind.approval_requested,
+                kind=EventKind.approval_requested,
                 payload={
                     "approval_id": approval.id,
                     "description": approval.description,
@@ -2775,7 +2775,7 @@ class RuntimeService:
             new_event(
                 session_id=job_id,
                 timestamp=datetime.now(UTC),
-                kind=CPEventKind.approval_resolved,
+                kind=EventKind.approval_resolved,
                 payload={
                     "approval_id": approval.id,
                     "resolution": resolution,
@@ -2857,7 +2857,7 @@ class RuntimeService:
                     new_event(
                         session_id=job_id,
                         timestamp=datetime.now(UTC),
-                        kind=CPEventKind.approval_requested,
+                        kind=EventKind.approval_requested,
                         payload={
                             "approval_id": approval.id,
                             "description": approval.description,
@@ -2876,7 +2876,7 @@ class RuntimeService:
                     new_event(
                         session_id=job_id,
                         timestamp=datetime.now(UTC),
-                        kind=CPEventKind.approval_resolved,
+                        kind=EventKind.approval_resolved,
                         payload={
                             "approval_id": approval.id,
                             "resolution": resolution,
@@ -2919,7 +2919,7 @@ class RuntimeService:
             new_event(
                 session_id=job_id,
                 timestamp=datetime.now(UTC),
-                kind=CPEventKind.job_mode_changed,
+                kind=EventKind.job_mode_changed,
                 payload={
                     "previous_mode": JobMode.plan,
                     "new_mode": JobMode.plan_implementing,
@@ -3018,7 +3018,7 @@ class RuntimeService:
                 new_event(
                     session_id=job.id,
                     timestamp=started_at,
-                    kind=CPEventKind.secondary_session_started,
+                    kind=EventKind.secondary_session_started,
                     payload={
                         "session_id": session_id,
                         "kind": SecondarySessionKind.preflight.value,
@@ -3079,7 +3079,7 @@ class RuntimeService:
                     new_event(
                         session_id=job.id,
                         timestamp=now,
-                        kind=CPEventKind.secondary_session_entry,
+                        kind=EventKind.secondary_session_entry,
                         payload={"session_id": session_id, "entry": entry_payload},
                     )
                 )
@@ -3104,7 +3104,7 @@ class RuntimeService:
                     new_event(
                         session_id=job.id,
                         timestamp=now,
-                        kind=CPEventKind.secondary_session_entry,
+                        kind=EventKind.secondary_session_entry,
                         payload={"session_id": session_id, "entry": entry_payload},
                     )
                 )
@@ -3130,7 +3130,7 @@ class RuntimeService:
                 new_event(
                     session_id=job.id,
                     timestamp=completed_at,
-                    kind=CPEventKind.secondary_session_completed,
+                    kind=EventKind.secondary_session_completed,
                     payload={
                         "session_id": session_id,
                         "status": SecondarySessionStatus.completed.value,
@@ -3151,7 +3151,7 @@ class RuntimeService:
                     new_event(
                         session_id=job.id,
                         timestamp=completed_at,
-                        kind=CPEventKind.context_handoff,
+                        kind=EventKind.context_handoff,
                         payload={
                             "source": "preflight",
                             "source_session_id": session_id,
@@ -3175,7 +3175,7 @@ class RuntimeService:
                     new_event(
                         session_id=job.id,
                         timestamp=datetime.now(UTC),
-                        kind=CPEventKind.secondary_session_completed,
+                        kind=EventKind.secondary_session_completed,
                         payload={
                             "session_id": session_id,
                             "status": SecondarySessionStatus.failed.value,

--- a/backend/services/runtime/service.py
+++ b/backend/services/runtime/service.py
@@ -44,7 +44,13 @@ from backend.models.domain import (
 from backend.models.domain import (
     SessionEvent as CPSessionEvent,
 )
-from backend.models.events import DomainEventKind, SessionEvent, new_event
+from backend.models.events import (
+    TRANSCRIPT_KINDS,
+    CPEventKind,
+    SessionEvent,
+    new_event,
+    transcript_kind_for_role,
+)
 from backend.persistence.job_repo import JobRepository
 from backend.services.job.job_service import JobService
 from backend.services.runtime.handoff import (
@@ -382,7 +388,7 @@ class RuntimeService:
                         new_event(
                             session_id=job_id,
                             timestamp=datetime.now(UTC),
-                            kind=DomainEventKind.job_title_updated,
+                            kind=CPEventKind.job_title_updated,
                             payload={"title": title},
                         )
                     )
@@ -780,7 +786,7 @@ class RuntimeService:
             new_event(
                 session_id=job_id,
                 timestamp=datetime.now(UTC),
-                kind=DomainEventKind.execution_phase_changed,
+                kind=CPEventKind.execution_phase_changed,
                 payload={"phase": ExecutionPhase.environment_setup},
             )
         )
@@ -821,7 +827,7 @@ class RuntimeService:
                 new_event(
                     session_id=job_id,
                     timestamp=datetime.now(UTC),
-                    kind=DomainEventKind.execution_phase_changed,
+                    kind=CPEventKind.execution_phase_changed,
                     payload={"phase": ExecutionPhase.agent_reasoning},
                 )
             )
@@ -936,7 +942,7 @@ class RuntimeService:
             new_event(
                 session_id=job_id,
                 timestamp=datetime.now(UTC),
-                kind=DomainEventKind.job_review,
+                kind=CPEventKind.job_review,
                 payload={
                     "resolution": Resolution.unresolved,
                     "model_downgraded": True,
@@ -1034,7 +1040,7 @@ class RuntimeService:
         if final_resolution in (Resolution.merged, Resolution.pr_created, Resolution.discarded):
             final_state = JobState.completed
         final_event_kind = (
-            DomainEventKind.job_completed if final_state == JobState.completed else DomainEventKind.job_review
+            CPEventKind.job_completed if final_state == JobState.completed else CPEventKind.job_review
         )
 
         await self._set_step_terminal_state(job_id, final_state)
@@ -1195,7 +1201,7 @@ class RuntimeService:
 
     async def _on_policy_settings_changed(self, event: SessionEvent) -> None:
         """Reload action policy for all running jobs when settings change."""
-        if event.kind != DomainEventKind.policy_settings_changed:
+        if event.kind != CPEventKind.policy_settings_changed:
             return
 
         job_ids = list(self._policy_routers.keys())
@@ -1370,7 +1376,7 @@ class RuntimeService:
                         new_event(
                             session_id=job_id,
                             timestamp=datetime.now(UTC),
-                            kind=DomainEventKind.job_failed,
+                            kind=CPEventKind.job_failed,
                             payload={"reason": "Job cleanup: previous error handlers failed to transition state"},
                         )
                     )
@@ -1405,7 +1411,7 @@ class RuntimeService:
             new_event(
                 session_id=job_id,
                 timestamp=datetime.now(UTC),
-                kind=DomainEventKind.approval_resolved,
+                kind=CPEventKind.approval_resolved,
                 payload={
                     "approval_id": approval_id,
                     "resolution": resolution,
@@ -1477,7 +1483,7 @@ class RuntimeService:
                         new_event(
                             session_id=job_id,
                             timestamp=datetime.now(UTC),
-                            kind=DomainEventKind.job_canceled,
+                            kind=CPEventKind.job_canceled,
                             payload={"reason": "operator_cancel"},
                         )
                     )
@@ -1566,7 +1572,7 @@ class RuntimeService:
             return None
 
         # Step tracking — annotate transcript events with step boundaries
-        if domain_event.kind == DomainEventKind.transcript_updated and self._step_tracker is not None:
+        if domain_event.kind in TRANSCRIPT_KINDS and self._step_tracker is not None:
             role = str(domain_event.payload.get("role", ""))
             if role != "agent_delta":
                 await self._step_tracker.on_transcript_event(job_id, domain_event)
@@ -1735,7 +1741,7 @@ class RuntimeService:
         # Managed sessions (via CopilotAdapter) already include one; discovered
         # sessions from the watchers don't.  Synthesize one and rotate it
         # on each completed agent message (role=="agent") to mark turn boundaries.
-        if domain_event.kind == DomainEventKind.transcript_updated:
+        if domain_event.kind in TRANSCRIPT_KINDS:
             payload = domain_event.payload
             if not payload.get("turn_id"):
                 tid = self._turn_ids.get(job_id)
@@ -1747,11 +1753,11 @@ class RuntimeService:
                 self._turn_ids[job_id] = str(uuid.uuid4())
 
         error_reason: str | None = None
-        if domain_event.kind == DomainEventKind.job_failed:
+        if domain_event.kind == CPEventKind.job_failed:
             error_reason = str(domain_event.payload.get("message", "Agent error"))
 
         # Suppress SDK echoes
-        if domain_event.kind == DomainEventKind.transcript_updated and job_id in self._echo_suppress:
+        if domain_event.kind in TRANSCRIPT_KINDS and job_id in self._echo_suppress:
             content = str(domain_event.payload.get("content", ""))
             if content in self._echo_suppress[job_id]:
                 self._echo_suppress[job_id].discard(content)
@@ -1760,7 +1766,7 @@ class RuntimeService:
         # Handle approval requests (managed sessions only — external sessions
         # handle their own approvals; we just publish for UI visibility).
         if (
-            domain_event.kind == DomainEventKind.approval_requested
+            domain_event.kind == CPEventKind.approval_requested
             and self._approval_service is not None
             and agent_session is not None
         ):
@@ -1821,7 +1827,7 @@ class RuntimeService:
                 await self._persist_sdk_session_id(job_id, session_id)
 
             # Model downgrade: publish event, abort session, signal caller
-            if domain_event.kind == DomainEventKind.model_downgraded:
+            if domain_event.kind == CPEventKind.model_downgraded:
                 requested = str(domain_event.payload.get("requested_model", ""))
                 actual = str(domain_event.payload.get("actual_model", ""))
                 log.warning(
@@ -1840,7 +1846,7 @@ class RuntimeService:
 
             # Step tracking — annotate transcript events with step_id
             # (must run BEFORE publish so the payload is enriched for subscribers)
-            if domain_event.kind == DomainEventKind.transcript_updated and self._step_tracker is not None:
+            if domain_event.kind in TRANSCRIPT_KINDS and self._step_tracker is not None:
                 role = str(domain_event.payload.get("role", ""))
                 if role != "agent_delta":
                     await self._step_tracker.on_transcript_event(job_id, domain_event)
@@ -1855,7 +1861,7 @@ class RuntimeService:
 
             # Tag log lines with the current session number so callers can filter
             # by session when a job has been resumed one or more times.
-            if domain_event.kind == DomainEventKind.log_line_emitted:
+            if domain_event.kind == CPEventKind.log_line_emitted:
                 domain_event.payload.setdefault("session_number", session_number)
 
             await self._event_bus.publish(domain_event)
@@ -1935,7 +1941,7 @@ class RuntimeService:
                     payload["active_tool_since"] = active[1]
 
                 await self._event_bus.publish(
-                    new_event(session_id=job_id, timestamp=now, kind=DomainEventKind.session_heartbeat, payload=payload)
+                    new_event(session_id=job_id, timestamp=now, kind=CPEventKind.session_heartbeat, payload=payload)
                 )
 
                 # --- Stall detection via sidecar session ---
@@ -2035,7 +2041,7 @@ class RuntimeService:
             new_event(
                 session_id=job_id,
                 timestamp=datetime.now(UTC),
-                kind=DomainEventKind.stall_detected,
+                kind=CPEventKind.stall_detected,
                 payload={
                     "job_id": job_id,
                     "tool_name": tool_name,
@@ -2123,7 +2129,7 @@ class RuntimeService:
         operator_event = new_event(
             session_id=job_id,
             timestamp=now,
-            kind=DomainEventKind.transcript_updated,
+            kind=transcript_kind_for_role(TranscriptRole.operator),
             payload={
                 "job_id": job_id,
                 "seq": 0,
@@ -2189,7 +2195,7 @@ class RuntimeService:
                 new_event(
                     session_id=job_id,
                     timestamp=datetime.now(UTC),
-                    kind=DomainEventKind.batch_approval_resolved,
+                    kind=CPEventKind.batch_approval_resolved,
                     payload={
                         "batch_id": batch_id,
                         "resolution": resolution,
@@ -2411,7 +2417,7 @@ class RuntimeService:
                 new_event(
                     session_id=job_id,
                     timestamp=datetime.now(UTC),
-                    kind=DomainEventKind.job_failed,
+                    kind=CPEventKind.job_failed,
                     payload={"reason": reason},
                 )
             )
@@ -2542,7 +2548,7 @@ class RuntimeService:
             new_event(
                 session_id=job_id,
                 timestamp=datetime.now(UTC),
-                kind=DomainEventKind.job_state_changed,
+                kind=CPEventKind.job_state_changed,
                 payload={
                     "previous_state": previous_state,
                     "new_state": new_state,
@@ -2556,21 +2562,24 @@ class RuntimeService:
             new_event(
                 session_id=job_id,
                 timestamp=datetime.now(UTC),
-                kind=DomainEventKind.job_setup_progress,
+                kind=CPEventKind.job_setup_progress,
                 payload={"step": step},
             )
         )
 
     def _translate_event(self, job_id: str, event: CPSessionEvent) -> SessionEvent | None:
         """Translate a SessionEvent into a DomainEvent."""
-        mapping: dict[SessionEventKind, DomainEventKind] = {
-            SessionEventKind.log: DomainEventKind.log_line_emitted,
-            SessionEventKind.transcript: DomainEventKind.transcript_updated,
-            SessionEventKind.approval_request: DomainEventKind.approval_requested,
-            SessionEventKind.error: DomainEventKind.job_failed,
-            SessionEventKind.model_downgraded: DomainEventKind.model_downgraded,
+        mapping: dict[SessionEventKind, CPEventKind] = {
+            SessionEventKind.log: CPEventKind.log_line_emitted,
+            SessionEventKind.approval_request: CPEventKind.approval_requested,
+            SessionEventKind.error: CPEventKind.job_failed,
+            SessionEventKind.model_downgraded: CPEventKind.model_downgraded,
         }
-        kind = mapping.get(event.kind)
+        kind: CPEventKind | None
+        if event.kind == SessionEventKind.transcript:
+            kind = transcript_kind_for_role(str(event.payload.get("role", "")))
+        else:
+            kind = mapping.get(event.kind)
         if kind is None:
             # 'done' events are handled at the _run_job level
             return None
@@ -2745,7 +2754,7 @@ class RuntimeService:
             new_event(
                 session_id=job_id,
                 timestamp=datetime.now(UTC),
-                kind=DomainEventKind.approval_requested,
+                kind=CPEventKind.approval_requested,
                 payload={
                     "approval_id": approval.id,
                     "description": approval.description,
@@ -2766,7 +2775,7 @@ class RuntimeService:
             new_event(
                 session_id=job_id,
                 timestamp=datetime.now(UTC),
-                kind=DomainEventKind.approval_resolved,
+                kind=CPEventKind.approval_resolved,
                 payload={
                     "approval_id": approval.id,
                     "resolution": resolution,
@@ -2848,7 +2857,7 @@ class RuntimeService:
                     new_event(
                         session_id=job_id,
                         timestamp=datetime.now(UTC),
-                        kind=DomainEventKind.approval_requested,
+                        kind=CPEventKind.approval_requested,
                         payload={
                             "approval_id": approval.id,
                             "description": approval.description,
@@ -2867,7 +2876,7 @@ class RuntimeService:
                     new_event(
                         session_id=job_id,
                         timestamp=datetime.now(UTC),
-                        kind=DomainEventKind.approval_resolved,
+                        kind=CPEventKind.approval_resolved,
                         payload={
                             "approval_id": approval.id,
                             "resolution": resolution,
@@ -2910,7 +2919,7 @@ class RuntimeService:
             new_event(
                 session_id=job_id,
                 timestamp=datetime.now(UTC),
-                kind=DomainEventKind.job_mode_changed,
+                kind=CPEventKind.job_mode_changed,
                 payload={
                     "previous_mode": JobMode.plan,
                     "new_mode": JobMode.plan_implementing,
@@ -3009,7 +3018,7 @@ class RuntimeService:
                 new_event(
                     session_id=job.id,
                     timestamp=started_at,
-                    kind=DomainEventKind.secondary_session_started,
+                    kind=CPEventKind.secondary_session_started,
                     payload={
                         "session_id": session_id,
                         "kind": SecondarySessionKind.preflight.value,
@@ -3070,7 +3079,7 @@ class RuntimeService:
                     new_event(
                         session_id=job.id,
                         timestamp=now,
-                        kind=DomainEventKind.secondary_session_entry,
+                        kind=CPEventKind.secondary_session_entry,
                         payload={"session_id": session_id, "entry": entry_payload},
                     )
                 )
@@ -3095,7 +3104,7 @@ class RuntimeService:
                     new_event(
                         session_id=job.id,
                         timestamp=now,
-                        kind=DomainEventKind.secondary_session_entry,
+                        kind=CPEventKind.secondary_session_entry,
                         payload={"session_id": session_id, "entry": entry_payload},
                     )
                 )
@@ -3121,7 +3130,7 @@ class RuntimeService:
                 new_event(
                     session_id=job.id,
                     timestamp=completed_at,
-                    kind=DomainEventKind.secondary_session_completed,
+                    kind=CPEventKind.secondary_session_completed,
                     payload={
                         "session_id": session_id,
                         "status": SecondarySessionStatus.completed.value,
@@ -3142,7 +3151,7 @@ class RuntimeService:
                     new_event(
                         session_id=job.id,
                         timestamp=completed_at,
-                        kind=DomainEventKind.context_handoff,
+                        kind=CPEventKind.context_handoff,
                         payload={
                             "source": "preflight",
                             "source_session_id": session_id,
@@ -3166,7 +3175,7 @@ class RuntimeService:
                     new_event(
                         session_id=job.id,
                         timestamp=datetime.now(UTC),
-                        kind=DomainEventKind.secondary_session_completed,
+                        kind=CPEventKind.secondary_session_completed,
                         payload={
                             "session_id": session_id,
                             "status": SecondarySessionStatus.failed.value,

--- a/backend/services/runtime/telemetry.py
+++ b/backend/services/runtime/telemetry.py
@@ -16,7 +16,7 @@ from sqlalchemy.exc import DBAPIError
 
 from backend.models.api_schemas import ExecutionPhase
 from backend.models.domain import JobState
-from backend.models.events import DomainEventKind, new_event
+from backend.models.events import CPEventKind, new_event
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -103,7 +103,7 @@ class RuntimeTelemetry:
                 new_event(
                     session_id=job_id,
                     timestamp=datetime.now(UTC),
-                    kind=DomainEventKind.execution_phase_changed,
+                    kind=CPEventKind.execution_phase_changed,
                     payload={"phase": ExecutionPhase.finalization},
                 )
             )
@@ -160,7 +160,7 @@ class RuntimeTelemetry:
                 new_event(
                     session_id=job_id,
                     timestamp=datetime.now(UTC),
-                    kind=DomainEventKind.telemetry_updated,
+                    kind=CPEventKind.telemetry_updated,
                     payload={"job_id": job_id},
                 )
             )
@@ -240,7 +240,7 @@ class RuntimeTelemetry:
                     from backend.persistence.event_repo import EventRepository
 
                     event_repo = EventRepository(session)
-                    log_events = await event_repo.list_all_by_job(job_id, [DomainEventKind.log_line_emitted])
+                    log_events = await event_repo.list_all_by_job(job_id, [CPEventKind.log_line_emitted])
                     if log_events:
                         await artifact_svc.store_log_artifact(
                             job_id,

--- a/backend/services/runtime/telemetry.py
+++ b/backend/services/runtime/telemetry.py
@@ -16,7 +16,7 @@ from sqlalchemy.exc import DBAPIError
 
 from backend.models.api_schemas import ExecutionPhase
 from backend.models.domain import JobState
-from backend.models.events import CPEventKind, new_event
+from backend.models.events import EventKind, new_event
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -103,7 +103,7 @@ class RuntimeTelemetry:
                 new_event(
                     session_id=job_id,
                     timestamp=datetime.now(UTC),
-                    kind=CPEventKind.execution_phase_changed,
+                    kind=EventKind.execution_phase_changed,
                     payload={"phase": ExecutionPhase.finalization},
                 )
             )
@@ -160,7 +160,7 @@ class RuntimeTelemetry:
                 new_event(
                     session_id=job_id,
                     timestamp=datetime.now(UTC),
-                    kind=CPEventKind.telemetry_updated,
+                    kind=EventKind.telemetry_updated,
                     payload={"job_id": job_id},
                 )
             )
@@ -240,7 +240,7 @@ class RuntimeTelemetry:
                     from backend.persistence.event_repo import EventRepository
 
                     event_repo = EventRepository(session)
-                    log_events = await event_repo.list_all_by_job(job_id, [CPEventKind.log_line_emitted])
+                    log_events = await event_repo.list_all_by_job(job_id, [EventKind.log_line_emitted])
                     if log_events:
                         await artifact_svc.store_log_artifact(
                             job_id,

--- a/backend/services/runtime/telemetry.py
+++ b/backend/services/runtime/telemetry.py
@@ -16,7 +16,7 @@ from sqlalchemy.exc import DBAPIError
 
 from backend.models.api_schemas import ExecutionPhase
 from backend.models.domain import JobState
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, new_event
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -100,9 +100,8 @@ class RuntimeTelemetry:
         async with best_effort(log, "execution_phase_event", job_id=job_id):
             self._resolve_adapter(config.sdk).set_execution_phase(job_id, ExecutionPhase.finalization)
             await self._event_bus.publish(
-                DomainEvent(
-                    event_id=DomainEvent.make_event_id(),
-                    job_id=job_id,
+                new_event(
+                    session_id=job_id,
                     timestamp=datetime.now(UTC),
                     kind=DomainEventKind.execution_phase_changed,
                     payload={"phase": ExecutionPhase.finalization},
@@ -158,9 +157,8 @@ class RuntimeTelemetry:
 
             # Signal clients that final telemetry is available
             await self._event_bus.publish(
-                DomainEvent(
-                    event_id=DomainEvent.make_event_id(),
-                    job_id=job_id,
+                new_event(
+                    session_id=job_id,
                     timestamp=datetime.now(UTC),
                     kind=DomainEventKind.telemetry_updated,
                     payload={"job_id": job_id},

--- a/backend/services/runtime/verify.py
+++ b/backend/services/runtime/verify.py
@@ -16,7 +16,7 @@ from sqlalchemy.exc import DBAPIError
 from backend.config import DEFAULT_SELF_REVIEW_PROMPT, DEFAULT_VERIFY_PROMPT
 from backend.models.api_schemas import ExecutionPhase
 from backend.models.domain import CodePlaneError, SessionConfig
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, new_event
 
 if TYPE_CHECKING:
     from backend.services.runtime.service import RuntimeService
@@ -143,9 +143,8 @@ async def run_verify_review(
     # Emit verification phase change
     host._resolve_adapter(base_config.sdk).set_execution_phase(job_id, ExecutionPhase.verification)
     await host._event_bus.publish(
-        DomainEvent(
-            event_id=DomainEvent.make_event_id(),
-            job_id=job_id,
+        new_event(
+            session_id=job_id,
             timestamp=datetime.now(UTC),
             kind=DomainEventKind.execution_phase_changed,
             payload={"phase": ExecutionPhase.verification},

--- a/backend/services/runtime/verify.py
+++ b/backend/services/runtime/verify.py
@@ -16,7 +16,7 @@ from sqlalchemy.exc import DBAPIError
 from backend.config import DEFAULT_SELF_REVIEW_PROMPT, DEFAULT_VERIFY_PROMPT
 from backend.models.api_schemas import ExecutionPhase
 from backend.models.domain import CodePlaneError, SessionConfig
-from backend.models.events import DomainEventKind, new_event
+from backend.models.events import TRANSCRIPT_KINDS, CPEventKind, new_event
 
 if TYPE_CHECKING:
     from backend.services.runtime.service import RuntimeService
@@ -83,11 +83,11 @@ async def run_followup_turn(
                 host._session_ids[job_id] = new_session_id
                 await host._persist_sdk_session_id(job_id, new_session_id)
 
-            if domain_event.kind == DomainEventKind.log_line_emitted:
+            if domain_event.kind == CPEventKind.log_line_emitted:
                 domain_event.payload.setdefault("session_number", session_number)
 
             # Step tracking for follow-up turns
-            if domain_event.kind == DomainEventKind.transcript_updated and host._step_tracker is not None:
+            if domain_event.kind in TRANSCRIPT_KINDS and host._step_tracker is not None:
                 role = domain_event.payload.get("role", "")
                 if role != "agent_delta":
                     await host._step_tracker.on_transcript_event(job_id, domain_event)
@@ -146,7 +146,7 @@ async def run_verify_review(
         new_event(
             session_id=job_id,
             timestamp=datetime.now(UTC),
-            kind=DomainEventKind.execution_phase_changed,
+            kind=CPEventKind.execution_phase_changed,
             payload={"phase": ExecutionPhase.verification},
         )
     )

--- a/backend/services/runtime/verify.py
+++ b/backend/services/runtime/verify.py
@@ -16,7 +16,7 @@ from sqlalchemy.exc import DBAPIError
 from backend.config import DEFAULT_SELF_REVIEW_PROMPT, DEFAULT_VERIFY_PROMPT
 from backend.models.api_schemas import ExecutionPhase
 from backend.models.domain import CodePlaneError, SessionConfig
-from backend.models.events import TRANSCRIPT_KINDS, CPEventKind, new_event
+from backend.models.events import TRANSCRIPT_KINDS, EventKind, new_event
 
 if TYPE_CHECKING:
     from backend.services.runtime.service import RuntimeService
@@ -83,7 +83,7 @@ async def run_followup_turn(
                 host._session_ids[job_id] = new_session_id
                 await host._persist_sdk_session_id(job_id, new_session_id)
 
-            if domain_event.kind == CPEventKind.log_line_emitted:
+            if domain_event.kind == EventKind.log_line_emitted:
                 domain_event.payload.setdefault("session_number", session_number)
 
             # Step tracking for follow-up turns
@@ -146,7 +146,7 @@ async def run_verify_review(
         new_event(
             session_id=job_id,
             timestamp=datetime.now(UTC),
-            kind=CPEventKind.execution_phase_changed,
+            kind=EventKind.execution_phase_changed,
             payload={"phase": ExecutionPhase.verification},
         )
     )

--- a/backend/services/sidecar/dispatcher.py
+++ b/backend/services/sidecar/dispatcher.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
     from backend.models.domain import SidecarLifetime, SidecarPhase
-    from backend.models.events import DomainEvent
+    from backend.models.events import SessionEvent
     from backend.services.events.event_bus import EventBus
     from backend.services.sidecar.session import SidecarSessionManager
 
@@ -642,11 +642,11 @@ class SidecarDispatcher:
 
     # -- Trigger entry points -----------------------------------------------
 
-    async def handle_event(self, event: DomainEvent) -> None:
+    async def handle_event(self, event: SessionEvent) -> None:
         """EventBus subscriber.  Evaluate event/regex/content/file conditions."""
         for job_id, state in list(self._jobs.items()):
             # Only update activity for events belonging to this job (or global events)
-            if not event.job_id or event.job_id == job_id:
+            if not event.session_id or event.session_id == job_id:
                 state.last_activity = time.monotonic()
 
             # Recursion guard: if this job is already inside a pipeline execution,
@@ -669,7 +669,7 @@ class SidecarDispatcher:
                             if not all(str(payload.get(k)) == v for k, v in cond.event_filter.items()):
                                 continue
                         # Check job_id match (events carry job_id)
-                        if hasattr(event, "job_id") and event.job_id and event.job_id != job_id:
+                        if hasattr(event, "job_id") and event.session_id and event.session_id != job_id:
                             continue
                         if cond.once and (defn.name, idx) in state.fired_once:
                             continue
@@ -683,7 +683,7 @@ class SidecarDispatcher:
                         content = self._extract_content(event, cond.source)
                         if content is None:
                             continue
-                        if hasattr(event, "job_id") and event.job_id and event.job_id != job_id:
+                        if hasattr(event, "job_id") and event.session_id and event.session_id != job_id:
                             continue
                         match = (cond._compiled or re.compile(cond.pattern)).search(content)  # noqa: SLF001
                         if not match:
@@ -700,7 +700,7 @@ class SidecarDispatcher:
                         content = self._extract_content(event, cond.source)
                         if content is None:
                             continue
-                        if hasattr(event, "job_id") and event.job_id and event.job_id != job_id:
+                        if hasattr(event, "job_id") and event.session_id and event.session_id != job_id:
                             continue
                         check_content = content if cond.case_sensitive else content.lower()
                         matched = any(
@@ -718,7 +718,7 @@ class SidecarDispatcher:
                     elif isinstance(cond, FilePatternCondition):
                         if event.kind != "DiffUpdated":
                             continue
-                        if hasattr(event, "job_id") and event.job_id and event.job_id != job_id:
+                        if hasattr(event, "job_id") and event.session_id and event.session_id != job_id:
                             continue
                         changed_files = self._extract_changed_files(event)
                         if not changed_files:
@@ -1194,7 +1194,7 @@ class SidecarDispatcher:
         route: OutputRoute,
     ) -> None:
         """Deliver parsed output to a destination."""
-        from backend.models.events import DomainEvent, DomainEventKind
+        from backend.models.events import DomainEventKind, new_event
 
         if isinstance(route, EventBusRoute):
             payload: dict[str, Any] = {"sidecar_name": defn.name}
@@ -1209,9 +1209,8 @@ class SidecarDispatcher:
             else:
                 payload["result"] = parsed
             await self._event_bus.publish(
-                DomainEvent(
-                    event_id=DomainEvent.make_event_id(),
-                    job_id=job_id,
+                new_event(
+                    session_id=job_id,
                     timestamp=datetime.now(UTC),
                     kind=DomainEventKind(route.event_kind),
                     payload=payload,
@@ -1222,9 +1221,8 @@ class SidecarDispatcher:
             # Publish a metadata update event — consumers (job service) handle persistence
             value = parsed if isinstance(parsed, str) else json.dumps(parsed)
             await self._event_bus.publish(
-                DomainEvent(
-                    event_id=DomainEvent.make_event_id(),
-                    job_id=job_id,
+                new_event(
+                    session_id=job_id,
                     timestamp=datetime.now(UTC),
                     kind=DomainEventKind.job_title_updated
                     if route.field_name == "title"
@@ -1257,7 +1255,7 @@ class SidecarDispatcher:
             # Publish unified secondary session events for visibility
             import uuid as _uuid
 
-            from backend.models.events import DomainEvent, DomainEventKind
+            from backend.models.events import DomainEventKind, new_event
             from backend.models.secondary_session import EntryKind, SecondarySessionKind, SecondarySessionStatus
 
             _sess_id = str(_uuid.uuid4())
@@ -1296,9 +1294,8 @@ class SidecarDispatcher:
                     output=content,
                 )
             await self._event_bus.publish(
-                DomainEvent(
-                    event_id=DomainEvent.make_event_id(),
-                    job_id=job_id,
+                new_event(
+                    session_id=job_id,
                     timestamp=_now,
                     kind=DomainEventKind.secondary_session_started,
                     payload={
@@ -1310,9 +1307,8 @@ class SidecarDispatcher:
                 )
             )
             await self._event_bus.publish(
-                DomainEvent(
-                    event_id=DomainEvent.make_event_id(),
-                    job_id=job_id,
+                new_event(
+                    session_id=job_id,
                     timestamp=_now,
                     kind=DomainEventKind.secondary_session_completed,
                     payload={
@@ -1369,9 +1365,8 @@ class SidecarDispatcher:
             verdict = str(raw_verdict).lower().strip()
             reason = str(parsed.get(route.reason_field, ""))
             await self._event_bus.publish(
-                DomainEvent(
-                    event_id=DomainEvent.make_event_id(),
-                    job_id=job_id,
+                new_event(
+                    session_id=job_id,
                     timestamp=datetime.now(UTC),
                     kind=DomainEventKind.sidecar_gate_verdict,
                     payload={
@@ -1396,7 +1391,7 @@ class SidecarDispatcher:
         """Publish secondary session events so the sidecar's output appears in the feed."""
         import uuid
 
-        from backend.models.events import DomainEvent, DomainEventKind
+        from backend.models.events import DomainEventKind, new_event
         from backend.models.secondary_session import EntryKind, SecondarySessionKind, SecondarySessionStatus
 
         content = parsed if isinstance(parsed, str) else json.dumps(parsed)
@@ -1432,9 +1427,8 @@ class SidecarDispatcher:
 
         # Always emit SSE events for live frontend display
         await self._event_bus.publish(
-            DomainEvent(
-                event_id=DomainEvent.make_event_id(),
-                job_id=job_id,
+            new_event(
+                session_id=job_id,
                 timestamp=now,
                 kind=DomainEventKind.secondary_session_started,
                 payload={
@@ -1446,9 +1440,8 @@ class SidecarDispatcher:
             )
         )
         await self._event_bus.publish(
-            DomainEvent(
-                event_id=DomainEvent.make_event_id(),
-                job_id=job_id,
+            new_event(
+                session_id=job_id,
                 timestamp=now,
                 kind=DomainEventKind.secondary_session_completed,
                 payload={
@@ -1473,7 +1466,7 @@ class SidecarDispatcher:
         return not result.get(gate_field, True)
 
     @staticmethod
-    def _extract_content(event: DomainEvent, source: str) -> str | None:
+    def _extract_content(event: SessionEvent, source: str) -> str | None:
         """Extract text content from a domain event for regex/content matching."""
         payload = event.payload or {}
 
@@ -1498,7 +1491,7 @@ class SidecarDispatcher:
         return None
 
     @staticmethod
-    def _extract_changed_files(event: DomainEvent) -> list[dict[str, str]]:
+    def _extract_changed_files(event: SessionEvent) -> list[dict[str, str]]:
         """Extract file change info from a DiffUpdated event."""
         payload = event.payload or {}
         files = payload.get("files") or payload.get("changed_files") or []

--- a/backend/services/sidecar/dispatcher.py
+++ b/backend/services/sidecar/dispatcher.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
     from backend.services.sidecar.session import SidecarSessionManager
 
 from backend.models.domain import SessionConfig, SidecarConfig
+from backend.models.events import TRANSCRIPT_KINDS, CPEventKind
 
 log = structlog.get_logger()
 
@@ -716,7 +717,7 @@ class SidecarDispatcher:
 
                     # FilePatternCondition — match changed file paths from diff events
                     elif isinstance(cond, FilePatternCondition):
-                        if event.kind != "DiffUpdated":
+                        if event.kind != CPEventKind.diff_updated:
                             continue
                         if hasattr(event, "job_id") and event.session_id and event.session_id != job_id:
                             continue
@@ -1471,20 +1472,20 @@ class SidecarDispatcher:
         payload = event.payload or {}
 
         if source == "messages":
-            # TranscriptUpdated events carry role + content
-            if event.kind == "TranscriptUpdated":
+            # Transcript events carry role + content
+            if event.kind in TRANSCRIPT_KINDS:
                 role = payload.get("role", "")
                 if role in ("agent", "agent_delta"):
                     return str(payload.get("content")) if payload.get("content") is not None else None
             return None
 
         if source == "tool_calls":
-            if event.kind == "TranscriptUpdated" and payload.get("role") == "tool_call":
+            if event.kind in TRANSCRIPT_KINDS and payload.get("role") == "tool_call":
                 return str(payload.get("tool_name", ""))
             return None
 
         if source == "tool_output":
-            if event.kind == "TranscriptUpdated" and payload.get("role") == "tool_call":
+            if event.kind in TRANSCRIPT_KINDS and payload.get("role") == "tool_call":
                 return str(payload.get("tool_result")) if payload.get("tool_result") is not None else None
             return None
 
@@ -1492,7 +1493,7 @@ class SidecarDispatcher:
 
     @staticmethod
     def _extract_changed_files(event: SessionEvent) -> list[dict[str, str]]:
-        """Extract file change info from a DiffUpdated event."""
+        """Extract file change info from a diff.updated event."""
         payload = event.payload or {}
         files = payload.get("files") or payload.get("changed_files") or []
         if isinstance(files, list):

--- a/backend/services/sidecar/dispatcher.py
+++ b/backend/services/sidecar/dispatcher.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
     from backend.services.sidecar.session import SidecarSessionManager
 
 from backend.models.domain import SessionConfig, SidecarConfig
-from backend.models.events import TRANSCRIPT_KINDS, CPEventKind
+from backend.models.events import TRANSCRIPT_KINDS, EventKind
 
 log = structlog.get_logger()
 
@@ -717,7 +717,7 @@ class SidecarDispatcher:
 
                     # FilePatternCondition — match changed file paths from diff events
                     elif isinstance(cond, FilePatternCondition):
-                        if event.kind != CPEventKind.diff_updated:
+                        if event.kind != EventKind.diff_updated:
                             continue
                         if hasattr(event, "job_id") and event.session_id and event.session_id != job_id:
                             continue
@@ -1195,7 +1195,7 @@ class SidecarDispatcher:
         route: OutputRoute,
     ) -> None:
         """Deliver parsed output to a destination."""
-        from backend.models.events import CPEventKind, new_event
+        from backend.models.events import EventKind, new_event
 
         if isinstance(route, EventBusRoute):
             payload: dict[str, Any] = {"sidecar_name": defn.name}
@@ -1213,7 +1213,7 @@ class SidecarDispatcher:
                 new_event(
                     session_id=job_id,
                     timestamp=datetime.now(UTC),
-                    kind=CPEventKind(route.event_kind),
+                    kind=EventKind(route.event_kind),
                     payload=payload,
                 )
             )
@@ -1225,9 +1225,9 @@ class SidecarDispatcher:
                 new_event(
                     session_id=job_id,
                     timestamp=datetime.now(UTC),
-                    kind=CPEventKind.job_title_updated
+                    kind=EventKind.job_title_updated
                     if route.field_name == "title"
-                    else CPEventKind.sidecar_metadata_update,
+                    else EventKind.sidecar_metadata_update,
                     payload={"field": route.field_name, "value": value, "sidecar_name": defn.name},
                 )
             )
@@ -1256,7 +1256,7 @@ class SidecarDispatcher:
             # Publish unified secondary session events for visibility
             import uuid as _uuid
 
-            from backend.models.events import CPEventKind, new_event
+            from backend.models.events import EventKind, new_event
             from backend.models.secondary_session import EntryKind, SecondarySessionKind, SecondarySessionStatus
 
             _sess_id = str(_uuid.uuid4())
@@ -1298,7 +1298,7 @@ class SidecarDispatcher:
                 new_event(
                     session_id=job_id,
                     timestamp=_now,
-                    kind=CPEventKind.secondary_session_started,
+                    kind=EventKind.secondary_session_started,
                     payload={
                         "session_id": _sess_id,
                         "kind": SecondarySessionKind.sidecar.value,
@@ -1311,7 +1311,7 @@ class SidecarDispatcher:
                 new_event(
                     session_id=job_id,
                     timestamp=_now,
-                    kind=CPEventKind.secondary_session_completed,
+                    kind=EventKind.secondary_session_completed,
                     payload={
                         "session_id": _sess_id,
                         "status": SecondarySessionStatus.completed.value,
@@ -1369,7 +1369,7 @@ class SidecarDispatcher:
                 new_event(
                     session_id=job_id,
                     timestamp=datetime.now(UTC),
-                    kind=CPEventKind.sidecar_gate_verdict,
+                    kind=EventKind.sidecar_gate_verdict,
                     payload={
                         "sidecar_name": defn.name,
                         "verdict": verdict,
@@ -1392,7 +1392,7 @@ class SidecarDispatcher:
         """Publish secondary session events so the sidecar's output appears in the feed."""
         import uuid
 
-        from backend.models.events import CPEventKind, new_event
+        from backend.models.events import EventKind, new_event
         from backend.models.secondary_session import EntryKind, SecondarySessionKind, SecondarySessionStatus
 
         content = parsed if isinstance(parsed, str) else json.dumps(parsed)
@@ -1431,7 +1431,7 @@ class SidecarDispatcher:
             new_event(
                 session_id=job_id,
                 timestamp=now,
-                kind=CPEventKind.secondary_session_started,
+                kind=EventKind.secondary_session_started,
                 payload={
                     "session_id": session_id,
                     "kind": SecondarySessionKind.sidecar.value,
@@ -1444,7 +1444,7 @@ class SidecarDispatcher:
             new_event(
                 session_id=job_id,
                 timestamp=now,
-                kind=CPEventKind.secondary_session_completed,
+                kind=EventKind.secondary_session_completed,
                 payload={
                     "session_id": session_id,
                     "status": SecondarySessionStatus.completed.value,

--- a/backend/services/sidecar/dispatcher.py
+++ b/backend/services/sidecar/dispatcher.py
@@ -1194,7 +1194,7 @@ class SidecarDispatcher:
         route: OutputRoute,
     ) -> None:
         """Deliver parsed output to a destination."""
-        from backend.models.events import DomainEventKind, new_event
+        from backend.models.events import CPEventKind, new_event
 
         if isinstance(route, EventBusRoute):
             payload: dict[str, Any] = {"sidecar_name": defn.name}
@@ -1212,7 +1212,7 @@ class SidecarDispatcher:
                 new_event(
                     session_id=job_id,
                     timestamp=datetime.now(UTC),
-                    kind=DomainEventKind(route.event_kind),
+                    kind=CPEventKind(route.event_kind),
                     payload=payload,
                 )
             )
@@ -1224,9 +1224,9 @@ class SidecarDispatcher:
                 new_event(
                     session_id=job_id,
                     timestamp=datetime.now(UTC),
-                    kind=DomainEventKind.job_title_updated
+                    kind=CPEventKind.job_title_updated
                     if route.field_name == "title"
-                    else DomainEventKind.sidecar_metadata_update,
+                    else CPEventKind.sidecar_metadata_update,
                     payload={"field": route.field_name, "value": value, "sidecar_name": defn.name},
                 )
             )
@@ -1255,7 +1255,7 @@ class SidecarDispatcher:
             # Publish unified secondary session events for visibility
             import uuid as _uuid
 
-            from backend.models.events import DomainEventKind, new_event
+            from backend.models.events import CPEventKind, new_event
             from backend.models.secondary_session import EntryKind, SecondarySessionKind, SecondarySessionStatus
 
             _sess_id = str(_uuid.uuid4())
@@ -1297,7 +1297,7 @@ class SidecarDispatcher:
                 new_event(
                     session_id=job_id,
                     timestamp=_now,
-                    kind=DomainEventKind.secondary_session_started,
+                    kind=CPEventKind.secondary_session_started,
                     payload={
                         "session_id": _sess_id,
                         "kind": SecondarySessionKind.sidecar.value,
@@ -1310,7 +1310,7 @@ class SidecarDispatcher:
                 new_event(
                     session_id=job_id,
                     timestamp=_now,
-                    kind=DomainEventKind.secondary_session_completed,
+                    kind=CPEventKind.secondary_session_completed,
                     payload={
                         "session_id": _sess_id,
                         "status": SecondarySessionStatus.completed.value,
@@ -1368,7 +1368,7 @@ class SidecarDispatcher:
                 new_event(
                     session_id=job_id,
                     timestamp=datetime.now(UTC),
-                    kind=DomainEventKind.sidecar_gate_verdict,
+                    kind=CPEventKind.sidecar_gate_verdict,
                     payload={
                         "sidecar_name": defn.name,
                         "verdict": verdict,
@@ -1391,7 +1391,7 @@ class SidecarDispatcher:
         """Publish secondary session events so the sidecar's output appears in the feed."""
         import uuid
 
-        from backend.models.events import DomainEventKind, new_event
+        from backend.models.events import CPEventKind, new_event
         from backend.models.secondary_session import EntryKind, SecondarySessionKind, SecondarySessionStatus
 
         content = parsed if isinstance(parsed, str) else json.dumps(parsed)
@@ -1430,7 +1430,7 @@ class SidecarDispatcher:
             new_event(
                 session_id=job_id,
                 timestamp=now,
-                kind=DomainEventKind.secondary_session_started,
+                kind=CPEventKind.secondary_session_started,
                 payload={
                     "session_id": session_id,
                     "kind": SecondarySessionKind.sidecar.value,
@@ -1443,7 +1443,7 @@ class SidecarDispatcher:
             new_event(
                 session_id=job_id,
                 timestamp=now,
-                kind=DomainEventKind.secondary_session_completed,
+                kind=CPEventKind.secondary_session_completed,
                 payload={
                     "session_id": session_id,
                     "status": SecondarySessionStatus.completed.value,

--- a/backend/services/sidecar/session.py
+++ b/backend/services/sidecar/session.py
@@ -243,7 +243,7 @@ class AgenticSidecarSession:
         final_text = ""
         try:
             async for event in self._adapter.stream_events(session_id):
-                if event.kind.value != "transcript" or not isinstance(event.payload, dict):
+                if str(event.kind) != "transcript" or not isinstance(event.payload, dict):
                     continue
                 role = str(event.payload.get("role", ""))
                 if role in ("agent", "assistant"):

--- a/backend/services/steps/diff_service.py
+++ b/backend/services/steps/diff_service.py
@@ -18,7 +18,7 @@ from backend.models.api_schemas import (
     HunkMotivation,
     StepDiffPayload,
 )
-from backend.models.events import DomainEventKind
+from backend.models.events import CPEventKind
 from backend.services.artifacts.diff_service import DiffService
 
 if TYPE_CHECKING:
@@ -186,7 +186,7 @@ class StepDiffService:
         # Try plan_step_updated events first (plan step IDs like ps-XXXX)
         events = await self._job_svc.list_events_by_job(
             job_id,
-            [DomainEventKind.plan_step_updated],
+            [CPEventKind.plan_step_updated],
             limit=_EVENT_QUERY_CEILING,
         )
         for ev in events:

--- a/backend/services/steps/diff_service.py
+++ b/backend/services/steps/diff_service.py
@@ -18,7 +18,7 @@ from backend.models.api_schemas import (
     HunkMotivation,
     StepDiffPayload,
 )
-from backend.models.events import CPEventKind
+from backend.models.events import EventKind
 from backend.services.artifacts.diff_service import DiffService
 
 if TYPE_CHECKING:
@@ -186,7 +186,7 @@ class StepDiffService:
         # Try plan_step_updated events first (plan step IDs like ps-XXXX)
         events = await self._job_svc.list_events_by_job(
             job_id,
-            [CPEventKind.plan_step_updated],
+            [EventKind.plan_step_updated],
             limit=_EVENT_QUERY_CEILING,
         )
         for ev in events:

--- a/backend/services/steps/persistence.py
+++ b/backend/services/steps/persistence.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, cast
 
 from backend.models.db import StepRow
 from backend.models.events import (
-    DomainEventKind,
+    CPEventKind,
     SessionEvent,
     StepCompletedPayloadDict,
     StepStartedPayloadDict,
@@ -30,9 +30,9 @@ class StepPersistenceSubscriber:
 
     async def __call__(self, event: SessionEvent) -> None:
         """EventBus entry point — dispatches to kind-specific handlers."""
-        if event.kind == DomainEventKind.step_started:
+        if event.kind == CPEventKind.step_started:
             await self._on_step_started(event)
-        elif event.kind == DomainEventKind.step_completed:
+        elif event.kind == CPEventKind.step_completed:
             await self._on_step_completed(event)
         # All other event kinds: early return (no-op)
 

--- a/backend/services/steps/persistence.py
+++ b/backend/services/steps/persistence.py
@@ -6,7 +6,12 @@ import json
 from typing import TYPE_CHECKING, cast
 
 from backend.models.db import StepRow
-from backend.models.events import DomainEvent, DomainEventKind, StepCompletedPayloadDict, StepStartedPayloadDict
+from backend.models.events import (
+    DomainEventKind,
+    SessionEvent,
+    StepCompletedPayloadDict,
+    StepStartedPayloadDict,
+)
 
 if TYPE_CHECKING:
     from backend.persistence.step_repo import StepRepository
@@ -23,7 +28,7 @@ class StepPersistenceSubscriber:
     def __init__(self, step_repo: StepRepository) -> None:
         self._step_repo = step_repo
 
-    async def __call__(self, event: DomainEvent) -> None:
+    async def __call__(self, event: SessionEvent) -> None:
         """EventBus entry point — dispatches to kind-specific handlers."""
         if event.kind == DomainEventKind.step_started:
             await self._on_step_started(event)
@@ -31,11 +36,11 @@ class StepPersistenceSubscriber:
             await self._on_step_completed(event)
         # All other event kinds: early return (no-op)
 
-    async def _on_step_started(self, event: DomainEvent) -> None:
+    async def _on_step_started(self, event: SessionEvent) -> None:
         p = cast("StepStartedPayloadDict", event.payload)
         row = StepRow(
             id=p["step_id"],
-            job_id=event.job_id,
+            job_id=event.session_id,
             step_number=p["step_number"],
             turn_id=p.get("turn_id"),
             intent=p.get("intent", ""),
@@ -44,7 +49,7 @@ class StepPersistenceSubscriber:
         )
         await self._step_repo.create(row)
 
-    async def _on_step_completed(self, event: DomainEvent) -> None:
+    async def _on_step_completed(self, event: SessionEvent) -> None:
         p = cast("StepCompletedPayloadDict", event.payload)
         step_id = p["step_id"]
         assert step_id is not None

--- a/backend/services/steps/persistence.py
+++ b/backend/services/steps/persistence.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, cast
 
 from backend.models.db import StepRow
 from backend.models.events import (
-    CPEventKind,
+    EventKind,
     SessionEvent,
     StepCompletedPayloadDict,
     StepStartedPayloadDict,
@@ -30,9 +30,9 @@ class StepPersistenceSubscriber:
 
     async def __call__(self, event: SessionEvent) -> None:
         """EventBus entry point — dispatches to kind-specific handlers."""
-        if event.kind == CPEventKind.step_started:
+        if event.kind == EventKind.step_started:
             await self._on_step_started(event)
-        elif event.kind == CPEventKind.step_completed:
+        elif event.kind == EventKind.step_completed:
             await self._on_step_completed(event)
         # All other event kinds: early return (no-op)
 

--- a/backend/services/steps/tracker.py
+++ b/backend/services/steps/tracker.py
@@ -17,7 +17,7 @@ import json
 import uuid
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 import structlog
 
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from backend.services.events.event_bus import EventBus
     from backend.services.git.git_service import GitService
 
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, SessionEvent, new_event
 from backend.services.git.git_service import GitError
 from backend.services.tools.tool_classifier import TOOL_CATEGORIES
 
@@ -103,9 +103,9 @@ class StepTracker:
     def current_step(self, job_id: str) -> _StepState | None:
         return self._current.get(job_id)
 
-    async def on_transcript_event(self, job_id: str, event: DomainEvent) -> None:
+    async def on_transcript_event(self, job_id: str, event: SessionEvent) -> None:
         """Process a TranscriptUpdated event."""
-        payload = cast("dict[str, Any]", event.payload)
+        payload = event.payload
         role = payload.get("role", "")
         content = payload.get("content", "")
         turn_id = payload.get("turn_id") or ""
@@ -167,7 +167,7 @@ class StepTracker:
                 "step_tracker_missing_turn_id",
                 job_id=job_id,
                 role=role,
-                event_id=event.event_id,
+                event_id=event.id,
             )
 
         current = self._current.get(job_id)
@@ -264,9 +264,8 @@ class StepTracker:
         )
         self._current[job_id] = state
         await self._event_bus.publish(
-            DomainEvent(
-                event_id=DomainEvent.make_event_id(),
-                job_id=job_id,
+            new_event(
+                session_id=job_id,
                 timestamp=state.started_at,
                 kind=DomainEventKind.step_started,
                 payload={
@@ -327,9 +326,8 @@ class StepTracker:
                     log.debug("step_diff_numstat_failed", job_id=job_id, exc_info=True)
 
         await self._event_bus.publish(
-            DomainEvent(
-                event_id=DomainEvent.make_event_id(),
-                job_id=job_id,
+            new_event(
+                session_id=job_id,
                 timestamp=now,
                 kind=DomainEventKind.step_completed,
                 payload={
@@ -367,7 +365,7 @@ class StepTracker:
 # ---------------------------------------------------------------------------
 
 
-def _detect_latest_generation(step_events: Sequence[DomainEvent]) -> set[str]:
+def _detect_latest_generation(step_events: Sequence[SessionEvent]) -> set[str]:
     """Detect the latest plan generation from a sequence of plan_step_updated events.
 
     The step tracker replaces the in-memory plan when re-inferring, but old
@@ -381,7 +379,7 @@ def _detect_latest_generation(step_events: Sequence[DomainEvent]) -> set[str]:
     current_gen_start: float = 0.0
 
     for ev in step_events:
-        payload = cast("dict[str, Any]", ev.payload)
+        payload = ev.payload
         sid = payload.get("plan_step_id", "")
         if not sid:
             continue
@@ -402,7 +400,7 @@ def _detect_latest_generation(step_events: Sequence[DomainEvent]) -> set[str]:
 
 
 def hydrate_plan_steps(
-    step_events: Sequence[DomainEvent],
+    step_events: Sequence[SessionEvent],
     job_id: str,
     *,
     detect_generations: bool = True,
@@ -426,7 +424,7 @@ def hydrate_plan_steps(
     step_latest: dict[str, dict[str, Any]] = {}
     step_order: list[str] = []
     for ev in step_events:
-        payload = cast("dict[str, Any]", ev.payload)
+        payload = ev.payload
         sid = payload.get("plan_step_id", "")
         if not sid:
             continue

--- a/backend/services/steps/tracker.py
+++ b/backend/services/steps/tracker.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from backend.services.events.event_bus import EventBus
     from backend.services.git.git_service import GitService
 
-from backend.models.events import CPEventKind, SessionEvent, new_event
+from backend.models.events import EventKind, SessionEvent, new_event
 from backend.services.git.git_service import GitError
 from backend.services.tools.tool_classifier import TOOL_CATEGORIES
 
@@ -267,7 +267,7 @@ class StepTracker:
             new_event(
                 session_id=job_id,
                 timestamp=state.started_at,
-                kind=CPEventKind.step_started,
+                kind=EventKind.step_started,
                 payload={
                     "step_id": step_id,
                     "step_number": n,
@@ -329,7 +329,7 @@ class StepTracker:
             new_event(
                 session_id=job_id,
                 timestamp=now,
-                kind=CPEventKind.step_completed,
+                kind=EventKind.step_completed,
                 payload={
                     "step_id": state.step_id,
                     "turn_id": state.turn_id,

--- a/backend/services/steps/tracker.py
+++ b/backend/services/steps/tracker.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from backend.services.events.event_bus import EventBus
     from backend.services.git.git_service import GitService
 
-from backend.models.events import DomainEventKind, SessionEvent, new_event
+from backend.models.events import CPEventKind, SessionEvent, new_event
 from backend.services.git.git_service import GitError
 from backend.services.tools.tool_classifier import TOOL_CATEGORIES
 
@@ -267,7 +267,7 @@ class StepTracker:
             new_event(
                 session_id=job_id,
                 timestamp=state.started_at,
-                kind=DomainEventKind.step_started,
+                kind=CPEventKind.step_started,
                 payload={
                     "step_id": step_id,
                     "step_number": n,
@@ -329,7 +329,7 @@ class StepTracker:
             new_event(
                 session_id=job_id,
                 timestamp=now,
-                kind=DomainEventKind.step_completed,
+                kind=CPEventKind.step_completed,
                 payload={
                     "step_id": state.step_id,
                     "turn_id": state.turn_id,

--- a/backend/services/trail/activity_tracker.py
+++ b/backend/services/trail/activity_tracker.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 import structlog
 
-from backend.models.events import CPEventKind, new_event
+from backend.models.events import EventKind, new_event
 from backend.services.trail.models import (
     Activity,
     ActivityStep,
@@ -128,7 +128,7 @@ class ActivityTracker:
                 new_event(
                     session_id=job_id,
                     timestamp=datetime.now(UTC),
-                    kind=CPEventKind.turn_summary,
+                    kind=EventKind.turn_summary,
                     payload={
                         "turn_id": turn_id,
                         "title": title,
@@ -178,7 +178,7 @@ class ActivityTracker:
             new_event(
                 session_id=job_id,
                 timestamp=datetime.now(UTC),
-                kind=CPEventKind.turn_summary,
+                kind=EventKind.turn_summary,
                 payload={
                     "turn_id": turn_id,
                     "title": title,

--- a/backend/services/trail/activity_tracker.py
+++ b/backend/services/trail/activity_tracker.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 import structlog
 
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, new_event
 from backend.services.trail.models import (
     Activity,
     ActivityStep,
@@ -125,9 +125,8 @@ class ActivityTracker:
             prev_step.title = title
             prev_step.turn_id = turn_id
             await self._event_bus.publish(
-                DomainEvent(
-                    event_id=DomainEvent.make_event_id(),
-                    job_id=job_id,
+                new_event(
+                    session_id=job_id,
                     timestamp=datetime.now(UTC),
                     kind=DomainEventKind.turn_summary,
                     payload={
@@ -176,9 +175,8 @@ class ActivityTracker:
         state.activity_steps.append(step)
 
         await self._event_bus.publish(
-            DomainEvent(
-                event_id=DomainEvent.make_event_id(),
-                job_id=job_id,
+            new_event(
+                session_id=job_id,
                 timestamp=datetime.now(UTC),
                 kind=DomainEventKind.turn_summary,
                 payload={

--- a/backend/services/trail/activity_tracker.py
+++ b/backend/services/trail/activity_tracker.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 import structlog
 
-from backend.models.events import DomainEventKind, new_event
+from backend.models.events import CPEventKind, new_event
 from backend.services.trail.models import (
     Activity,
     ActivityStep,
@@ -128,7 +128,7 @@ class ActivityTracker:
                 new_event(
                     session_id=job_id,
                     timestamp=datetime.now(UTC),
-                    kind=DomainEventKind.turn_summary,
+                    kind=CPEventKind.turn_summary,
                     payload={
                         "turn_id": turn_id,
                         "title": title,
@@ -178,7 +178,7 @@ class ActivityTracker:
             new_event(
                 session_id=job_id,
                 timestamp=datetime.now(UTC),
-                kind=DomainEventKind.turn_summary,
+                kind=CPEventKind.turn_summary,
                 payload={
                     "turn_id": turn_id,
                     "title": title,

--- a/backend/services/trail/enricher.py
+++ b/backend/services/trail/enricher.py
@@ -13,7 +13,7 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from backend.config import TrailConfig
 from backend.models.db import TrailNodeRow
-from backend.models.events import DomainEventKind, new_event
+from backend.models.events import CPEventKind, new_event
 from backend.persistence.trail_repo import TrailNodeRepository
 from backend.services.story.motivation import (
     _EDIT_SYSTEM_PROMPT,
@@ -266,7 +266,7 @@ class TrailEnricher:
                         new_event(
                             session_id=node.job_id,
                             timestamp=node.timestamp,
-                            kind=DomainEventKind.turn_summary,
+                            kind=CPEventKind.turn_summary,
                             payload={
                                 "turn_id": node.turn_id,
                                 "title": title,

--- a/backend/services/trail/enricher.py
+++ b/backend/services/trail/enricher.py
@@ -13,7 +13,7 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from backend.config import TrailConfig
 from backend.models.db import TrailNodeRow
-from backend.models.events import CPEventKind, new_event
+from backend.models.events import EventKind, new_event
 from backend.persistence.trail_repo import TrailNodeRepository
 from backend.services.story.motivation import (
     _EDIT_SYSTEM_PROMPT,
@@ -266,7 +266,7 @@ class TrailEnricher:
                         new_event(
                             session_id=node.job_id,
                             timestamp=node.timestamp,
-                            kind=CPEventKind.turn_summary,
+                            kind=EventKind.turn_summary,
                             payload={
                                 "turn_id": node.turn_id,
                                 "title": title,

--- a/backend/services/trail/enricher.py
+++ b/backend/services/trail/enricher.py
@@ -13,7 +13,7 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from backend.config import TrailConfig
 from backend.models.db import TrailNodeRow
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, new_event
 from backend.persistence.trail_repo import TrailNodeRepository
 from backend.services.story.motivation import (
     _EDIT_SYSTEM_PROMPT,
@@ -263,9 +263,8 @@ class TrailEnricher:
                 # the activity tracker will handle emission when it runs.
                 if activity_id:
                     await self._event_bus.publish(
-                        DomainEvent(
-                            event_id=DomainEvent.make_event_id(),
-                            job_id=node.job_id,
+                        new_event(
+                            session_id=node.job_id,
                             timestamp=node.timestamp,
                             kind=DomainEventKind.turn_summary,
                             payload={

--- a/backend/services/trail/models.py
+++ b/backend/services/trail/models.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, TypedDict
 if TYPE_CHECKING:
     from datetime import datetime
 
-    from backend.models.events import DomainEvent
+    from backend.models.events import SessionEvent
 
 # ---------------------------------------------------------------------------
 # Buffer size constants — see context_window_eval.py for derivation
@@ -171,7 +171,7 @@ class TrailJobState:
     active_step_id: str | None = None
     current_phase: str | None = None
     next_seq: int = 1
-    pending_events: list[DomainEvent] = field(default_factory=list)
+    pending_events: list[SessionEvent] = field(default_factory=list)
 
     # Plan management
     plan_steps: list[PlanStep] = field(default_factory=list)

--- a/backend/services/trail/node_builder.py
+++ b/backend/services/trail/node_builder.py
@@ -11,7 +11,7 @@ from sqlalchemy import select as sa_select
 from sqlalchemy.exc import DBAPIError
 
 from backend.models.db import JobRow, TrailNodeRow
-from backend.models.events import DomainEventKind, SessionEvent
+from backend.models.events import TRANSCRIPT_KINDS, CPEventKind, SessionEvent
 from backend.services.trail.models import (
     MESSAGE_SIGNAL_BUFFER_SIZE,
     Activity,
@@ -139,27 +139,27 @@ class TrailNodeBuilder:
 
         async with lock:
             try:
-                if event.kind == DomainEventKind.job_state_changed:
+                if event.kind == CPEventKind.job_state_changed:
                     new_state = (event.payload or {}).get("new_state")
                     if new_state == "running" and event.session_id not in self._job_state:
                         await self._on_job_started(event)
-                elif event.kind == DomainEventKind.session_resumed:
+                elif event.kind == CPEventKind.session_resumed:
                     await self._on_session_resumed(event)
-                elif event.kind == DomainEventKind.step_completed:
+                elif event.kind == CPEventKind.step_completed:
                     await self._on_step_completed(event)
-                elif event.kind == DomainEventKind.step_started:
+                elif event.kind == CPEventKind.step_started:
                     self._on_step_started(event)
-                elif event.kind == DomainEventKind.execution_phase_changed:
+                elif event.kind == CPEventKind.execution_phase_changed:
                     await self._on_phase_changed(event)
-                elif event.kind == DomainEventKind.transcript_updated:
+                elif event.kind in TRANSCRIPT_KINDS:
                     await self._on_transcript_updated(event)
-                elif event.kind == DomainEventKind.approval_requested:
+                elif event.kind == CPEventKind.approval_requested:
                     await self._on_approval_requested(event)
                 elif event.kind in (
-                    DomainEventKind.job_completed,
-                    DomainEventKind.job_failed,
-                    DomainEventKind.job_canceled,
-                    DomainEventKind.job_review,
+                    CPEventKind.job_completed,
+                    CPEventKind.job_failed,
+                    CPEventKind.job_canceled,
+                    CPEventKind.job_review,
                 ):
                     await self._on_job_terminal(event)
             except Exception:  # Safety-net: protect event loop from unexpected failures
@@ -216,7 +216,7 @@ class TrailNodeBuilder:
             # 200 provides ~3× headroom over observed maximums.
             plan_events = await event_repo.list_by_job(
                 job_id,
-                [DomainEventKind.plan_step_updated],
+                [CPEventKind.plan_step_updated],
                 limit=200,
             )
         if plan_events:
@@ -840,8 +840,8 @@ class TrailNodeBuilder:
         seq = state.next_seq
         state.next_seq += 1
 
-        status = "completed" if event.kind == DomainEventKind.job_completed else "failed"
-        if event.kind == DomainEventKind.job_canceled:
+        status = "completed" if event.kind == CPEventKind.job_completed else "failed"
+        if event.kind == CPEventKind.job_canceled:
             status = "canceled"
 
         node = TrailNodeRow(

--- a/backend/services/trail/node_builder.py
+++ b/backend/services/trail/node_builder.py
@@ -11,7 +11,7 @@ from sqlalchemy import select as sa_select
 from sqlalchemy.exc import DBAPIError
 
 from backend.models.db import JobRow, TrailNodeRow
-from backend.models.events import TRANSCRIPT_KINDS, CPEventKind, SessionEvent
+from backend.models.events import TRANSCRIPT_KINDS, EventKind, SessionEvent
 from backend.services.trail.models import (
     MESSAGE_SIGNAL_BUFFER_SIZE,
     Activity,
@@ -139,27 +139,27 @@ class TrailNodeBuilder:
 
         async with lock:
             try:
-                if event.kind == CPEventKind.job_state_changed:
+                if event.kind == EventKind.job_state_changed:
                     new_state = (event.payload or {}).get("new_state")
                     if new_state == "running" and event.session_id not in self._job_state:
                         await self._on_job_started(event)
-                elif event.kind == CPEventKind.session_resumed:
+                elif event.kind == EventKind.session_resumed:
                     await self._on_session_resumed(event)
-                elif event.kind == CPEventKind.step_completed:
+                elif event.kind == EventKind.step_completed:
                     await self._on_step_completed(event)
-                elif event.kind == CPEventKind.step_started:
+                elif event.kind == EventKind.step_started:
                     self._on_step_started(event)
-                elif event.kind == CPEventKind.execution_phase_changed:
+                elif event.kind == EventKind.execution_phase_changed:
                     await self._on_phase_changed(event)
                 elif event.kind in TRANSCRIPT_KINDS:
                     await self._on_transcript_updated(event)
-                elif event.kind == CPEventKind.approval_requested:
+                elif event.kind == EventKind.approval_requested:
                     await self._on_approval_requested(event)
                 elif event.kind in (
-                    CPEventKind.job_completed,
-                    CPEventKind.job_failed,
-                    CPEventKind.job_canceled,
-                    CPEventKind.job_review,
+                    EventKind.job_completed,
+                    EventKind.job_failed,
+                    EventKind.job_canceled,
+                    EventKind.job_review,
                 ):
                     await self._on_job_terminal(event)
             except Exception:  # Safety-net: protect event loop from unexpected failures
@@ -216,7 +216,7 @@ class TrailNodeBuilder:
             # 200 provides ~3× headroom over observed maximums.
             plan_events = await event_repo.list_by_job(
                 job_id,
-                [CPEventKind.plan_step_updated],
+                [EventKind.plan_step_updated],
                 limit=200,
             )
         if plan_events:
@@ -840,8 +840,8 @@ class TrailNodeBuilder:
         seq = state.next_seq
         state.next_seq += 1
 
-        status = "completed" if event.kind == CPEventKind.job_completed else "failed"
-        if event.kind == CPEventKind.job_canceled:
+        status = "completed" if event.kind == EventKind.job_completed else "failed"
+        if event.kind == EventKind.job_canceled:
             status = "canceled"
 
         node = TrailNodeRow(

--- a/backend/services/trail/node_builder.py
+++ b/backend/services/trail/node_builder.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 
 import asyncio
 import json
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 import structlog
 from sqlalchemy import select as sa_select
 from sqlalchemy.exc import DBAPIError
 
 from backend.models.db import JobRow, TrailNodeRow
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, SessionEvent
 from backend.services.trail.models import (
     MESSAGE_SIGNAL_BUFFER_SIZE,
     Activity,
@@ -123,9 +123,9 @@ class TrailNodeBuilder:
         if self._background_tasks:
             await asyncio.gather(*self._background_tasks, return_exceptions=True)
 
-    async def handle_event(self, event: DomainEvent) -> None:
+    async def handle_event(self, event: SessionEvent) -> None:
         """Domain event subscriber — builds deterministic trail nodes."""
-        job_id = event.job_id
+        job_id = event.session_id
         if not job_id:
             return
 
@@ -141,7 +141,7 @@ class TrailNodeBuilder:
             try:
                 if event.kind == DomainEventKind.job_state_changed:
                     new_state = (event.payload or {}).get("new_state")
-                    if new_state == "running" and event.job_id not in self._job_state:
+                    if new_state == "running" and event.session_id not in self._job_state:
                         await self._on_job_started(event)
                 elif event.kind == DomainEventKind.session_resumed:
                     await self._on_session_resumed(event)
@@ -163,15 +163,15 @@ class TrailNodeBuilder:
                 ):
                     await self._on_job_terminal(event)
             except Exception:  # Safety-net: protect event loop from unexpected failures
-                log.warning("trail_event_error", event_kind=event.kind, job_id=event.job_id, exc_info=True)
+                log.warning("trail_event_error", event_kind=event.kind, job_id=event.session_id, exc_info=True)
 
-    async def _on_session_resumed(self, event: DomainEvent) -> None:
+    async def _on_session_resumed(self, event: SessionEvent) -> None:
         """Rehydrate trail state when a job session resumes.
 
         §13.5: Try loading from persisted snapshot first (lossless).
         Fall back to reconstruction from trail nodes (lossy).
         """
-        job_id = event.job_id
+        job_id = event.session_id
         assert job_id is not None
         if job_id in self._job_state:
             return
@@ -220,15 +220,15 @@ class TrailNodeBuilder:
                 limit=200,
             )
         if plan_events:
-            latest_by_id: dict[str, DomainEvent] = {}
+            latest_by_id: dict[str, SessionEvent] = {}
             for ev in plan_events:
-                p = cast("dict[str, Any]", ev.payload)
+                p = ev.payload
                 ps_id = p.get("plan_step_id")
                 if ps_id:
                     latest_by_id[ps_id] = ev
             steps: list[PlanStep] = []
             for ps_id, ev in latest_by_id.items():
-                p = cast("dict[str, Any]", ev.payload)
+                p = ev.payload
                 ps = PlanStep(
                     plan_step_id=ps_id,
                     label=str(p.get("label", "")),
@@ -285,9 +285,9 @@ class TrailNodeBuilder:
             activities=len(state.activities),
         )
 
-    async def _on_job_started(self, event: DomainEvent) -> None:
+    async def _on_job_started(self, event: SessionEvent) -> None:
         """Create the goal node for a new job."""
-        job_id = event.job_id
+        job_id = event.session_id
         assert job_id is not None
         state = TrailJobState()
         self._job_state[job_id] = state
@@ -332,23 +332,23 @@ class TrailNodeBuilder:
         await self._repo.create(node)
         log.debug("trail_goal_created", job_id=job_id, node_id=node_id)
 
-    def _on_step_started(self, event: DomainEvent) -> None:
+    def _on_step_started(self, event: SessionEvent) -> None:
         """Track the currently active step for approval anchoring."""
-        job_id = event.job_id
+        job_id = event.session_id
         assert job_id is not None
         state = self._job_state.get(job_id)
         if state:
             state.active_step_id = event.payload.get("step_id")
 
-    async def _on_step_completed(self, event: DomainEvent) -> None:
+    async def _on_step_completed(self, event: SessionEvent) -> None:
         """Create a deterministic trail node from step completion data."""
-        job_id = event.job_id
+        job_id = event.session_id
         assert job_id is not None
         state = self._job_state.get(job_id)
         if not state:
             return
 
-        payload = cast("dict[str, Any]", event.payload)
+        payload = event.payload
         if payload.get("status") == "canceled":
             return
 
@@ -598,12 +598,12 @@ class TrailNodeBuilder:
 
     async def _emit_pending_event(
         self,
-        event: DomainEvent,
+        event: SessionEvent,
         state: TrailJobState,
         anchor_seq: int,
     ) -> None:
         """Emit a deferred event (e.g. approval_requested before step_completed)."""
-        job_id = event.job_id
+        job_id = event.session_id
         assert job_id is not None
         node_id = make_node_id()
         seq = state.next_seq
@@ -626,7 +626,7 @@ class TrailNodeBuilder:
         await self._repo.create(node)
         log.debug("trail_request_node_created", job_id=job_id, node_id=node_id)
 
-    async def _on_transcript_updated(self, event: DomainEvent) -> None:
+    async def _on_transcript_updated(self, event: SessionEvent) -> None:
         """Create or update trail nodes for transcript messages.
 
         Handles three transcript roles:
@@ -635,7 +635,7 @@ class TrailNodeBuilder:
           (tool_display, tool_intent, tool_success) per §13.3.
         - agent/assistant: Updates step node agent_message if not already set.
         """
-        job_id = event.job_id
+        job_id = event.session_id
         assert job_id is not None
         state = self._job_state.get(job_id)
         if not state:
@@ -653,11 +653,11 @@ class TrailNodeBuilder:
 
     async def _handle_operator_transcript(
         self,
-        event: DomainEvent,
+        event: SessionEvent,
         state: TrailJobState,
     ) -> None:
         """Create a request node for an operator/user transcript message."""
-        job_id = event.job_id
+        job_id = event.session_id
         assert job_id is not None
         payload = event.payload or {}
         content = str(payload.get("content", "")).strip()
@@ -692,7 +692,7 @@ class TrailNodeBuilder:
 
     async def _handle_tool_call_transcript(
         self,
-        event: DomainEvent,
+        event: SessionEvent,
         state: TrailJobState,
     ) -> None:
         """Update matching write sub-node with tool metadata (§13.3).
@@ -701,7 +701,7 @@ class TrailNodeBuilder:
         matching (job_id, turn_id, tool_name) and populate tool_display,
         tool_intent, tool_success. Skips report_intent (frontend-only).
         """
-        payload = cast("dict[str, Any]", event.payload or {})
+        payload = event.payload or {}
         tool_name = payload.get("tool_name", "")
         if not tool_name or tool_name == "report_intent":
             return
@@ -709,7 +709,7 @@ class TrailNodeBuilder:
         turn_id = payload.get("turn_id")
         if not turn_id:
             return
-        if not event.job_id:
+        if not event.session_id:
             return
 
         tool_display = payload.get("tool_display") or None
@@ -719,7 +719,7 @@ class TrailNodeBuilder:
             tool_success = bool(tool_success)
 
         updated = await self._repo.update_tool_metadata(
-            event.job_id,
+            event.session_id,
             turn_id,
             tool_name,
             tool_display=tool_display,
@@ -729,14 +729,14 @@ class TrailNodeBuilder:
         if updated:
             log.debug(
                 "trail_tool_metadata_updated",
-                job_id=event.job_id,
+                job_id=event.session_id,
                 turn_id=turn_id,
                 tool_name=tool_name,
             )
 
     async def _handle_assistant_transcript(
         self,
-        event: DomainEvent,
+        event: SessionEvent,
         state: TrailJobState,
     ) -> None:
         """Track assistant message content for activity boundary detection.
@@ -757,9 +757,9 @@ class TrailNodeBuilder:
         if len(state.recent_messages) > MESSAGE_SIGNAL_BUFFER_SIZE:
             state.recent_messages = state.recent_messages[-MESSAGE_SIGNAL_BUFFER_SIZE:]
 
-    async def _on_phase_changed(self, event: DomainEvent) -> None:
+    async def _on_phase_changed(self, event: SessionEvent) -> None:
         """Create a summarize node for execution phase transitions."""
-        job_id = event.job_id
+        job_id = event.session_id
         assert job_id is not None
         state = self._job_state.get(job_id)
         if not state:
@@ -788,9 +788,9 @@ class TrailNodeBuilder:
         await self._repo.create(node)
         log.debug("trail_summarize_created", job_id=job_id, phase=phase)
 
-    async def _on_approval_requested(self, event: DomainEvent) -> None:
+    async def _on_approval_requested(self, event: SessionEvent) -> None:
         """Create a request node or defer if step hasn't completed yet."""
-        job_id = event.job_id
+        job_id = event.session_id
         assert job_id is not None
         state = self._job_state.get(job_id)
         if not state:
@@ -820,9 +820,9 @@ class TrailNodeBuilder:
             await self._repo.create(node)
             log.debug("trail_request_created", job_id=job_id, node_id=node_id)
 
-    async def _on_job_terminal(self, event: DomainEvent) -> None:
+    async def _on_job_terminal(self, event: SessionEvent) -> None:
         """Create a terminal summarize node and clean up."""
-        job_id = event.job_id
+        job_id = event.session_id
         assert job_id is not None
         state = self._job_state.get(job_id)
         if not state:

--- a/backend/services/trail/plan_manager.py
+++ b/backend/services/trail/plan_manager.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 import structlog
 
-from backend.models.events import CPEventKind, new_event
+from backend.models.events import EventKind, new_event
 from backend.services.trail.models import (
     CONTEXT_WINDOW_SIZE,
     MESSAGE_SIGNAL_BUFFER_SIZE,
@@ -227,7 +227,7 @@ class PlanManager:
                 new_event(
                     session_id=job_id,
                     timestamp=now,
-                    kind=CPEventKind.step_entries_reassigned,
+                    kind=EventKind.step_entries_reassigned,
                     payload={
                         "turn_id": turn_id,
                         "old_step_id": stamped_step_id,
@@ -539,7 +539,7 @@ class PlanManager:
             new_event(
                 session_id=job_id,
                 timestamp=datetime.now(UTC),
-                kind=CPEventKind.plan_step_updated,
+                kind=EventKind.plan_step_updated,
                 payload=ps.to_event_payload(),
             )
         )
@@ -549,7 +549,7 @@ class PlanManager:
             new_event(
                 session_id=job_id,
                 timestamp=datetime.now(UTC),
-                kind=CPEventKind.progress_headline,
+                kind=EventKind.progress_headline,
                 payload={
                     "headline": ps.label,
                     "headline_past": ps.label,

--- a/backend/services/trail/plan_manager.py
+++ b/backend/services/trail/plan_manager.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 import structlog
 
-from backend.models.events import DomainEventKind, new_event
+from backend.models.events import CPEventKind, new_event
 from backend.services.trail.models import (
     CONTEXT_WINDOW_SIZE,
     MESSAGE_SIGNAL_BUFFER_SIZE,
@@ -227,7 +227,7 @@ class PlanManager:
                 new_event(
                     session_id=job_id,
                     timestamp=now,
-                    kind=DomainEventKind.step_entries_reassigned,
+                    kind=CPEventKind.step_entries_reassigned,
                     payload={
                         "turn_id": turn_id,
                         "old_step_id": stamped_step_id,
@@ -539,7 +539,7 @@ class PlanManager:
             new_event(
                 session_id=job_id,
                 timestamp=datetime.now(UTC),
-                kind=DomainEventKind.plan_step_updated,
+                kind=CPEventKind.plan_step_updated,
                 payload=ps.to_event_payload(),
             )
         )
@@ -549,7 +549,7 @@ class PlanManager:
             new_event(
                 session_id=job_id,
                 timestamp=datetime.now(UTC),
-                kind=DomainEventKind.progress_headline,
+                kind=CPEventKind.progress_headline,
                 payload={
                     "headline": ps.label,
                     "headline_past": ps.label,

--- a/backend/services/trail/plan_manager.py
+++ b/backend/services/trail/plan_manager.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 import structlog
 
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, new_event
 from backend.services.trail.models import (
     CONTEXT_WINDOW_SIZE,
     MESSAGE_SIGNAL_BUFFER_SIZE,
@@ -224,9 +224,8 @@ class PlanManager:
         stamped_step_id = steps[active_idx].plan_step_id
         if target_idx != active_idx and turn_id and ps.plan_step_id != stamped_step_id:
             await self._event_bus.publish(
-                DomainEvent(
-                    event_id=DomainEvent.make_event_id(),
-                    job_id=job_id,
+                new_event(
+                    session_id=job_id,
                     timestamp=now,
                     kind=DomainEventKind.step_entries_reassigned,
                     payload={
@@ -537,9 +536,8 @@ class PlanManager:
 
     async def _emit_plan_step(self, job_id: str, ps: PlanStep) -> None:
         await self._event_bus.publish(
-            DomainEvent(
-                event_id=DomainEvent.make_event_id(),
-                job_id=job_id,
+            new_event(
+                session_id=job_id,
                 timestamp=datetime.now(UTC),
                 kind=DomainEventKind.plan_step_updated,
                 payload=ps.to_event_payload(),
@@ -548,9 +546,8 @@ class PlanManager:
 
     async def _emit_card_headline(self, job_id: str, ps: PlanStep) -> None:
         await self._event_bus.publish(
-            DomainEvent(
-                event_id=DomainEvent.make_event_id(),
-                job_id=job_id,
+            new_event(
+                session_id=job_id,
                 timestamp=datetime.now(UTC),
                 kind=DomainEventKind.progress_headline,
                 payload={

--- a/backend/services/trail/service.py
+++ b/backend/services/trail/service.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 import structlog
 
 from backend.config import TrailConfig
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, SessionEvent, new_event
 from backend.persistence.trail_repo import TrailNodeRepository
 from backend.services.tools.parsing_utils import ensure_dict
 from backend.services.trail.activity_tracker import ActivityTracker
@@ -108,7 +108,7 @@ class TrailService:
     # Event handling (delegate to node builder + plan feed)
     # ==================================================================
 
-    async def handle_event(self, event: DomainEvent) -> None:
+    async def handle_event(self, event: SessionEvent) -> None:
         """Domain event subscriber — single entry point for all enrichment.
 
         Both managed (RuntimeService) and imported (IngestService) jobs
@@ -121,16 +121,16 @@ class TrailService:
         if event.kind == DomainEventKind.transcript_updated:
             await self._on_transcript_event(event)
 
-    async def _on_transcript_event(self, event: DomainEvent) -> None:
+    async def _on_transcript_event(self, event: SessionEvent) -> None:
         """Feed plan manager and capture native plans from transcript events."""
-        payload = cast("dict[str, Any]", event.payload or {})
+        payload = event.payload or {}
         role = str(payload.get("role", ""))
 
         # Skip ephemeral streaming deltas — no plan value
         if role == "agent_delta":
             return
 
-        job_id = event.job_id
+        job_id = event.session_id
         if not job_id:
             return
         content = str(payload.get("content", ""))
@@ -220,9 +220,8 @@ class TrailService:
                 await session.commit()
 
             await self._event_bus.publish(
-                DomainEvent(
-                    event_id=DomainEvent.make_event_id(),
-                    job_id=job_id,
+                new_event(
+                    session_id=job_id,
                     timestamp=datetime.now(UTC),
                     kind=DomainEventKind.job_title_updated,
                     payload={"title": title},

--- a/backend/services/trail/service.py
+++ b/backend/services/trail/service.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 import structlog
 
 from backend.config import TrailConfig
-from backend.models.events import TRANSCRIPT_KINDS, CPEventKind, SessionEvent, new_event
+from backend.models.events import TRANSCRIPT_KINDS, EventKind, SessionEvent, new_event
 from backend.persistence.trail_repo import TrailNodeRepository
 from backend.services.tools.parsing_utils import ensure_dict
 from backend.services.trail.activity_tracker import ActivityTracker
@@ -223,7 +223,7 @@ class TrailService:
                 new_event(
                     session_id=job_id,
                     timestamp=datetime.now(UTC),
-                    kind=CPEventKind.job_title_updated,
+                    kind=EventKind.job_title_updated,
                     payload={"title": title},
                 )
             )

--- a/backend/services/trail/service.py
+++ b/backend/services/trail/service.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 import structlog
 
 from backend.config import TrailConfig
-from backend.models.events import DomainEventKind, SessionEvent, new_event
+from backend.models.events import TRANSCRIPT_KINDS, CPEventKind, SessionEvent, new_event
 from backend.persistence.trail_repo import TrailNodeRepository
 from backend.services.tools.parsing_utils import ensure_dict
 from backend.services.trail.activity_tracker import ActivityTracker
@@ -118,7 +118,7 @@ class TrailService:
         """
         await self._node_builder.handle_event(event)
 
-        if event.kind == DomainEventKind.transcript_updated:
+        if event.kind in TRANSCRIPT_KINDS:
             await self._on_transcript_event(event)
 
     async def _on_transcript_event(self, event: SessionEvent) -> None:
@@ -223,7 +223,7 @@ class TrailService:
                 new_event(
                     session_id=job_id,
                     timestamp=datetime.now(UTC),
-                    kind=DomainEventKind.job_title_updated,
+                    kind=CPEventKind.job_title_updated,
                     payload={"title": title},
                 )
             )

--- a/backend/services/watcher/claude.py
+++ b/backend/services/watcher/claude.py
@@ -30,7 +30,7 @@ parse_message = cast("Any", _message_parser).parse_message
 MessageParseError = cast("type[Exception]", getattr(_message_parser, "MessageParseError", ValueError))
 
 from backend.models.domain import Job, JobSource, JobState, SessionEvent  # noqa: E402
-from backend.models.events import DomainEventKind, new_event  # noqa: E402
+from backend.models.events import CPEventKind, new_event  # noqa: E402
 from backend.services.events.event_pipeline import EventPipeline  # noqa: E402
 from backend.services.watcher.telemetry_mixin import WatcherTelemetryMixin  # noqa: E402
 
@@ -574,7 +574,7 @@ class ClaudeSessionStateWatcher(WatcherTelemetryMixin):
                         new_event(
                             session_id=job_id,
                             timestamp=now,
-                            kind=DomainEventKind.job_state_changed,
+                            kind=CPEventKind.job_state_changed,
                             payload={"state": JobState.running, "new_state": JobState.running},
                         )
                     )
@@ -623,7 +623,7 @@ class ClaudeSessionStateWatcher(WatcherTelemetryMixin):
             new_event(
                 session_id=job_id,
                 timestamp=now,
-                kind=DomainEventKind.job_created,
+                kind=CPEventKind.job_created,
                 payload={
                     "repo": repo_path,
                     "branch": branch,
@@ -637,7 +637,7 @@ class ClaudeSessionStateWatcher(WatcherTelemetryMixin):
             new_event(
                 session_id=job_id,
                 timestamp=now,
-                kind=DomainEventKind.job_state_changed,
+                kind=CPEventKind.job_state_changed,
                 payload={"state": JobState.running, "new_state": JobState.running},
             )
         )
@@ -1027,7 +1027,7 @@ class ClaudeSessionStateWatcher(WatcherTelemetryMixin):
             new_event(
                 session_id=job_id,
                 timestamp=now,
-                kind=DomainEventKind.job_state_changed,
+                kind=CPEventKind.job_state_changed,
                 payload={"state": new_state, "new_state": new_state},
             )
         )
@@ -1037,7 +1037,7 @@ class ClaudeSessionStateWatcher(WatcherTelemetryMixin):
                 new_event(
                     session_id=job_id,
                     timestamp=now,
-                    kind=DomainEventKind.job_review,
+                    kind=CPEventKind.job_review,
                     payload={"resolution": "unresolved"},
                 )
             )

--- a/backend/services/watcher/claude.py
+++ b/backend/services/watcher/claude.py
@@ -30,7 +30,7 @@ parse_message = cast("Any", _message_parser).parse_message
 MessageParseError = cast("type[Exception]", getattr(_message_parser, "MessageParseError", ValueError))
 
 from backend.models.domain import Job, JobSource, JobState, SessionEvent  # noqa: E402
-from backend.models.events import DomainEvent, DomainEventKind  # noqa: E402
+from backend.models.events import DomainEventKind, new_event  # noqa: E402
 from backend.services.events.event_pipeline import EventPipeline  # noqa: E402
 from backend.services.watcher.telemetry_mixin import WatcherTelemetryMixin  # noqa: E402
 
@@ -571,9 +571,8 @@ class ClaudeSessionStateWatcher(WatcherTelemetryMixin):
                         session_id=session_id,
                     )
                     await self._event_bus.publish(
-                        DomainEvent(
-                            event_id=DomainEvent.make_event_id(),
-                            job_id=job_id,
+                        new_event(
+                            session_id=job_id,
                             timestamp=now,
                             kind=DomainEventKind.job_state_changed,
                             payload={"state": JobState.running, "new_state": JobState.running},
@@ -621,9 +620,8 @@ class ClaudeSessionStateWatcher(WatcherTelemetryMixin):
 
         # Publish creation events
         await self._event_bus.publish(
-            DomainEvent(
-                event_id=DomainEvent.make_event_id(),
-                job_id=job_id,
+            new_event(
+                session_id=job_id,
                 timestamp=now,
                 kind=DomainEventKind.job_created,
                 payload={
@@ -636,9 +634,8 @@ class ClaudeSessionStateWatcher(WatcherTelemetryMixin):
             )
         )
         await self._event_bus.publish(
-            DomainEvent(
-                event_id=DomainEvent.make_event_id(),
-                job_id=job_id,
+            new_event(
+                session_id=job_id,
                 timestamp=now,
                 kind=DomainEventKind.job_state_changed,
                 payload={"state": JobState.running, "new_state": JobState.running},
@@ -1027,9 +1024,8 @@ class ClaudeSessionStateWatcher(WatcherTelemetryMixin):
             return
 
         await self._event_bus.publish(
-            DomainEvent(
-                event_id=DomainEvent.make_event_id(),
-                job_id=job_id,
+            new_event(
+                session_id=job_id,
                 timestamp=now,
                 kind=DomainEventKind.job_state_changed,
                 payload={"state": new_state, "new_state": new_state},
@@ -1038,9 +1034,8 @@ class ClaudeSessionStateWatcher(WatcherTelemetryMixin):
 
         if new_state == JobState.review:
             await self._event_bus.publish(
-                DomainEvent(
-                    event_id=DomainEvent.make_event_id(),
-                    job_id=job_id,
+                new_event(
+                    session_id=job_id,
                     timestamp=now,
                     kind=DomainEventKind.job_review,
                     payload={"resolution": "unresolved"},

--- a/backend/services/watcher/claude.py
+++ b/backend/services/watcher/claude.py
@@ -30,7 +30,7 @@ parse_message = cast("Any", _message_parser).parse_message
 MessageParseError = cast("type[Exception]", getattr(_message_parser, "MessageParseError", ValueError))
 
 from backend.models.domain import Job, JobSource, JobState, SessionEvent  # noqa: E402
-from backend.models.events import CPEventKind, new_event  # noqa: E402
+from backend.models.events import EventKind, new_event  # noqa: E402
 from backend.services.events.event_pipeline import EventPipeline  # noqa: E402
 from backend.services.watcher.telemetry_mixin import WatcherTelemetryMixin  # noqa: E402
 
@@ -574,7 +574,7 @@ class ClaudeSessionStateWatcher(WatcherTelemetryMixin):
                         new_event(
                             session_id=job_id,
                             timestamp=now,
-                            kind=CPEventKind.job_state_changed,
+                            kind=EventKind.job_state_changed,
                             payload={"state": JobState.running, "new_state": JobState.running},
                         )
                     )
@@ -623,7 +623,7 @@ class ClaudeSessionStateWatcher(WatcherTelemetryMixin):
             new_event(
                 session_id=job_id,
                 timestamp=now,
-                kind=CPEventKind.job_created,
+                kind=EventKind.job_created,
                 payload={
                     "repo": repo_path,
                     "branch": branch,
@@ -637,7 +637,7 @@ class ClaudeSessionStateWatcher(WatcherTelemetryMixin):
             new_event(
                 session_id=job_id,
                 timestamp=now,
-                kind=CPEventKind.job_state_changed,
+                kind=EventKind.job_state_changed,
                 payload={"state": JobState.running, "new_state": JobState.running},
             )
         )
@@ -1027,7 +1027,7 @@ class ClaudeSessionStateWatcher(WatcherTelemetryMixin):
             new_event(
                 session_id=job_id,
                 timestamp=now,
-                kind=CPEventKind.job_state_changed,
+                kind=EventKind.job_state_changed,
                 payload={"state": new_state, "new_state": new_state},
             )
         )
@@ -1037,7 +1037,7 @@ class ClaudeSessionStateWatcher(WatcherTelemetryMixin):
                 new_event(
                     session_id=job_id,
                     timestamp=now,
-                    kind=CPEventKind.job_review,
+                    kind=EventKind.job_review,
                     payload={"resolution": "unresolved"},
                 )
             )

--- a/backend/services/watcher/copilot.py
+++ b/backend/services/watcher/copilot.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING, Any, cast
 import structlog
 
 from backend.models.domain import DonePayload, ErrorPayload, Job, JobSource, JobState, SessionEvent
-from backend.models.events import CPEventKind, new_event
+from backend.models.events import EventKind, new_event
 from backend.services.events.event_pipeline import EventPipeline
 from backend.services.watcher.telemetry_mixin import WatcherTelemetryMixin
 
@@ -488,7 +488,7 @@ class SessionStateWatcher(WatcherTelemetryMixin):
             new_event(
                 session_id=job_id,
                 timestamp=now,
-                kind=CPEventKind.job_created,
+                kind=EventKind.job_created,
                 payload={
                     "repo": repo_path,
                     "branch": branch,
@@ -502,7 +502,7 @@ class SessionStateWatcher(WatcherTelemetryMixin):
             new_event(
                 session_id=job_id,
                 timestamp=now,
-                kind=CPEventKind.job_state_changed,
+                kind=EventKind.job_state_changed,
                 payload={"state": JobState.running, "new_state": JobState.running},
             )
         )
@@ -964,7 +964,7 @@ class SessionStateWatcher(WatcherTelemetryMixin):
             new_event(
                 session_id=job_id,
                 timestamp=now,
-                kind=CPEventKind.job_state_changed,
+                kind=EventKind.job_state_changed,
                 payload={"state": new_state, "new_state": new_state},
             )
         )
@@ -974,7 +974,7 @@ class SessionStateWatcher(WatcherTelemetryMixin):
                 new_event(
                     session_id=job_id,
                     timestamp=now,
-                    kind=CPEventKind.job_review,
+                    kind=EventKind.job_review,
                     payload={"resolution": "unresolved"},
                 )
             )

--- a/backend/services/watcher/copilot.py
+++ b/backend/services/watcher/copilot.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING, Any, cast
 import structlog
 
 from backend.models.domain import DonePayload, ErrorPayload, Job, JobSource, JobState, SessionEvent
-from backend.models.events import DomainEventKind, new_event
+from backend.models.events import CPEventKind, new_event
 from backend.services.events.event_pipeline import EventPipeline
 from backend.services.watcher.telemetry_mixin import WatcherTelemetryMixin
 
@@ -488,7 +488,7 @@ class SessionStateWatcher(WatcherTelemetryMixin):
             new_event(
                 session_id=job_id,
                 timestamp=now,
-                kind=DomainEventKind.job_created,
+                kind=CPEventKind.job_created,
                 payload={
                     "repo": repo_path,
                     "branch": branch,
@@ -502,7 +502,7 @@ class SessionStateWatcher(WatcherTelemetryMixin):
             new_event(
                 session_id=job_id,
                 timestamp=now,
-                kind=DomainEventKind.job_state_changed,
+                kind=CPEventKind.job_state_changed,
                 payload={"state": JobState.running, "new_state": JobState.running},
             )
         )
@@ -964,7 +964,7 @@ class SessionStateWatcher(WatcherTelemetryMixin):
             new_event(
                 session_id=job_id,
                 timestamp=now,
-                kind=DomainEventKind.job_state_changed,
+                kind=CPEventKind.job_state_changed,
                 payload={"state": new_state, "new_state": new_state},
             )
         )
@@ -974,7 +974,7 @@ class SessionStateWatcher(WatcherTelemetryMixin):
                 new_event(
                     session_id=job_id,
                     timestamp=now,
-                    kind=DomainEventKind.job_review,
+                    kind=CPEventKind.job_review,
                     payload={"resolution": "unresolved"},
                 )
             )

--- a/backend/services/watcher/copilot.py
+++ b/backend/services/watcher/copilot.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING, Any, cast
 import structlog
 
 from backend.models.domain import DonePayload, ErrorPayload, Job, JobSource, JobState, SessionEvent
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, new_event
 from backend.services.events.event_pipeline import EventPipeline
 from backend.services.watcher.telemetry_mixin import WatcherTelemetryMixin
 
@@ -485,9 +485,8 @@ class SessionStateWatcher(WatcherTelemetryMixin):
 
         # Publish creation events
         await self._event_bus.publish(
-            DomainEvent(
-                event_id=DomainEvent.make_event_id(),
-                job_id=job_id,
+            new_event(
+                session_id=job_id,
                 timestamp=now,
                 kind=DomainEventKind.job_created,
                 payload={
@@ -500,9 +499,8 @@ class SessionStateWatcher(WatcherTelemetryMixin):
             )
         )
         await self._event_bus.publish(
-            DomainEvent(
-                event_id=DomainEvent.make_event_id(),
-                job_id=job_id,
+            new_event(
+                session_id=job_id,
                 timestamp=now,
                 kind=DomainEventKind.job_state_changed,
                 payload={"state": JobState.running, "new_state": JobState.running},
@@ -963,9 +961,8 @@ class SessionStateWatcher(WatcherTelemetryMixin):
             self._jobs_with_streaming_usage.discard(job_id)
 
         await self._event_bus.publish(
-            DomainEvent(
-                event_id=DomainEvent.make_event_id(),
-                job_id=job_id,
+            new_event(
+                session_id=job_id,
                 timestamp=now,
                 kind=DomainEventKind.job_state_changed,
                 payload={"state": new_state, "new_state": new_state},
@@ -974,9 +971,8 @@ class SessionStateWatcher(WatcherTelemetryMixin):
 
         if new_state == JobState.review:
             await self._event_bus.publish(
-                DomainEvent(
-                    event_id=DomainEvent.make_event_id(),
-                    job_id=job_id,
+                new_event(
+                    session_id=job_id,
                     timestamp=now,
                     kind=DomainEventKind.job_review,
                     payload={"resolution": "unresolved"},

--- a/backend/tests/integration/test_api_jobs.py
+++ b/backend/tests/integration/test_api_jobs.py
@@ -18,6 +18,7 @@ import pytest
 
 from backend.models.db import EventRow
 from backend.models.domain import JobNotFoundError, StateConflictError
+from backend.models.events import CPEventKind
 
 if TYPE_CHECKING:
     from httpx import AsyncClient
@@ -177,7 +178,7 @@ class TestJobsCrud:
                 EventRow(
                     event_id=f"evt-{uuid4().hex}",
                     job_id=jid,
-                    kind="ProgressHeadline",
+                    kind=CPEventKind.progress_headline.value,
                     timestamp=datetime.now(UTC),
                     payload=(
                         '{"headline":"Audit keyboard shortcuts",'
@@ -252,7 +253,7 @@ class TestJobsCrud:
                 EventRow(
                     event_id=f"evt-{uuid4().hex}",
                     job_id=jid,
-                    kind="ProgressHeadline",
+                    kind=CPEventKind.progress_headline.value,
                     timestamp=datetime.now(UTC),
                     payload=(
                         '{"headline":"Finalize shortcut audit",'

--- a/backend/tests/integration/test_api_jobs.py
+++ b/backend/tests/integration/test_api_jobs.py
@@ -18,7 +18,7 @@ import pytest
 
 from backend.models.db import EventRow
 from backend.models.domain import JobNotFoundError, StateConflictError
-from backend.models.events import CPEventKind
+from backend.models.events import EventKind
 
 if TYPE_CHECKING:
     from httpx import AsyncClient
@@ -178,7 +178,7 @@ class TestJobsCrud:
                 EventRow(
                     event_id=f"evt-{uuid4().hex}",
                     job_id=jid,
-                    kind=CPEventKind.progress_headline.value,
+                    kind=EventKind.progress_headline.value,
                     timestamp=datetime.now(UTC),
                     payload=(
                         '{"headline":"Audit keyboard shortcuts",'
@@ -253,7 +253,7 @@ class TestJobsCrud:
                 EventRow(
                     event_id=f"evt-{uuid4().hex}",
                     job_id=jid,
-                    kind=CPEventKind.progress_headline.value,
+                    kind=EventKind.progress_headline.value,
                     timestamp=datetime.now(UTC),
                     payload=(
                         '{"headline":"Finalize shortcut audit",'

--- a/backend/tests/integration/test_integration.py
+++ b/backend/tests/integration/test_integration.py
@@ -137,7 +137,7 @@ class TestEventBusIntegration:
     @pytest.mark.asyncio
     async def test_concurrent_subscribers(self, event_bus: EventBus) -> None:
         """Multiple subscribers receive the same event."""
-        from backend.models.events import CPEventKind, SessionEvent, new_event
+        from backend.models.events import EventKind, SessionEvent, new_event
 
         received: list[str] = []
 
@@ -154,7 +154,7 @@ class TestEventBusIntegration:
             event_id="evt-1",
             session_id="job-1",
             timestamp=datetime.now(UTC),
-            kind=CPEventKind.job_state_changed,
+            kind=EventKind.job_state_changed,
             payload={"old_state": "queued", "new_state": "running"},
         )
         await event_bus.publish(event)
@@ -164,7 +164,7 @@ class TestEventBusIntegration:
 
     @pytest.mark.asyncio
     async def test_subscriber_error_does_not_crash_bus(self, event_bus: EventBus) -> None:
-        from backend.models.events import CPEventKind, SessionEvent, new_event
+        from backend.models.events import EventKind, SessionEvent, new_event
 
         received: list[str] = []
 
@@ -181,7 +181,7 @@ class TestEventBusIntegration:
             event_id="evt-1",
             session_id="job-1",
             timestamp=datetime.now(UTC),
-            kind=CPEventKind.job_state_changed,
+            kind=EventKind.job_state_changed,
             payload={},
         )
         await event_bus.publish(event)

--- a/backend/tests/integration/test_integration.py
+++ b/backend/tests/integration/test_integration.py
@@ -137,22 +137,22 @@ class TestEventBusIntegration:
     @pytest.mark.asyncio
     async def test_concurrent_subscribers(self, event_bus: EventBus) -> None:
         """Multiple subscribers receive the same event."""
-        from backend.models.events import DomainEvent, DomainEventKind
+        from backend.models.events import DomainEventKind, SessionEvent, new_event
 
         received: list[str] = []
 
-        async def sub1(event: DomainEvent) -> None:
-            received.append(f"sub1:{event.kind.value}")
+        async def sub1(event: SessionEvent) -> None:
+            received.append(f"sub1:{str(event.kind)}")
 
-        async def sub2(event: DomainEvent) -> None:
-            received.append(f"sub2:{event.kind.value}")
+        async def sub2(event: SessionEvent) -> None:
+            received.append(f"sub2:{str(event.kind)}")
 
         event_bus.subscribe(sub1)
         event_bus.subscribe(sub2)
 
-        event = DomainEvent(
+        event = new_event(
             event_id="evt-1",
-            job_id="job-1",
+            session_id="job-1",
             timestamp=datetime.now(UTC),
             kind=DomainEventKind.job_state_changed,
             payload={"old_state": "queued", "new_state": "running"},
@@ -164,22 +164,22 @@ class TestEventBusIntegration:
 
     @pytest.mark.asyncio
     async def test_subscriber_error_does_not_crash_bus(self, event_bus: EventBus) -> None:
-        from backend.models.events import DomainEvent, DomainEventKind
+        from backend.models.events import DomainEventKind, SessionEvent, new_event
 
         received: list[str] = []
 
-        async def bad_sub(event: DomainEvent) -> None:
+        async def bad_sub(event: SessionEvent) -> None:
             raise ValueError("subscriber failed")
 
-        async def good_sub(event: DomainEvent) -> None:
+        async def good_sub(event: SessionEvent) -> None:
             received.append("ok")
 
         event_bus.subscribe(bad_sub)
         event_bus.subscribe(good_sub)
 
-        event = DomainEvent(
+        event = new_event(
             event_id="evt-1",
-            job_id="job-1",
+            session_id="job-1",
             timestamp=datetime.now(UTC),
             kind=DomainEventKind.job_state_changed,
             payload={},

--- a/backend/tests/integration/test_integration.py
+++ b/backend/tests/integration/test_integration.py
@@ -137,7 +137,7 @@ class TestEventBusIntegration:
     @pytest.mark.asyncio
     async def test_concurrent_subscribers(self, event_bus: EventBus) -> None:
         """Multiple subscribers receive the same event."""
-        from backend.models.events import DomainEventKind, SessionEvent, new_event
+        from backend.models.events import CPEventKind, SessionEvent, new_event
 
         received: list[str] = []
 
@@ -154,17 +154,17 @@ class TestEventBusIntegration:
             event_id="evt-1",
             session_id="job-1",
             timestamp=datetime.now(UTC),
-            kind=DomainEventKind.job_state_changed,
+            kind=CPEventKind.job_state_changed,
             payload={"old_state": "queued", "new_state": "running"},
         )
         await event_bus.publish(event)
 
-        assert "sub1:JobStateChanged" in received
-        assert "sub2:JobStateChanged" in received
+        assert "sub1:job.state_changed" in received
+        assert "sub2:job.state_changed" in received
 
     @pytest.mark.asyncio
     async def test_subscriber_error_does_not_crash_bus(self, event_bus: EventBus) -> None:
-        from backend.models.events import DomainEventKind, SessionEvent, new_event
+        from backend.models.events import CPEventKind, SessionEvent, new_event
 
         received: list[str] = []
 
@@ -181,7 +181,7 @@ class TestEventBusIntegration:
             event_id="evt-1",
             session_id="job-1",
             timestamp=datetime.now(UTC),
-            kind=DomainEventKind.job_state_changed,
+            kind=CPEventKind.job_state_changed,
             payload={},
         )
         await event_bus.publish(event)

--- a/backend/tests/unit/test_action_policy_engine.py
+++ b/backend/tests/unit/test_action_policy_engine.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from backend.models.events import CPEventKind, SessionEvent, new_event
+from backend.models.events import EventKind, SessionEvent, new_event
 from backend.services.action_policy.batcher import ApprovalBatcher
 from backend.services.action_policy.classifier import (
     Action,
@@ -250,7 +250,7 @@ class TestOnPolicySettingsChanged:
     async def test_ignores_non_policy_events(self) -> None:
         svc = _make_runtime_service()
         event = new_event(
-            event_id="e1", session_id="j1", timestamp=datetime.now(UTC), kind=CPEventKind.job_created, payload={}
+            event_id="e1", session_id="j1", timestamp=datetime.now(UTC), kind=EventKind.job_created, payload={}
         )
         # Should return without error
         await svc._on_policy_settings_changed(event)
@@ -362,7 +362,7 @@ def _make_policy_event() -> SessionEvent:
         event_id="e-policy",
         session_id="",
         timestamp=datetime.now(UTC),
-        kind=CPEventKind.policy_settings_changed,
+        kind=EventKind.policy_settings_changed,
         payload={},
     )
 

--- a/backend/tests/unit/test_action_policy_engine.py
+++ b/backend/tests/unit/test_action_policy_engine.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, SessionEvent, new_event
 from backend.services.action_policy.batcher import ApprovalBatcher
 from backend.services.action_policy.classifier import (
     Action,
@@ -249,12 +249,8 @@ class TestOnPolicySettingsChanged:
     @pytest.mark.asyncio
     async def test_ignores_non_policy_events(self) -> None:
         svc = _make_runtime_service()
-        event = DomainEvent(
-            event_id="e1",
-            job_id="j1",
-            timestamp=datetime.now(UTC),
-            kind=DomainEventKind.job_created,
-            payload={},
+        event = new_event(
+            event_id="e1", session_id="j1", timestamp=datetime.now(UTC), kind=DomainEventKind.job_created, payload={}
         )
         # Should return without error
         await svc._on_policy_settings_changed(event)
@@ -361,10 +357,10 @@ class TestOnPolicySettingsChanged:
 # ---------------------------------------------------------------------------
 
 
-def _make_policy_event() -> DomainEvent:
-    return DomainEvent(
+def _make_policy_event() -> SessionEvent:
+    return new_event(
         event_id="e-policy",
-        job_id="",
+        session_id="",
         timestamp=datetime.now(UTC),
         kind=DomainEventKind.policy_settings_changed,
         payload={},

--- a/backend/tests/unit/test_action_policy_engine.py
+++ b/backend/tests/unit/test_action_policy_engine.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from backend.models.events import DomainEventKind, SessionEvent, new_event
+from backend.models.events import CPEventKind, SessionEvent, new_event
 from backend.services.action_policy.batcher import ApprovalBatcher
 from backend.services.action_policy.classifier import (
     Action,
@@ -250,7 +250,7 @@ class TestOnPolicySettingsChanged:
     async def test_ignores_non_policy_events(self) -> None:
         svc = _make_runtime_service()
         event = new_event(
-            event_id="e1", session_id="j1", timestamp=datetime.now(UTC), kind=DomainEventKind.job_created, payload={}
+            event_id="e1", session_id="j1", timestamp=datetime.now(UTC), kind=CPEventKind.job_created, payload={}
         )
         # Should return without error
         await svc._on_policy_settings_changed(event)
@@ -362,7 +362,7 @@ def _make_policy_event() -> SessionEvent:
         event_id="e-policy",
         session_id="",
         timestamp=datetime.now(UTC),
-        kind=DomainEventKind.policy_settings_changed,
+        kind=CPEventKind.policy_settings_changed,
         payload={},
     )
 

--- a/backend/tests/unit/test_activity_tracker.py
+++ b/backend/tests/unit/test_activity_tracker.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from backend.models.events import CPEventKind, SessionEvent
+from backend.models.events import EventKind, SessionEvent
 from backend.services.events.event_bus import EventBus
 
 # Import after models to avoid circular
@@ -116,7 +116,7 @@ class TestEmitActivityStepTitleFailure:
         events: list[SessionEvent] = []
 
         async def _handler(e: SessionEvent) -> None:
-            if e.kind == CPEventKind.turn_summary:
+            if e.kind == EventKind.turn_summary:
                 events.append(e)
 
         event_bus.subscribe(_handler)
@@ -167,7 +167,7 @@ class TestEmitActivityStepSameActivity:
         events: list[SessionEvent] = []
 
         async def _handler(e: SessionEvent) -> None:
-            if e.kind == CPEventKind.turn_summary:
+            if e.kind == EventKind.turn_summary:
                 events.append(e)
 
         event_bus.subscribe(_handler)
@@ -220,7 +220,7 @@ class TestEmitActivityStepNewActivity:
         events: list[SessionEvent] = []
 
         async def _handler(e: SessionEvent) -> None:
-            if e.kind == CPEventKind.turn_summary:
+            if e.kind == EventKind.turn_summary:
                 events.append(e)
 
         event_bus.subscribe(_handler)
@@ -314,7 +314,7 @@ class TestEmitActivityStepMerge:
         events: list[SessionEvent] = []
 
         async def _handler(e: SessionEvent) -> None:
-            if e.kind == CPEventKind.turn_summary:
+            if e.kind == EventKind.turn_summary:
                 events.append(e)
 
         event_bus.subscribe(_handler)

--- a/backend/tests/unit/test_activity_tracker.py
+++ b/backend/tests/unit/test_activity_tracker.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from backend.models.events import DomainEventKind, SessionEvent
+from backend.models.events import CPEventKind, SessionEvent
 from backend.services.events.event_bus import EventBus
 
 # Import after models to avoid circular
@@ -116,7 +116,7 @@ class TestEmitActivityStepTitleFailure:
         events: list[SessionEvent] = []
 
         async def _handler(e: SessionEvent) -> None:
-            if e.kind == DomainEventKind.turn_summary:
+            if e.kind == CPEventKind.turn_summary:
                 events.append(e)
 
         event_bus.subscribe(_handler)
@@ -167,7 +167,7 @@ class TestEmitActivityStepSameActivity:
         events: list[SessionEvent] = []
 
         async def _handler(e: SessionEvent) -> None:
-            if e.kind == DomainEventKind.turn_summary:
+            if e.kind == CPEventKind.turn_summary:
                 events.append(e)
 
         event_bus.subscribe(_handler)
@@ -220,7 +220,7 @@ class TestEmitActivityStepNewActivity:
         events: list[SessionEvent] = []
 
         async def _handler(e: SessionEvent) -> None:
-            if e.kind == DomainEventKind.turn_summary:
+            if e.kind == CPEventKind.turn_summary:
                 events.append(e)
 
         event_bus.subscribe(_handler)
@@ -314,7 +314,7 @@ class TestEmitActivityStepMerge:
         events: list[SessionEvent] = []
 
         async def _handler(e: SessionEvent) -> None:
-            if e.kind == DomainEventKind.turn_summary:
+            if e.kind == CPEventKind.turn_summary:
                 events.append(e)
 
         event_bus.subscribe(_handler)

--- a/backend/tests/unit/test_activity_tracker.py
+++ b/backend/tests/unit/test_activity_tracker.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, SessionEvent
 from backend.services.events.event_bus import EventBus
 
 # Import after models to avoid circular
@@ -113,9 +113,9 @@ class TestEmitActivityStepTitleFailure:
         )
         job_state["j1"] = _state()
 
-        events: list[DomainEvent] = []
+        events: list[SessionEvent] = []
 
-        async def _handler(e: DomainEvent) -> None:
+        async def _handler(e: SessionEvent) -> None:
             if e.kind == DomainEventKind.turn_summary:
                 events.append(e)
 
@@ -164,9 +164,9 @@ class TestEmitActivityStepSameActivity:
         state = _state()
         job_state["j1"] = state
 
-        events: list[DomainEvent] = []
+        events: list[SessionEvent] = []
 
-        async def _handler(e: DomainEvent) -> None:
+        async def _handler(e: SessionEvent) -> None:
             if e.kind == DomainEventKind.turn_summary:
                 events.append(e)
 
@@ -217,9 +217,9 @@ class TestEmitActivityStepNewActivity:
         state = _state()
         job_state["j1"] = state
 
-        events: list[DomainEvent] = []
+        events: list[SessionEvent] = []
 
-        async def _handler(e: DomainEvent) -> None:
+        async def _handler(e: SessionEvent) -> None:
             if e.kind == DomainEventKind.turn_summary:
                 events.append(e)
 
@@ -311,9 +311,9 @@ class TestEmitActivityStepMerge:
         )
         job_state["j1"] = state
 
-        events: list[DomainEvent] = []
+        events: list[SessionEvent] = []
 
-        async def _handler(e: DomainEvent) -> None:
+        async def _handler(e: SessionEvent) -> None:
             if e.kind == DomainEventKind.turn_summary:
                 events.append(e)
 

--- a/backend/tests/unit/test_api_jobs.py
+++ b/backend/tests/unit/test_api_jobs.py
@@ -40,21 +40,21 @@ async def test_resolve_job_publishes_after_commit() -> None:
 
     session.commit = AsyncMock(side_effect=_commit)
 
-    from backend.models.events import DomainEventKind, new_event
+    from backend.models.events import CPEventKind, new_event
 
     now = datetime.now(UTC)
     resolved_event = new_event(
         event_id="evt-1",
         session_id="job-1",
         timestamp=now,
-        kind=DomainEventKind.job_resolved,
+        kind=CPEventKind.job_resolved,
         payload={"resolution": "discarded"},
     )
     completed_event = new_event(
         event_id="evt-2",
         session_id="job-1",
         timestamp=now,
-        kind=DomainEventKind.job_completed,
+        kind=CPEventKind.job_completed,
         payload={"resolution": "discarded", "merge_status": "discarded", "pr_url": None},
     )
     svc = SimpleNamespace(
@@ -89,7 +89,7 @@ async def test_resolve_job_publishes_after_commit() -> None:
     # Two events: job_resolved + job_completed
     assert event_bus.publish.await_count == 2
     assert published_events[0] is resolved_event
-    assert published_events[1].kind == DomainEventKind.job_completed
+    assert published_events[1].kind == CPEventKind.job_completed
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_api_jobs.py
+++ b/backend/tests/unit/test_api_jobs.py
@@ -40,21 +40,21 @@ async def test_resolve_job_publishes_after_commit() -> None:
 
     session.commit = AsyncMock(side_effect=_commit)
 
-    from backend.models.events import CPEventKind, new_event
+    from backend.models.events import EventKind, new_event
 
     now = datetime.now(UTC)
     resolved_event = new_event(
         event_id="evt-1",
         session_id="job-1",
         timestamp=now,
-        kind=CPEventKind.job_resolved,
+        kind=EventKind.job_resolved,
         payload={"resolution": "discarded"},
     )
     completed_event = new_event(
         event_id="evt-2",
         session_id="job-1",
         timestamp=now,
-        kind=CPEventKind.job_completed,
+        kind=EventKind.job_completed,
         payload={"resolution": "discarded", "merge_status": "discarded", "pr_url": None},
     )
     svc = SimpleNamespace(
@@ -89,7 +89,7 @@ async def test_resolve_job_publishes_after_commit() -> None:
     # Two events: job_resolved + job_completed
     assert event_bus.publish.await_count == 2
     assert published_events[0] is resolved_event
-    assert published_events[1].kind == CPEventKind.job_completed
+    assert published_events[1].kind == EventKind.job_completed
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_api_jobs.py
+++ b/backend/tests/unit/test_api_jobs.py
@@ -40,19 +40,19 @@ async def test_resolve_job_publishes_after_commit() -> None:
 
     session.commit = AsyncMock(side_effect=_commit)
 
-    from backend.models.events import DomainEvent, DomainEventKind
+    from backend.models.events import DomainEventKind, new_event
 
     now = datetime.now(UTC)
-    resolved_event = DomainEvent(
+    resolved_event = new_event(
         event_id="evt-1",
-        job_id="job-1",
+        session_id="job-1",
         timestamp=now,
         kind=DomainEventKind.job_resolved,
         payload={"resolution": "discarded"},
     )
-    completed_event = DomainEvent(
+    completed_event = new_event(
         event_id="evt-2",
-        job_id="job-1",
+        session_id="job-1",
         timestamp=now,
         kind=DomainEventKind.job_completed,
         payload={"resolution": "discarded", "merge_status": "discarded", "pr_url": None},

--- a/backend/tests/unit/test_audit_changes.py
+++ b/backend/tests/unit/test_audit_changes.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
 
 from backend.models.db import Base
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, new_event
 from backend.persistence.database import _set_sqlite_pragmas
 from backend.persistence.event_repo import EventRepository
 from backend.persistence.job_repo import JobRepository
@@ -174,11 +174,7 @@ class TestBuildConflictResumePrompt:
         job = make_job(id="j-1", branch="feat/x", base_ref="main", worktree_path="/repos/test")
         await job_repo.create(job)
 
-        evt = DomainEvent.for_job(
-            "j-1",
-            DomainEventKind.merge_conflict,
-            {"conflict_files": ["src/a.py", "src/b.py"]},
-        )
+        evt = new_event("j-1", DomainEventKind.merge_conflict, {"conflict_files": ["src/a.py", "src/b.py"]})
         await event_repo.append(evt)
         await session.commit()
 
@@ -235,10 +231,10 @@ class TestBuildConflictResumePrompt:
         await job_repo.create(job)
 
         # First conflict event — stale
-        evt1 = DomainEvent.for_job("j-3", DomainEventKind.merge_conflict, {"conflict_files": ["old.py"]})
+        evt1 = new_event("j-3", DomainEventKind.merge_conflict, {"conflict_files": ["old.py"]})
         await event_repo.append(evt1)
         # Second conflict event — current
-        evt2 = DomainEvent.for_job("j-3", DomainEventKind.merge_conflict, {"conflict_files": ["new.py"]})
+        evt2 = new_event("j-3", DomainEventKind.merge_conflict, {"conflict_files": ["new.py"]})
         await event_repo.append(evt2)
         await session.commit()
 
@@ -269,7 +265,7 @@ class TestEventRepoListAllByJob:
         await job_repo.create(make_job(id=job_id, worktree_path="/repos/test"))
 
         for i in range(10):
-            evt = DomainEvent.for_job(job_id, DomainEventKind.log_line_emitted, {"seq": i})
+            evt = new_event(job_id, DomainEventKind.log_line_emitted, {"seq": i})
             await repo.append(evt)
         await session.commit()
 
@@ -284,9 +280,9 @@ class TestEventRepoListAllByJob:
         job_repo = JobRepository(session)
         await job_repo.create(make_job(id=job_id, worktree_path="/repos/test"))
 
-        await repo.append(DomainEvent.for_job(job_id, DomainEventKind.log_line_emitted, {"seq": 0}))
-        await repo.append(DomainEvent.for_job(job_id, DomainEventKind.merge_conflict, {"conflict_files": []}))
-        await repo.append(DomainEvent.for_job(job_id, DomainEventKind.log_line_emitted, {"seq": 1}))
+        await repo.append(new_event(job_id, DomainEventKind.log_line_emitted, {"seq": 0}))
+        await repo.append(new_event(job_id, DomainEventKind.merge_conflict, {"conflict_files": []}))
+        await repo.append(new_event(job_id, DomainEventKind.log_line_emitted, {"seq": 1}))
         await session.commit()
 
         logs = await repo.list_all_by_job(job_id, kinds=[DomainEventKind.log_line_emitted])
@@ -304,11 +300,11 @@ class TestEventRepoListAllByJob:
         await job_repo.create(make_job(id=job_id, worktree_path="/repos/test"))
 
         for i in range(5):
-            await repo.append(DomainEvent.for_job(job_id, DomainEventKind.log_line_emitted, {"seq": i}))
+            await repo.append(new_event(job_id, DomainEventKind.log_line_emitted, {"seq": i}))
         await session.commit()
 
         results = await repo.list_all_by_job(job_id, kinds=[DomainEventKind.log_line_emitted])
-        db_ids = [r.db_id for r in results]
+        db_ids = [r.metadata.sequence for r in results]
         assert db_ids == sorted(db_ids)
 
     @pytest.mark.asyncio
@@ -320,7 +316,7 @@ class TestEventRepoListAllByJob:
         await job_repo.create(make_job(id=job_id, worktree_path="/repos/test"))
 
         for i in range(5):
-            await repo.append(DomainEvent.for_job(job_id, DomainEventKind.log_line_emitted, {"seq": i}))
+            await repo.append(new_event(job_id, DomainEventKind.log_line_emitted, {"seq": i}))
         await session.commit()
 
         limited = await repo.list_by_job(job_id, kinds=[DomainEventKind.log_line_emitted], limit=3)

--- a/backend/tests/unit/test_audit_changes.py
+++ b/backend/tests/unit/test_audit_changes.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
 
 from backend.models.db import Base
-from backend.models.events import CPEventKind, new_event
+from backend.models.events import EventKind, new_event
 from backend.persistence.database import _set_sqlite_pragmas
 from backend.persistence.event_repo import EventRepository
 from backend.persistence.job_repo import JobRepository
@@ -174,7 +174,7 @@ class TestBuildConflictResumePrompt:
         job = make_job(id="j-1", branch="feat/x", base_ref="main", worktree_path="/repos/test")
         await job_repo.create(job)
 
-        evt = new_event("j-1", CPEventKind.merge_conflict, {"conflict_files": ["src/a.py", "src/b.py"]})
+        evt = new_event("j-1", EventKind.merge_conflict, {"conflict_files": ["src/a.py", "src/b.py"]})
         await event_repo.append(evt)
         await session.commit()
 
@@ -231,10 +231,10 @@ class TestBuildConflictResumePrompt:
         await job_repo.create(job)
 
         # First conflict event — stale
-        evt1 = new_event("j-3", CPEventKind.merge_conflict, {"conflict_files": ["old.py"]})
+        evt1 = new_event("j-3", EventKind.merge_conflict, {"conflict_files": ["old.py"]})
         await event_repo.append(evt1)
         # Second conflict event — current
-        evt2 = new_event("j-3", CPEventKind.merge_conflict, {"conflict_files": ["new.py"]})
+        evt2 = new_event("j-3", EventKind.merge_conflict, {"conflict_files": ["new.py"]})
         await event_repo.append(evt2)
         await session.commit()
 
@@ -265,11 +265,11 @@ class TestEventRepoListAllByJob:
         await job_repo.create(make_job(id=job_id, worktree_path="/repos/test"))
 
         for i in range(10):
-            evt = new_event(job_id, CPEventKind.log_line_emitted, {"seq": i})
+            evt = new_event(job_id, EventKind.log_line_emitted, {"seq": i})
             await repo.append(evt)
         await session.commit()
 
-        results = await repo.list_all_by_job(job_id, kinds=[CPEventKind.log_line_emitted])
+        results = await repo.list_all_by_job(job_id, kinds=[EventKind.log_line_emitted])
         assert len(results) == 10
 
     @pytest.mark.asyncio
@@ -280,15 +280,15 @@ class TestEventRepoListAllByJob:
         job_repo = JobRepository(session)
         await job_repo.create(make_job(id=job_id, worktree_path="/repos/test"))
 
-        await repo.append(new_event(job_id, CPEventKind.log_line_emitted, {"seq": 0}))
-        await repo.append(new_event(job_id, CPEventKind.merge_conflict, {"conflict_files": []}))
-        await repo.append(new_event(job_id, CPEventKind.log_line_emitted, {"seq": 1}))
+        await repo.append(new_event(job_id, EventKind.log_line_emitted, {"seq": 0}))
+        await repo.append(new_event(job_id, EventKind.merge_conflict, {"conflict_files": []}))
+        await repo.append(new_event(job_id, EventKind.log_line_emitted, {"seq": 1}))
         await session.commit()
 
-        logs = await repo.list_all_by_job(job_id, kinds=[CPEventKind.log_line_emitted])
+        logs = await repo.list_all_by_job(job_id, kinds=[EventKind.log_line_emitted])
         assert len(logs) == 2
 
-        conflicts = await repo.list_all_by_job(job_id, kinds=[CPEventKind.merge_conflict])
+        conflicts = await repo.list_all_by_job(job_id, kinds=[EventKind.merge_conflict])
         assert len(conflicts) == 1
 
     @pytest.mark.asyncio
@@ -300,10 +300,10 @@ class TestEventRepoListAllByJob:
         await job_repo.create(make_job(id=job_id, worktree_path="/repos/test"))
 
         for i in range(5):
-            await repo.append(new_event(job_id, CPEventKind.log_line_emitted, {"seq": i}))
+            await repo.append(new_event(job_id, EventKind.log_line_emitted, {"seq": i}))
         await session.commit()
 
-        results = await repo.list_all_by_job(job_id, kinds=[CPEventKind.log_line_emitted])
+        results = await repo.list_all_by_job(job_id, kinds=[EventKind.log_line_emitted])
         db_ids = [r.metadata.sequence for r in results]
         assert db_ids == sorted(db_ids)
 
@@ -316,13 +316,13 @@ class TestEventRepoListAllByJob:
         await job_repo.create(make_job(id=job_id, worktree_path="/repos/test"))
 
         for i in range(5):
-            await repo.append(new_event(job_id, CPEventKind.log_line_emitted, {"seq": i}))
+            await repo.append(new_event(job_id, EventKind.log_line_emitted, {"seq": i}))
         await session.commit()
 
-        limited = await repo.list_by_job(job_id, kinds=[CPEventKind.log_line_emitted], limit=3)
+        limited = await repo.list_by_job(job_id, kinds=[EventKind.log_line_emitted], limit=3)
         assert len(limited) == 3
 
-        unlimited = await repo.list_all_by_job(job_id, kinds=[CPEventKind.log_line_emitted])
+        unlimited = await repo.list_all_by_job(job_id, kinds=[EventKind.log_line_emitted])
         assert len(unlimited) == 5
 
 

--- a/backend/tests/unit/test_audit_changes.py
+++ b/backend/tests/unit/test_audit_changes.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
 
 from backend.models.db import Base
-from backend.models.events import DomainEventKind, new_event
+from backend.models.events import CPEventKind, new_event
 from backend.persistence.database import _set_sqlite_pragmas
 from backend.persistence.event_repo import EventRepository
 from backend.persistence.job_repo import JobRepository
@@ -174,7 +174,7 @@ class TestBuildConflictResumePrompt:
         job = make_job(id="j-1", branch="feat/x", base_ref="main", worktree_path="/repos/test")
         await job_repo.create(job)
 
-        evt = new_event("j-1", DomainEventKind.merge_conflict, {"conflict_files": ["src/a.py", "src/b.py"]})
+        evt = new_event("j-1", CPEventKind.merge_conflict, {"conflict_files": ["src/a.py", "src/b.py"]})
         await event_repo.append(evt)
         await session.commit()
 
@@ -231,10 +231,10 @@ class TestBuildConflictResumePrompt:
         await job_repo.create(job)
 
         # First conflict event — stale
-        evt1 = new_event("j-3", DomainEventKind.merge_conflict, {"conflict_files": ["old.py"]})
+        evt1 = new_event("j-3", CPEventKind.merge_conflict, {"conflict_files": ["old.py"]})
         await event_repo.append(evt1)
         # Second conflict event — current
-        evt2 = new_event("j-3", DomainEventKind.merge_conflict, {"conflict_files": ["new.py"]})
+        evt2 = new_event("j-3", CPEventKind.merge_conflict, {"conflict_files": ["new.py"]})
         await event_repo.append(evt2)
         await session.commit()
 
@@ -265,11 +265,11 @@ class TestEventRepoListAllByJob:
         await job_repo.create(make_job(id=job_id, worktree_path="/repos/test"))
 
         for i in range(10):
-            evt = new_event(job_id, DomainEventKind.log_line_emitted, {"seq": i})
+            evt = new_event(job_id, CPEventKind.log_line_emitted, {"seq": i})
             await repo.append(evt)
         await session.commit()
 
-        results = await repo.list_all_by_job(job_id, kinds=[DomainEventKind.log_line_emitted])
+        results = await repo.list_all_by_job(job_id, kinds=[CPEventKind.log_line_emitted])
         assert len(results) == 10
 
     @pytest.mark.asyncio
@@ -280,15 +280,15 @@ class TestEventRepoListAllByJob:
         job_repo = JobRepository(session)
         await job_repo.create(make_job(id=job_id, worktree_path="/repos/test"))
 
-        await repo.append(new_event(job_id, DomainEventKind.log_line_emitted, {"seq": 0}))
-        await repo.append(new_event(job_id, DomainEventKind.merge_conflict, {"conflict_files": []}))
-        await repo.append(new_event(job_id, DomainEventKind.log_line_emitted, {"seq": 1}))
+        await repo.append(new_event(job_id, CPEventKind.log_line_emitted, {"seq": 0}))
+        await repo.append(new_event(job_id, CPEventKind.merge_conflict, {"conflict_files": []}))
+        await repo.append(new_event(job_id, CPEventKind.log_line_emitted, {"seq": 1}))
         await session.commit()
 
-        logs = await repo.list_all_by_job(job_id, kinds=[DomainEventKind.log_line_emitted])
+        logs = await repo.list_all_by_job(job_id, kinds=[CPEventKind.log_line_emitted])
         assert len(logs) == 2
 
-        conflicts = await repo.list_all_by_job(job_id, kinds=[DomainEventKind.merge_conflict])
+        conflicts = await repo.list_all_by_job(job_id, kinds=[CPEventKind.merge_conflict])
         assert len(conflicts) == 1
 
     @pytest.mark.asyncio
@@ -300,10 +300,10 @@ class TestEventRepoListAllByJob:
         await job_repo.create(make_job(id=job_id, worktree_path="/repos/test"))
 
         for i in range(5):
-            await repo.append(new_event(job_id, DomainEventKind.log_line_emitted, {"seq": i}))
+            await repo.append(new_event(job_id, CPEventKind.log_line_emitted, {"seq": i}))
         await session.commit()
 
-        results = await repo.list_all_by_job(job_id, kinds=[DomainEventKind.log_line_emitted])
+        results = await repo.list_all_by_job(job_id, kinds=[CPEventKind.log_line_emitted])
         db_ids = [r.metadata.sequence for r in results]
         assert db_ids == sorted(db_ids)
 
@@ -316,13 +316,13 @@ class TestEventRepoListAllByJob:
         await job_repo.create(make_job(id=job_id, worktree_path="/repos/test"))
 
         for i in range(5):
-            await repo.append(new_event(job_id, DomainEventKind.log_line_emitted, {"seq": i}))
+            await repo.append(new_event(job_id, CPEventKind.log_line_emitted, {"seq": i}))
         await session.commit()
 
-        limited = await repo.list_by_job(job_id, kinds=[DomainEventKind.log_line_emitted], limit=3)
+        limited = await repo.list_by_job(job_id, kinds=[CPEventKind.log_line_emitted], limit=3)
         assert len(limited) == 3
 
-        unlimited = await repo.list_all_by_job(job_id, kinds=[DomainEventKind.log_line_emitted])
+        unlimited = await repo.list_all_by_job(job_id, kinds=[CPEventKind.log_line_emitted])
         assert len(unlimited) == 5
 
 

--- a/backend/tests/unit/test_behavior_toggles.py
+++ b/backend/tests/unit/test_behavior_toggles.py
@@ -15,7 +15,7 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from backend.models.db import Base, JobRow
-from backend.models.events import CPEventKind, SessionEvent, new_event
+from backend.models.events import EventKind, SessionEvent, new_event
 from backend.services.events.event_bus import EventBus
 from backend.services.trail import TrailService
 
@@ -49,7 +49,7 @@ def trail_service(session_factory, event_bus):
 
 
 def _make_event(
-    kind: CPEventKind,
+    kind: EventKind,
     job_id: str = "job-1",
     payload: dict | None = None,
 ) -> SessionEvent:
@@ -109,7 +109,7 @@ class TestPlanTrackingToggle:
         """Transcript events for disabled jobs skip plan feed but still run node_builder."""
         # Initialize job state so the event handler doesn't bail early
         start_event = _make_event(
-            CPEventKind.job_state_changed,
+            EventKind.job_state_changed,
             payload={"previous_state": "queued", "new_state": "running"},
         )
         await trail_service.handle_event(start_event)
@@ -118,7 +118,7 @@ class TestPlanTrackingToggle:
 
         with patch.object(trail_service._plan_manager, "feed_transcript", new_callable=AsyncMock) as feed_mock:
             event = _make_event(
-                CPEventKind.message_assistant,
+                EventKind.message_assistant,
                 payload={"role": "agent", "content": "I will do stuff"},
             )
             await trail_service.handle_event(event)
@@ -128,7 +128,7 @@ class TestPlanTrackingToggle:
     async def test_handle_event_skips_native_plan_for_disabled_job(self, trail_service: TrailService) -> None:
         """Native plan tool calls are ignored for disabled jobs."""
         start_event = _make_event(
-            CPEventKind.job_state_changed,
+            EventKind.job_state_changed,
             payload={"previous_state": "queued", "new_state": "running"},
         )
         await trail_service.handle_event(start_event)
@@ -137,7 +137,7 @@ class TestPlanTrackingToggle:
 
         with patch.object(trail_service._plan_manager, "feed_native_plan", new_callable=AsyncMock) as plan_mock:
             event = _make_event(
-                CPEventKind.tool_call_completed,
+                EventKind.tool_call_completed,
                 payload={
                     "role": "tool_call",
                     "tool_name": "manage_todo_list",

--- a/backend/tests/unit/test_behavior_toggles.py
+++ b/backend/tests/unit/test_behavior_toggles.py
@@ -15,7 +15,7 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from backend.models.db import Base, JobRow
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, SessionEvent, new_event
 from backend.services.events.event_bus import EventBus
 from backend.services.trail import TrailService
 
@@ -52,14 +52,8 @@ def _make_event(
     kind: DomainEventKind,
     job_id: str = "job-1",
     payload: dict | None = None,
-) -> DomainEvent:
-    return DomainEvent(
-        event_id=DomainEvent.make_event_id(),
-        job_id=job_id,
-        timestamp=datetime.now(UTC),
-        kind=kind,
-        payload=payload or {},
-    )
+) -> SessionEvent:
+    return new_event(session_id=job_id, timestamp=datetime.now(UTC), kind=kind, payload=payload or {})
 
 
 # ===================================================================

--- a/backend/tests/unit/test_behavior_toggles.py
+++ b/backend/tests/unit/test_behavior_toggles.py
@@ -15,7 +15,7 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from backend.models.db import Base, JobRow
-from backend.models.events import DomainEventKind, SessionEvent, new_event
+from backend.models.events import CPEventKind, SessionEvent, new_event
 from backend.services.events.event_bus import EventBus
 from backend.services.trail import TrailService
 
@@ -49,7 +49,7 @@ def trail_service(session_factory, event_bus):
 
 
 def _make_event(
-    kind: DomainEventKind,
+    kind: CPEventKind,
     job_id: str = "job-1",
     payload: dict | None = None,
 ) -> SessionEvent:
@@ -109,7 +109,7 @@ class TestPlanTrackingToggle:
         """Transcript events for disabled jobs skip plan feed but still run node_builder."""
         # Initialize job state so the event handler doesn't bail early
         start_event = _make_event(
-            DomainEventKind.job_state_changed,
+            CPEventKind.job_state_changed,
             payload={"previous_state": "queued", "new_state": "running"},
         )
         await trail_service.handle_event(start_event)
@@ -118,7 +118,7 @@ class TestPlanTrackingToggle:
 
         with patch.object(trail_service._plan_manager, "feed_transcript", new_callable=AsyncMock) as feed_mock:
             event = _make_event(
-                DomainEventKind.transcript_updated,
+                CPEventKind.message_assistant,
                 payload={"role": "agent", "content": "I will do stuff"},
             )
             await trail_service.handle_event(event)
@@ -128,7 +128,7 @@ class TestPlanTrackingToggle:
     async def test_handle_event_skips_native_plan_for_disabled_job(self, trail_service: TrailService) -> None:
         """Native plan tool calls are ignored for disabled jobs."""
         start_event = _make_event(
-            DomainEventKind.job_state_changed,
+            CPEventKind.job_state_changed,
             payload={"previous_state": "queued", "new_state": "running"},
         )
         await trail_service.handle_event(start_event)
@@ -137,7 +137,7 @@ class TestPlanTrackingToggle:
 
         with patch.object(trail_service._plan_manager, "feed_native_plan", new_callable=AsyncMock) as plan_mock:
             event = _make_event(
-                DomainEventKind.transcript_updated,
+                CPEventKind.tool_call_completed,
                 payload={
                     "role": "tool_call",
                     "tool_name": "manage_todo_list",

--- a/backend/tests/unit/test_claude_session_watcher.py
+++ b/backend/tests/unit/test_claude_session_watcher.py
@@ -231,7 +231,7 @@ class TestJsonlEventProcessing:
         runtime_service.feed_external_event.assert_called()
         call_args = runtime_service.feed_external_event.call_args
         session_event = call_args[0][1]
-        assert session_event.kind.value == "transcript"
+        assert str(session_event.kind) == "transcript"
         assert session_event.payload["role"] == "operator"
         assert "Fix the bug" in session_event.payload["content"]
 

--- a/backend/tests/unit/test_concurrency_stress.py
+++ b/backend/tests/unit/test_concurrency_stress.py
@@ -195,7 +195,7 @@ class TestConcurrentEventAppends:
 
     @pytest.mark.asyncio
     async def test_concurrent_appends_all_persisted(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
-        from backend.models.events import DomainEvent, DomainEventKind
+        from backend.models.events import DomainEventKind, new_event
         from backend.persistence.event_repo import EventRepository
 
         # Create a job for FK
@@ -205,9 +205,9 @@ class TestConcurrentEventAppends:
             await session.commit()
 
         async def append_event(seq: int) -> int:
-            event = DomainEvent(
+            event = new_event(
                 event_id=f"evt-{seq}",
-                job_id="ev-job",
+                session_id="ev-job",
                 timestamp=datetime.now(UTC),
                 kind=DomainEventKind.log_line_emitted,
                 payload={"seq": seq, "message": f"line-{seq}", "level": "info"},
@@ -229,5 +229,5 @@ class TestConcurrentEventAppends:
         assert len(events) == 20
 
         # IDs should be monotonically increasing
-        event_ids = [e.db_id for e in events if e.db_id is not None]
+        event_ids = [e.metadata.sequence for e in events if e.metadata.sequence is not None]
         assert event_ids == sorted(event_ids)

--- a/backend/tests/unit/test_concurrency_stress.py
+++ b/backend/tests/unit/test_concurrency_stress.py
@@ -195,7 +195,7 @@ class TestConcurrentEventAppends:
 
     @pytest.mark.asyncio
     async def test_concurrent_appends_all_persisted(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
-        from backend.models.events import CPEventKind, new_event
+        from backend.models.events import EventKind, new_event
         from backend.persistence.event_repo import EventRepository
 
         # Create a job for FK
@@ -209,7 +209,7 @@ class TestConcurrentEventAppends:
                 event_id=f"evt-{seq}",
                 session_id="ev-job",
                 timestamp=datetime.now(UTC),
-                kind=CPEventKind.log_line_emitted,
+                kind=EventKind.log_line_emitted,
                 payload={"seq": seq, "message": f"line-{seq}", "level": "info"},
             )
             async with session_factory() as session:
@@ -225,7 +225,7 @@ class TestConcurrentEventAppends:
 
         async with session_factory() as session:
             event_repo = EventRepository(session)
-            events = await event_repo.list_by_job("ev-job", [CPEventKind.log_line_emitted], limit=100)
+            events = await event_repo.list_by_job("ev-job", [EventKind.log_line_emitted], limit=100)
         assert len(events) == 20
 
         # IDs should be monotonically increasing

--- a/backend/tests/unit/test_concurrency_stress.py
+++ b/backend/tests/unit/test_concurrency_stress.py
@@ -195,7 +195,7 @@ class TestConcurrentEventAppends:
 
     @pytest.mark.asyncio
     async def test_concurrent_appends_all_persisted(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
-        from backend.models.events import DomainEventKind, new_event
+        from backend.models.events import CPEventKind, new_event
         from backend.persistence.event_repo import EventRepository
 
         # Create a job for FK
@@ -209,7 +209,7 @@ class TestConcurrentEventAppends:
                 event_id=f"evt-{seq}",
                 session_id="ev-job",
                 timestamp=datetime.now(UTC),
-                kind=DomainEventKind.log_line_emitted,
+                kind=CPEventKind.log_line_emitted,
                 payload={"seq": seq, "message": f"line-{seq}", "level": "info"},
             )
             async with session_factory() as session:
@@ -225,7 +225,7 @@ class TestConcurrentEventAppends:
 
         async with session_factory() as session:
             event_repo = EventRepository(session)
-            events = await event_repo.list_by_job("ev-job", [DomainEventKind.log_line_emitted], limit=100)
+            events = await event_repo.list_by_job("ev-job", [CPEventKind.log_line_emitted], limit=100)
         assert len(events) == 20
 
         # IDs should be monotonically increasing

--- a/backend/tests/unit/test_console_dashboard.py
+++ b/backend/tests/unit/test_console_dashboard.py
@@ -15,7 +15,7 @@ from backend.console_dashboard import (
     ConsoleLogHandler,
     _JobInfo,
 )
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, SessionEvent, new_event
 
 # ── _JobInfo ──
 
@@ -126,8 +126,8 @@ class TestConsoleLog:
 
 
 class TestApplyEvent:
-    def _make_event(self, kind: DomainEventKind, job_id: str = "job-1", **payload) -> DomainEvent:
-        return DomainEvent.for_job(job_id=job_id, kind=kind, payload=payload)
+    def _make_event(self, kind: DomainEventKind, job_id: str = "job-1", **payload) -> SessionEvent:
+        return new_event(session_id=job_id, kind=kind, payload=payload)
 
     def test_job_created(self):
         log = ConsoleLog()
@@ -178,7 +178,7 @@ class TestApplyEvent:
     def test_no_job_id_ignored(self):
         log = ConsoleLog()
         log.start()
-        event = DomainEvent.for_job(job_id="", kind=DomainEventKind.job_created, payload={})
+        event = new_event(session_id="", kind=DomainEventKind.job_created, payload={})
         log._apply_event(event)
         assert len(log._jobs) == 0
 
@@ -244,11 +244,7 @@ class TestHandleEvent:
     async def test_handle_event(self):
         log = ConsoleLog()
         log.start()
-        event = DomainEvent.for_job(
-            job_id="job-1",
-            kind=DomainEventKind.job_created,
-            payload={},
-        )
+        event = new_event(session_id="job-1", kind=DomainEventKind.job_created, payload={})
         await log.handle_event(event)
         assert "job-1" in log._jobs
 

--- a/backend/tests/unit/test_console_dashboard.py
+++ b/backend/tests/unit/test_console_dashboard.py
@@ -15,7 +15,7 @@ from backend.console_dashboard import (
     ConsoleLogHandler,
     _JobInfo,
 )
-from backend.models.events import CPEventKind, SessionEvent, new_event
+from backend.models.events import EventKind, SessionEvent, new_event
 
 # ── _JobInfo ──
 
@@ -126,20 +126,20 @@ class TestConsoleLog:
 
 
 class TestApplyEvent:
-    def _make_event(self, kind: CPEventKind, job_id: str = "job-1", **payload) -> SessionEvent:
+    def _make_event(self, kind: EventKind, job_id: str = "job-1", **payload) -> SessionEvent:
         return new_event(session_id=job_id, kind=kind, payload=payload)
 
     def test_job_created(self):
         log = ConsoleLog()
         log.start()
-        event = self._make_event(CPEventKind.job_created)
+        event = self._make_event(EventKind.job_created)
         log._apply_event(event)
         assert "job-1" in log._jobs
 
     def test_job_state_changed(self):
         log = ConsoleLog()
         log.start()
-        event = self._make_event(CPEventKind.job_state_changed, new_state="running")
+        event = self._make_event(EventKind.job_state_changed, new_state="running")
         log._apply_event(event)
         assert "job-1" in log._jobs
 
@@ -147,7 +147,7 @@ class TestApplyEvent:
         log = ConsoleLog()
         log.start()
         log._jobs["job-1"] = _JobInfo("job-1")
-        event = self._make_event(CPEventKind.job_completed)
+        event = self._make_event(EventKind.job_completed)
         log._apply_event(event)
         assert "job-1" not in log._jobs
 
@@ -155,7 +155,7 @@ class TestApplyEvent:
         log = ConsoleLog()
         log.start()
         log._jobs["job-1"] = _JobInfo("job-1")
-        event = self._make_event(CPEventKind.job_failed)
+        event = self._make_event(EventKind.job_failed)
         log._apply_event(event)
         assert "job-1" not in log._jobs
 
@@ -163,7 +163,7 @@ class TestApplyEvent:
         log = ConsoleLog()
         log.start()
         log._jobs["job-1"] = _JobInfo("job-1")
-        event = self._make_event(CPEventKind.job_canceled)
+        event = self._make_event(EventKind.job_canceled)
         log._apply_event(event)
         assert "job-1" not in log._jobs
 
@@ -171,14 +171,14 @@ class TestApplyEvent:
         log = ConsoleLog()
         log.start()
         log._jobs["job-1"] = _JobInfo("job-1")
-        event = self._make_event(CPEventKind.job_title_updated, title="My Task")
+        event = self._make_event(EventKind.job_title_updated, title="My Task")
         log._apply_event(event)
         assert log._jobs["job-1"].title == "My Task"
 
     def test_no_job_id_ignored(self):
         log = ConsoleLog()
         log.start()
-        event = new_event(session_id="", kind=CPEventKind.job_created, payload={})
+        event = new_event(session_id="", kind=EventKind.job_created, payload={})
         log._apply_event(event)
         assert len(log._jobs) == 0
 
@@ -187,7 +187,7 @@ class TestApplyEvent:
         log.start()
         log._jobs["job-1"] = _JobInfo("job-1")
         event = self._make_event(
-            CPEventKind.approval_requested,
+            EventKind.approval_requested,
             description="run npm install",
         )
         log._apply_event(event)  # Should not raise
@@ -198,7 +198,7 @@ class TestApplyEvent:
         job = _JobInfo("job-1")
         job.title = "Build feature"
         log._jobs["job-1"] = job
-        event = self._make_event(CPEventKind.job_completed)
+        event = self._make_event(EventKind.job_completed)
         log._apply_event(event)
         assert "job-1" not in log._jobs
 
@@ -244,7 +244,7 @@ class TestHandleEvent:
     async def test_handle_event(self):
         log = ConsoleLog()
         log.start()
-        event = new_event(session_id="job-1", kind=CPEventKind.job_created, payload={})
+        event = new_event(session_id="job-1", kind=EventKind.job_created, payload={})
         await log.handle_event(event)
         assert "job-1" in log._jobs
 

--- a/backend/tests/unit/test_console_dashboard.py
+++ b/backend/tests/unit/test_console_dashboard.py
@@ -15,7 +15,7 @@ from backend.console_dashboard import (
     ConsoleLogHandler,
     _JobInfo,
 )
-from backend.models.events import DomainEventKind, SessionEvent, new_event
+from backend.models.events import CPEventKind, SessionEvent, new_event
 
 # ── _JobInfo ──
 
@@ -126,20 +126,20 @@ class TestConsoleLog:
 
 
 class TestApplyEvent:
-    def _make_event(self, kind: DomainEventKind, job_id: str = "job-1", **payload) -> SessionEvent:
+    def _make_event(self, kind: CPEventKind, job_id: str = "job-1", **payload) -> SessionEvent:
         return new_event(session_id=job_id, kind=kind, payload=payload)
 
     def test_job_created(self):
         log = ConsoleLog()
         log.start()
-        event = self._make_event(DomainEventKind.job_created)
+        event = self._make_event(CPEventKind.job_created)
         log._apply_event(event)
         assert "job-1" in log._jobs
 
     def test_job_state_changed(self):
         log = ConsoleLog()
         log.start()
-        event = self._make_event(DomainEventKind.job_state_changed, new_state="running")
+        event = self._make_event(CPEventKind.job_state_changed, new_state="running")
         log._apply_event(event)
         assert "job-1" in log._jobs
 
@@ -147,7 +147,7 @@ class TestApplyEvent:
         log = ConsoleLog()
         log.start()
         log._jobs["job-1"] = _JobInfo("job-1")
-        event = self._make_event(DomainEventKind.job_completed)
+        event = self._make_event(CPEventKind.job_completed)
         log._apply_event(event)
         assert "job-1" not in log._jobs
 
@@ -155,7 +155,7 @@ class TestApplyEvent:
         log = ConsoleLog()
         log.start()
         log._jobs["job-1"] = _JobInfo("job-1")
-        event = self._make_event(DomainEventKind.job_failed)
+        event = self._make_event(CPEventKind.job_failed)
         log._apply_event(event)
         assert "job-1" not in log._jobs
 
@@ -163,7 +163,7 @@ class TestApplyEvent:
         log = ConsoleLog()
         log.start()
         log._jobs["job-1"] = _JobInfo("job-1")
-        event = self._make_event(DomainEventKind.job_canceled)
+        event = self._make_event(CPEventKind.job_canceled)
         log._apply_event(event)
         assert "job-1" not in log._jobs
 
@@ -171,14 +171,14 @@ class TestApplyEvent:
         log = ConsoleLog()
         log.start()
         log._jobs["job-1"] = _JobInfo("job-1")
-        event = self._make_event(DomainEventKind.job_title_updated, title="My Task")
+        event = self._make_event(CPEventKind.job_title_updated, title="My Task")
         log._apply_event(event)
         assert log._jobs["job-1"].title == "My Task"
 
     def test_no_job_id_ignored(self):
         log = ConsoleLog()
         log.start()
-        event = new_event(session_id="", kind=DomainEventKind.job_created, payload={})
+        event = new_event(session_id="", kind=CPEventKind.job_created, payload={})
         log._apply_event(event)
         assert len(log._jobs) == 0
 
@@ -187,7 +187,7 @@ class TestApplyEvent:
         log.start()
         log._jobs["job-1"] = _JobInfo("job-1")
         event = self._make_event(
-            DomainEventKind.approval_requested,
+            CPEventKind.approval_requested,
             description="run npm install",
         )
         log._apply_event(event)  # Should not raise
@@ -198,7 +198,7 @@ class TestApplyEvent:
         job = _JobInfo("job-1")
         job.title = "Build feature"
         log._jobs["job-1"] = job
-        event = self._make_event(DomainEventKind.job_completed)
+        event = self._make_event(CPEventKind.job_completed)
         log._apply_event(event)
         assert "job-1" not in log._jobs
 
@@ -244,7 +244,7 @@ class TestHandleEvent:
     async def test_handle_event(self):
         log = ConsoleLog()
         log.start()
-        event = new_event(session_id="job-1", kind=DomainEventKind.job_created, payload={})
+        event = new_event(session_id="job-1", kind=CPEventKind.job_created, payload={})
         await log.handle_event(event)
         assert "job-1" in log._jobs
 

--- a/backend/tests/unit/test_crash_recovery.py
+++ b/backend/tests/unit/test_crash_recovery.py
@@ -128,22 +128,22 @@ class TestDeadLetterRetry:
     async def test_dead_letter_retries_and_succeeds(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
         """Simulate event persist failure then success on retry."""
         from backend.lifespan import _persist_event_with_retry
-        from backend.models.events import DomainEvent, DomainEventKind
+        from backend.models.events import DomainEventKind, new_event
 
-        event = DomainEvent(
+        event = new_event(
             event_id="test-evt-1",
-            job_id="job-1",
+            session_id="job-1",
             timestamp=datetime.now(UTC),
             kind=DomainEventKind.log_line_emitted,
             payload={"seq": 1, "message": "test", "level": "info"},
         )
 
         # First call should succeed normally
-        await _persist_event_with_retry(
+        db_id = await _persist_event_with_retry(
             event=event,
             session_factory=session_factory,
         )
-        assert event.db_id is not None
+        assert db_id is not None
 
     @pytest.mark.asyncio
     async def test_persist_retries_on_lock_error(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
@@ -151,12 +151,12 @@ class TestDeadLetterRetry:
         from sqlalchemy.exc import OperationalError
 
         from backend.lifespan import _persist_event_with_retry
-        from backend.models.events import DomainEvent, DomainEventKind
+        from backend.models.events import DomainEventKind, SessionEvent, new_event
         from backend.persistence.event_repo import EventRepository
 
-        event = DomainEvent(
+        event = new_event(
             event_id="test-evt-retry",
-            job_id="job-1",
+            session_id="job-1",
             timestamp=datetime.now(UTC),
             kind=DomainEventKind.log_line_emitted,
             payload={"seq": 1, "message": "retry test", "level": "info"},
@@ -165,7 +165,7 @@ class TestDeadLetterRetry:
         call_count = 0
         original_append = EventRepository.append
 
-        async def flaky_append(self: EventRepository, evt: DomainEvent) -> int:
+        async def flaky_append(self: EventRepository, evt: SessionEvent) -> int:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -175,11 +175,11 @@ class TestDeadLetterRetry:
         _lock = asyncio.Lock()
 
         with patch.object(EventRepository, "append", flaky_append):
-            await _persist_event_with_retry(
+            db_id = await _persist_event_with_retry(
                 event=event,
                 session_factory=session_factory,
                 retry_delay_s=0.01,
             )
 
         assert call_count == 2  # Failed once, succeeded on retry
-        assert event.db_id is not None
+        assert db_id is not None

--- a/backend/tests/unit/test_crash_recovery.py
+++ b/backend/tests/unit/test_crash_recovery.py
@@ -128,13 +128,13 @@ class TestDeadLetterRetry:
     async def test_dead_letter_retries_and_succeeds(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
         """Simulate event persist failure then success on retry."""
         from backend.lifespan import _persist_event_with_retry
-        from backend.models.events import DomainEventKind, new_event
+        from backend.models.events import CPEventKind, new_event
 
         event = new_event(
             event_id="test-evt-1",
             session_id="job-1",
             timestamp=datetime.now(UTC),
-            kind=DomainEventKind.log_line_emitted,
+            kind=CPEventKind.log_line_emitted,
             payload={"seq": 1, "message": "test", "level": "info"},
         )
 
@@ -151,14 +151,14 @@ class TestDeadLetterRetry:
         from sqlalchemy.exc import OperationalError
 
         from backend.lifespan import _persist_event_with_retry
-        from backend.models.events import DomainEventKind, SessionEvent, new_event
+        from backend.models.events import CPEventKind, SessionEvent, new_event
         from backend.persistence.event_repo import EventRepository
 
         event = new_event(
             event_id="test-evt-retry",
             session_id="job-1",
             timestamp=datetime.now(UTC),
-            kind=DomainEventKind.log_line_emitted,
+            kind=CPEventKind.log_line_emitted,
             payload={"seq": 1, "message": "retry test", "level": "info"},
         )
 

--- a/backend/tests/unit/test_crash_recovery.py
+++ b/backend/tests/unit/test_crash_recovery.py
@@ -128,13 +128,13 @@ class TestDeadLetterRetry:
     async def test_dead_letter_retries_and_succeeds(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
         """Simulate event persist failure then success on retry."""
         from backend.lifespan import _persist_event_with_retry
-        from backend.models.events import CPEventKind, new_event
+        from backend.models.events import EventKind, new_event
 
         event = new_event(
             event_id="test-evt-1",
             session_id="job-1",
             timestamp=datetime.now(UTC),
-            kind=CPEventKind.log_line_emitted,
+            kind=EventKind.log_line_emitted,
             payload={"seq": 1, "message": "test", "level": "info"},
         )
 
@@ -151,14 +151,14 @@ class TestDeadLetterRetry:
         from sqlalchemy.exc import OperationalError
 
         from backend.lifespan import _persist_event_with_retry
-        from backend.models.events import CPEventKind, SessionEvent, new_event
+        from backend.models.events import EventKind, SessionEvent, new_event
         from backend.persistence.event_repo import EventRepository
 
         event = new_event(
             event_id="test-evt-retry",
             session_id="job-1",
             timestamp=datetime.now(UTC),
-            kind=CPEventKind.log_line_emitted,
+            kind=EventKind.log_line_emitted,
             payload={"seq": 1, "message": "retry test", "level": "info"},
         )
 

--- a/backend/tests/unit/test_diff_service.py
+++ b/backend/tests/unit/test_diff_service.py
@@ -211,8 +211,8 @@ class TestEventPublishing:
         await diff_service.on_worktree_file_modified("job-1", "/work", "main")
         mock_event_bus.publish.assert_called_once()
         event = mock_event_bus.publish.call_args[0][0]
-        assert event.kind.value == "DiffUpdated"
-        assert event.job_id == "job-1"
+        assert str(event.kind) == "DiffUpdated"
+        assert event.session_id == "job-1"
 
     @pytest.mark.asyncio
     async def test_empty_diff_still_publishes(

--- a/backend/tests/unit/test_diff_service.py
+++ b/backend/tests/unit/test_diff_service.py
@@ -211,7 +211,7 @@ class TestEventPublishing:
         await diff_service.on_worktree_file_modified("job-1", "/work", "main")
         mock_event_bus.publish.assert_called_once()
         event = mock_event_bus.publish.call_args[0][0]
-        assert str(event.kind) == "DiffUpdated"
+        assert str(event.kind) == "diff.updated"
         assert event.session_id == "job-1"
 
     @pytest.mark.asyncio

--- a/backend/tests/unit/test_event_bus.py
+++ b/backend/tests/unit/test_event_bus.py
@@ -7,11 +7,11 @@ from datetime import UTC, datetime
 
 import pytest
 
-from backend.models.events import DomainEventKind, SessionEvent, new_event
+from backend.models.events import CPEventKind, SessionEvent, new_event
 from backend.services.events.event_bus import EventBus
 
 
-def _make_event(kind: DomainEventKind = DomainEventKind.job_created) -> SessionEvent:
+def _make_event(kind: CPEventKind = CPEventKind.job_created) -> SessionEvent:
     return new_event(
         event_id="evt-1", session_id="job-1", timestamp=datetime.now(UTC), kind=kind, payload={"hello": "world"}
     )

--- a/backend/tests/unit/test_event_bus.py
+++ b/backend/tests/unit/test_event_bus.py
@@ -7,17 +7,13 @@ from datetime import UTC, datetime
 
 import pytest
 
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, SessionEvent, new_event
 from backend.services.events.event_bus import EventBus
 
 
-def _make_event(kind: DomainEventKind = DomainEventKind.job_created) -> DomainEvent:
-    return DomainEvent(
-        event_id="evt-1",
-        job_id="job-1",
-        timestamp=datetime.now(UTC),
-        kind=kind,
-        payload={"hello": "world"},
+def _make_event(kind: DomainEventKind = DomainEventKind.job_created) -> SessionEvent:
+    return new_event(
+        event_id="evt-1", session_id="job-1", timestamp=datetime.now(UTC), kind=kind, payload={"hello": "world"}
     )
 
 
@@ -25,9 +21,9 @@ class TestEventBus:
     @pytest.mark.asyncio
     async def test_publish_to_single_subscriber(self) -> None:
         bus = EventBus()
-        received: list[DomainEvent] = []
+        received: list[SessionEvent] = []
 
-        async def handler(event: DomainEvent) -> None:
+        async def handler(event: SessionEvent) -> None:
             received.append(event)
 
         bus.subscribe(handler)
@@ -40,13 +36,13 @@ class TestEventBus:
     @pytest.mark.asyncio
     async def test_publish_to_multiple_subscribers(self) -> None:
         bus = EventBus()
-        received_a: list[DomainEvent] = []
-        received_b: list[DomainEvent] = []
+        received_a: list[SessionEvent] = []
+        received_b: list[SessionEvent] = []
 
-        async def handler_a(event: DomainEvent) -> None:
+        async def handler_a(event: SessionEvent) -> None:
             received_a.append(event)
 
-        async def handler_b(event: DomainEvent) -> None:
+        async def handler_b(event: SessionEvent) -> None:
             received_b.append(event)
 
         bus.subscribe(handler_a)
@@ -65,9 +61,9 @@ class TestEventBus:
     @pytest.mark.asyncio
     async def test_unsubscribe_removes_handler(self) -> None:
         bus = EventBus()
-        received: list[DomainEvent] = []
+        received: list[SessionEvent] = []
 
-        async def handler(event: DomainEvent) -> None:
+        async def handler(event: SessionEvent) -> None:
             received.append(event)
 
         bus.subscribe(handler)
@@ -80,7 +76,7 @@ class TestEventBus:
     async def test_unsubscribe_unknown_handler_is_noop(self) -> None:
         bus = EventBus()
 
-        async def handler(event: DomainEvent) -> None:
+        async def handler(event: SessionEvent) -> None:
             pass
 
         # Should not raise
@@ -89,12 +85,12 @@ class TestEventBus:
     @pytest.mark.asyncio
     async def test_subscriber_error_does_not_block_others(self) -> None:
         bus = EventBus()
-        received: list[DomainEvent] = []
+        received: list[SessionEvent] = []
 
-        async def failing_handler(event: DomainEvent) -> None:
+        async def failing_handler(event: SessionEvent) -> None:
             raise RuntimeError("boom")
 
-        async def good_handler(event: DomainEvent) -> None:
+        async def good_handler(event: SessionEvent) -> None:
             received.append(event)
 
         bus.subscribe(failing_handler)
@@ -110,11 +106,11 @@ class TestEventBus:
         bus = EventBus()
         order: list[str] = []
 
-        async def slow_handler(event: DomainEvent) -> None:
+        async def slow_handler(event: SessionEvent) -> None:
             await asyncio.sleep(0.05)
             order.append("slow")
 
-        async def fast_handler(event: DomainEvent) -> None:
+        async def fast_handler(event: SessionEvent) -> None:
             order.append("fast")
 
         bus.subscribe(slow_handler)
@@ -129,7 +125,7 @@ class TestEventBus:
         bus = EventBus()
         count = 0
 
-        async def handler(event: DomainEvent) -> None:
+        async def handler(event: SessionEvent) -> None:
             nonlocal count
             count += 1
 

--- a/backend/tests/unit/test_event_bus.py
+++ b/backend/tests/unit/test_event_bus.py
@@ -7,11 +7,11 @@ from datetime import UTC, datetime
 
 import pytest
 
-from backend.models.events import CPEventKind, SessionEvent, new_event
+from backend.models.events import EventKind, SessionEvent, new_event
 from backend.services.events.event_bus import EventBus
 
 
-def _make_event(kind: CPEventKind = CPEventKind.job_created) -> SessionEvent:
+def _make_event(kind: EventKind = EventKind.job_created) -> SessionEvent:
     return new_event(
         event_id="evt-1", session_id="job-1", timestamp=datetime.now(UTC), kind=kind, payload={"hello": "world"}
     )

--- a/backend/tests/unit/test_event_processor.py
+++ b/backend/tests/unit/test_event_processor.py
@@ -8,7 +8,7 @@ import pytest
 
 from backend.models.domain import SessionEvent as CPSessionEvent
 from backend.models.domain import SessionEventKind
-from backend.models.events import CPEventKind, SessionEvent
+from backend.models.events import EventKind, SessionEvent
 from backend.services.events.event_bus import EventBus
 from backend.services.events.event_processor import EventProcessor
 
@@ -33,32 +33,32 @@ class TestTranslateEvent:
         ev = CPSessionEvent(kind=SessionEventKind.log, payload={"message": "hello"})
         result = EventProcessor._translate_event("j1", ev)
         assert result is not None
-        assert result.kind == CPEventKind.log_line_emitted
+        assert result.kind == EventKind.log_line_emitted
         assert result.session_id == "j1"
 
     def test_transcript_event(self) -> None:
         ev = CPSessionEvent(kind=SessionEventKind.transcript, payload={"role": "agent", "content": "hi"})
         result = EventProcessor._translate_event("j1", ev)
         assert result is not None
-        assert result.kind == CPEventKind.message_assistant
+        assert result.kind == EventKind.message_assistant
 
     def test_approval_request_event(self) -> None:
         ev = CPSessionEvent(kind=SessionEventKind.approval_request, payload={"action": "rm -rf"})
         result = EventProcessor._translate_event("j1", ev)
         assert result is not None
-        assert result.kind == CPEventKind.approval_requested
+        assert result.kind == EventKind.approval_requested
 
     def test_error_event(self) -> None:
         ev = CPSessionEvent(kind=SessionEventKind.error, payload={"message": "failed"})
         result = EventProcessor._translate_event("j1", ev)
         assert result is not None
-        assert result.kind == CPEventKind.job_failed
+        assert result.kind == EventKind.job_failed
 
     def test_model_downgraded_event(self) -> None:
         ev = CPSessionEvent(kind=SessionEventKind.model_downgraded, payload={"from": "a", "to": "b"})
         result = EventProcessor._translate_event("j1", ev)
         assert result is not None
-        assert result.kind == CPEventKind.model_downgraded
+        assert result.kind == EventKind.model_downgraded
 
     def test_unknown_event_returns_none(self) -> None:
         ev = CPSessionEvent(kind=SessionEventKind.done, payload={})
@@ -82,7 +82,7 @@ class TestProcessEvent:
         received: list[SessionEvent] = []
 
         async def _handler(e: SessionEvent) -> None:
-            if e.kind == CPEventKind.log_line_emitted:
+            if e.kind == EventKind.log_line_emitted:
                 received.append(e)
 
         event_bus.subscribe(_handler)

--- a/backend/tests/unit/test_event_processor.py
+++ b/backend/tests/unit/test_event_processor.py
@@ -6,8 +6,9 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from backend.models.domain import SessionEvent, SessionEventKind
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.domain import SessionEvent as CPSessionEvent
+from backend.models.domain import SessionEventKind
+from backend.models.events import DomainEventKind, SessionEvent
 from backend.services.events.event_bus import EventBus
 from backend.services.events.event_processor import EventProcessor
 
@@ -29,43 +30,43 @@ def processor(event_bus: EventBus) -> EventProcessor:
 
 class TestTranslateEvent:
     def test_log_event(self) -> None:
-        ev = SessionEvent(kind=SessionEventKind.log, payload={"message": "hello"})
+        ev = CPSessionEvent(kind=SessionEventKind.log, payload={"message": "hello"})
         result = EventProcessor._translate_event("j1", ev)
         assert result is not None
         assert result.kind == DomainEventKind.log_line_emitted
-        assert result.job_id == "j1"
+        assert result.session_id == "j1"
 
     def test_transcript_event(self) -> None:
-        ev = SessionEvent(kind=SessionEventKind.transcript, payload={"role": "agent", "content": "hi"})
+        ev = CPSessionEvent(kind=SessionEventKind.transcript, payload={"role": "agent", "content": "hi"})
         result = EventProcessor._translate_event("j1", ev)
         assert result is not None
         assert result.kind == DomainEventKind.transcript_updated
 
     def test_approval_request_event(self) -> None:
-        ev = SessionEvent(kind=SessionEventKind.approval_request, payload={"action": "rm -rf"})
+        ev = CPSessionEvent(kind=SessionEventKind.approval_request, payload={"action": "rm -rf"})
         result = EventProcessor._translate_event("j1", ev)
         assert result is not None
         assert result.kind == DomainEventKind.approval_requested
 
     def test_error_event(self) -> None:
-        ev = SessionEvent(kind=SessionEventKind.error, payload={"message": "failed"})
+        ev = CPSessionEvent(kind=SessionEventKind.error, payload={"message": "failed"})
         result = EventProcessor._translate_event("j1", ev)
         assert result is not None
         assert result.kind == DomainEventKind.job_failed
 
     def test_model_downgraded_event(self) -> None:
-        ev = SessionEvent(kind=SessionEventKind.model_downgraded, payload={"from": "a", "to": "b"})
+        ev = CPSessionEvent(kind=SessionEventKind.model_downgraded, payload={"from": "a", "to": "b"})
         result = EventProcessor._translate_event("j1", ev)
         assert result is not None
         assert result.kind == DomainEventKind.model_downgraded
 
     def test_unknown_event_returns_none(self) -> None:
-        ev = SessionEvent(kind=SessionEventKind.done, payload={})
+        ev = CPSessionEvent(kind=SessionEventKind.done, payload={})
         result = EventProcessor._translate_event("j1", ev)
         assert result is None
 
     def test_file_changed_returns_none(self) -> None:
-        ev = SessionEvent(kind=SessionEventKind.file_changed, payload={"path": "a.py"})
+        ev = CPSessionEvent(kind=SessionEventKind.file_changed, payload={"path": "a.py"})
         result = EventProcessor._translate_event("j1", ev)
         assert result is None
 
@@ -78,15 +79,15 @@ class TestTranslateEvent:
 class TestProcessEvent:
     @pytest.mark.asyncio
     async def test_log_event_published(self, processor: EventProcessor, event_bus: EventBus) -> None:
-        received: list[DomainEvent] = []
+        received: list[SessionEvent] = []
 
-        async def _handler(e: DomainEvent) -> None:
+        async def _handler(e: SessionEvent) -> None:
             if e.kind == DomainEventKind.log_line_emitted:
                 received.append(e)
 
         event_bus.subscribe(_handler)
 
-        ev = SessionEvent(kind=SessionEventKind.log, payload={"message": "test"})
+        ev = CPSessionEvent(kind=SessionEventKind.log, payload={"message": "test"})
         result = await processor.process_event("j1", ev)
         assert result is not None
         assert len(received) == 1
@@ -97,7 +98,7 @@ class TestProcessEvent:
         diff_svc = AsyncMock()
         proc = EventProcessor(bus, diff_service=diff_svc)
 
-        ev = SessionEvent(kind=SessionEventKind.file_changed, payload={"path": "a.py"})
+        ev = CPSessionEvent(kind=SessionEventKind.file_changed, payload={"path": "a.py"})
         result = await proc.process_event("j1", ev, worktree_path="/w", base_ref="main")
         assert result is None
         diff_svc.on_worktree_file_modified.assert_awaited_once()
@@ -108,7 +109,7 @@ class TestProcessEvent:
         diff_svc = AsyncMock()
         proc = EventProcessor(bus, diff_service=diff_svc)
 
-        ev = SessionEvent(
+        ev = CPSessionEvent(
             kind=SessionEventKind.transcript,
             payload={"role": "tool_call", "tool_name": "write_file"},
         )
@@ -122,7 +123,7 @@ class TestProcessEvent:
         diff_svc = AsyncMock()
         proc = EventProcessor(bus, diff_service=diff_svc)
 
-        ev = SessionEvent(
+        ev = CPSessionEvent(
             kind=SessionEventKind.transcript,
             payload={"role": "tool_call", "tool_name": "report_intent"},
         )
@@ -132,7 +133,7 @@ class TestProcessEvent:
 
     @pytest.mark.asyncio
     async def test_transcript_gets_synthesized_turn_id(self, processor: EventProcessor) -> None:
-        ev = SessionEvent(
+        ev = CPSessionEvent(
             kind=SessionEventKind.transcript,
             payload={"role": "tool_call", "content": "running"},
         )
@@ -142,7 +143,7 @@ class TestProcessEvent:
 
     @pytest.mark.asyncio
     async def test_turn_id_rotates_on_agent_message(self, processor: EventProcessor) -> None:
-        ev1 = SessionEvent(
+        ev1 = CPSessionEvent(
             kind=SessionEventKind.transcript,
             payload={"role": "tool_call", "content": "running"},
         )
@@ -150,14 +151,14 @@ class TestProcessEvent:
         tid1 = result1.payload["turn_id"]
 
         # Agent message rotates the turn_id
-        ev2 = SessionEvent(
+        ev2 = CPSessionEvent(
             kind=SessionEventKind.transcript,
             payload={"role": "agent", "content": "done"},
         )
         await processor.process_event("j1", ev2)
 
         # Next event should have a new turn_id
-        ev3 = SessionEvent(
+        ev3 = CPSessionEvent(
             kind=SessionEventKind.transcript,
             payload={"role": "tool_call", "content": "another"},
         )

--- a/backend/tests/unit/test_event_processor.py
+++ b/backend/tests/unit/test_event_processor.py
@@ -8,7 +8,7 @@ import pytest
 
 from backend.models.domain import SessionEvent as CPSessionEvent
 from backend.models.domain import SessionEventKind
-from backend.models.events import DomainEventKind, SessionEvent
+from backend.models.events import CPEventKind, SessionEvent
 from backend.services.events.event_bus import EventBus
 from backend.services.events.event_processor import EventProcessor
 
@@ -33,32 +33,32 @@ class TestTranslateEvent:
         ev = CPSessionEvent(kind=SessionEventKind.log, payload={"message": "hello"})
         result = EventProcessor._translate_event("j1", ev)
         assert result is not None
-        assert result.kind == DomainEventKind.log_line_emitted
+        assert result.kind == CPEventKind.log_line_emitted
         assert result.session_id == "j1"
 
     def test_transcript_event(self) -> None:
         ev = CPSessionEvent(kind=SessionEventKind.transcript, payload={"role": "agent", "content": "hi"})
         result = EventProcessor._translate_event("j1", ev)
         assert result is not None
-        assert result.kind == DomainEventKind.transcript_updated
+        assert result.kind == CPEventKind.message_assistant
 
     def test_approval_request_event(self) -> None:
         ev = CPSessionEvent(kind=SessionEventKind.approval_request, payload={"action": "rm -rf"})
         result = EventProcessor._translate_event("j1", ev)
         assert result is not None
-        assert result.kind == DomainEventKind.approval_requested
+        assert result.kind == CPEventKind.approval_requested
 
     def test_error_event(self) -> None:
         ev = CPSessionEvent(kind=SessionEventKind.error, payload={"message": "failed"})
         result = EventProcessor._translate_event("j1", ev)
         assert result is not None
-        assert result.kind == DomainEventKind.job_failed
+        assert result.kind == CPEventKind.job_failed
 
     def test_model_downgraded_event(self) -> None:
         ev = CPSessionEvent(kind=SessionEventKind.model_downgraded, payload={"from": "a", "to": "b"})
         result = EventProcessor._translate_event("j1", ev)
         assert result is not None
-        assert result.kind == DomainEventKind.model_downgraded
+        assert result.kind == CPEventKind.model_downgraded
 
     def test_unknown_event_returns_none(self) -> None:
         ev = CPSessionEvent(kind=SessionEventKind.done, payload={})
@@ -82,7 +82,7 @@ class TestProcessEvent:
         received: list[SessionEvent] = []
 
         async def _handler(e: SessionEvent) -> None:
-            if e.kind == DomainEventKind.log_line_emitted:
+            if e.kind == CPEventKind.log_line_emitted:
                 received.append(e)
 
         event_bus.subscribe(_handler)

--- a/backend/tests/unit/test_lifespan.py
+++ b/backend/tests/unit/test_lifespan.py
@@ -8,7 +8,7 @@ import pytest
 from sqlalchemy.exc import OperationalError
 
 from backend.lifespan import _persist_event_with_retry
-from backend.models.events import DomainEventKind, SessionEvent, new_event
+from backend.models.events import CPEventKind, SessionEvent, new_event
 
 
 class _FakeSession:
@@ -37,7 +37,7 @@ def _make_event() -> SessionEvent:
         event_id="evt-1",
         session_id="job-1",
         timestamp=datetime.now(UTC),
-        kind=DomainEventKind.job_state_changed,
+        kind=CPEventKind.job_state_changed,
         payload={"state": "running"},
     )
 

--- a/backend/tests/unit/test_lifespan.py
+++ b/backend/tests/unit/test_lifespan.py
@@ -8,7 +8,7 @@ import pytest
 from sqlalchemy.exc import OperationalError
 
 from backend.lifespan import _persist_event_with_retry
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, SessionEvent, new_event
 
 
 class _FakeSession:
@@ -32,10 +32,10 @@ class _FakeSessionContext:
         return None
 
 
-def _make_event() -> DomainEvent:
-    return DomainEvent(
+def _make_event() -> SessionEvent:
+    return new_event(
         event_id="evt-1",
-        job_id="job-1",
+        session_id="job-1",
         timestamp=datetime.now(UTC),
         kind=DomainEventKind.job_state_changed,
         payload={"state": "running"},
@@ -56,7 +56,7 @@ async def test_persist_event_retries_sqlite_lock(monkeypatch: pytest.MonkeyPatch
         def __init__(self, session: _FakeSession) -> None:
             self._session = session
 
-        async def append(self, event: DomainEvent) -> None:
+        async def append(self, event: SessionEvent) -> None:
             nonlocal append_attempts
             append_attempts += 1
             if append_attempts == 1:
@@ -98,7 +98,7 @@ async def test_persist_event_does_not_retry_non_lock_errors(monkeypatch: pytest.
         def __init__(self, session: _FakeSession) -> None:
             self._session = session
 
-        async def append(self, event: DomainEvent) -> None:
+        async def append(self, event: SessionEvent) -> None:
             raise OperationalError("INSERT", {}, Exception("disk I/O error"))
 
     monkeypatch.setattr("backend.lifespan.EventRepository", _FakeRepo)

--- a/backend/tests/unit/test_lifespan.py
+++ b/backend/tests/unit/test_lifespan.py
@@ -8,7 +8,7 @@ import pytest
 from sqlalchemy.exc import OperationalError
 
 from backend.lifespan import _persist_event_with_retry
-from backend.models.events import CPEventKind, SessionEvent, new_event
+from backend.models.events import EventKind, SessionEvent, new_event
 
 
 class _FakeSession:
@@ -37,7 +37,7 @@ def _make_event() -> SessionEvent:
         event_id="evt-1",
         session_id="job-1",
         timestamp=datetime.now(UTC),
-        kind=CPEventKind.job_state_changed,
+        kind=EventKind.job_state_changed,
         payload={"state": "running"},
     )
 

--- a/backend/tests/unit/test_merge_service.py
+++ b/backend/tests/unit/test_merge_service.py
@@ -14,7 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from backend.config import CompletionConfig, CPLConfig
 from backend.models.db import Base
 from backend.models.domain import Job
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, SessionEvent
 from backend.persistence.database import _set_sqlite_pragmas
 from backend.persistence.job_repo import JobRepository
 from backend.services.events.event_bus import EventBus
@@ -142,9 +142,9 @@ class TestFastForwardMerge:
         service = _make_service(event_bus, session_factory)
         await _insert_job(session_factory, _make_job(str(repo)))
 
-        published: list[DomainEvent] = []
+        published: list[SessionEvent] = []
 
-        async def _collect(e: DomainEvent) -> None:
+        async def _collect(e: SessionEvent) -> None:
             published.append(e)
 
         event_bus.subscribe(_collect)
@@ -260,9 +260,9 @@ class TestConflictFallback:
         service = _make_service(event_bus, session_factory)
         await _insert_job(session_factory, _make_job(str(repo)))
 
-        published: list[DomainEvent] = []
+        published: list[SessionEvent] = []
 
-        async def _collect(e: DomainEvent) -> None:
+        async def _collect(e: SessionEvent) -> None:
             published.append(e)
 
         event_bus.subscribe(_collect)
@@ -387,9 +387,9 @@ class TestFalsePositiveConflicts:
         service = _make_service(event_bus, session_factory)
         await _insert_job(session_factory, _make_job(str(repo)))
 
-        published: list[DomainEvent] = []
+        published: list[SessionEvent] = []
 
-        async def _collect(e: DomainEvent) -> None:
+        async def _collect(e: SessionEvent) -> None:
             published.append(e)
 
         event_bus.subscribe(_collect)
@@ -425,9 +425,9 @@ class TestFalsePositiveConflicts:
         service = _make_service(event_bus, session_factory)
         await _insert_job(session_factory, _make_job(str(repo)))
 
-        published: list[DomainEvent] = []
+        published: list[SessionEvent] = []
 
-        async def _collect(e: DomainEvent) -> None:
+        async def _collect(e: SessionEvent) -> None:
             published.append(e)
 
         event_bus.subscribe(_collect)
@@ -469,9 +469,9 @@ class TestFalsePositiveConflicts:
         service = _make_service(event_bus, session_factory)
         await _insert_job(session_factory, _make_job(str(repo)))
 
-        published: list[DomainEvent] = []
+        published: list[SessionEvent] = []
 
-        async def _collect(e: DomainEvent) -> None:
+        async def _collect(e: SessionEvent) -> None:
             published.append(e)
 
         event_bus.subscribe(_collect)
@@ -521,9 +521,9 @@ class TestOperatorMerge:
         service = _make_service(event_bus, session_factory)
         await _insert_job(session_factory, _make_job(str(repo)))
 
-        published: list[DomainEvent] = []
+        published: list[SessionEvent] = []
 
-        async def _collect(e: DomainEvent) -> None:
+        async def _collect(e: SessionEvent) -> None:
             published.append(e)
 
         event_bus.subscribe(_collect)
@@ -559,9 +559,9 @@ class TestOperatorMerge:
         service = _make_service(event_bus, session_factory)
         await _insert_job(session_factory, _make_job(str(repo)))
 
-        published: list[DomainEvent] = []
+        published: list[SessionEvent] = []
 
-        async def _collect(e: DomainEvent) -> None:
+        async def _collect(e: SessionEvent) -> None:
             published.append(e)
 
         event_bus.subscribe(_collect)
@@ -610,9 +610,9 @@ class TestOperatorMerge:
         service = _make_service(event_bus, session_factory)
         await _insert_job(session_factory, _make_job(str(repo)))
 
-        published: list[DomainEvent] = []
+        published: list[SessionEvent] = []
 
-        async def _collect2(e: DomainEvent) -> None:
+        async def _collect2(e: SessionEvent) -> None:
             published.append(e)
 
         event_bus.subscribe(_collect2)

--- a/backend/tests/unit/test_merge_service.py
+++ b/backend/tests/unit/test_merge_service.py
@@ -14,7 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from backend.config import CompletionConfig, CPLConfig
 from backend.models.db import Base
 from backend.models.domain import Job
-from backend.models.events import CPEventKind, SessionEvent
+from backend.models.events import EventKind, SessionEvent
 from backend.persistence.database import _set_sqlite_pragmas
 from backend.persistence.job_repo import JobRepository
 from backend.services.events.event_bus import EventBus
@@ -162,7 +162,7 @@ class TestFastForwardMerge:
         assert result.strategy == "ff_only"
         assert (repo / "new_file.py").exists()
 
-        merge_events = [e for e in published if e.kind == CPEventKind.merge_completed]
+        merge_events = [e for e in published if e.kind == EventKind.merge_completed]
         assert len(merge_events) == 1
         assert merge_events[0].payload["strategy"] == "ff_only"
 
@@ -280,7 +280,7 @@ class TestConflictFallback:
         assert result.conflict_files is not None
         assert len(result.conflict_files) > 0
 
-        conflict_events = [e for e in published if e.kind == CPEventKind.merge_conflict]
+        conflict_events = [e for e in published if e.kind == EventKind.merge_conflict]
         assert len(conflict_events) == 1
 
         # Main worktree should be back on main (not stuck in merge state)
@@ -402,7 +402,7 @@ class TestFalsePositiveConflicts:
             "Cherry-pick stopped because one or more branch commits are already present on the "
             "base branch; rebase the branch or create a PR"
         )
-        conflict_events = [e for e in published if e.kind == CPEventKind.merge_conflict]
+        conflict_events = [e for e in published if e.kind == EventKind.merge_conflict]
         assert conflict_events == [], "No merge_conflict event should be published for already-applied commits"
 
     async def test_smart_merge_real_conflict_still_detected(
@@ -436,7 +436,7 @@ class TestFalsePositiveConflicts:
 
         assert result.status == "conflict"
         assert result.conflict_files  # should list the conflicting file
-        conflict_events = [e for e in published if e.kind == CPEventKind.merge_conflict]
+        conflict_events = [e for e in published if e.kind == EventKind.merge_conflict]
         assert len(conflict_events) == 1
 
     async def test_auto_merge_hook_failure_is_not_a_conflict(
@@ -486,7 +486,7 @@ class TestFalsePositiveConflicts:
         )
 
         assert str(result.status) == "error", f"Expected error, got {result.status!r}"
-        conflict_events = [e for e in published if e.kind == CPEventKind.merge_conflict]
+        conflict_events = [e for e in published if e.kind == EventKind.merge_conflict]
         assert conflict_events == [], "No merge_conflict event should be published for non-conflict merge failures"
 
         async with session_factory() as session:
@@ -531,7 +531,7 @@ class TestOperatorMerge:
         result = await service.resolve_job(_make_job(str(repo)), "merge")
 
         assert result.status == "error"
-        conflict_events = [e for e in published if e.kind == CPEventKind.merge_conflict]
+        conflict_events = [e for e in published if e.kind == EventKind.merge_conflict]
         assert conflict_events == []
 
         async with session_factory() as session:
@@ -571,7 +571,7 @@ class TestOperatorMerge:
         assert result.status == "conflict"
         assert result.conflict_files
 
-        conflict_events = [e for e in published if e.kind == CPEventKind.merge_conflict]
+        conflict_events = [e for e in published if e.kind == EventKind.merge_conflict]
         assert len(conflict_events) == 1
 
         # merge_status must be persisted in the DB
@@ -622,7 +622,7 @@ class TestOperatorMerge:
         assert result.status == "conflict"
         assert result.conflict_files
 
-        conflict_events = [e for e in published if e.kind == CPEventKind.merge_conflict]
+        conflict_events = [e for e in published if e.kind == EventKind.merge_conflict]
         assert len(conflict_events) == 1
 
         # merge_status must be persisted in the DB

--- a/backend/tests/unit/test_merge_service.py
+++ b/backend/tests/unit/test_merge_service.py
@@ -14,7 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from backend.config import CompletionConfig, CPLConfig
 from backend.models.db import Base
 from backend.models.domain import Job
-from backend.models.events import DomainEventKind, SessionEvent
+from backend.models.events import CPEventKind, SessionEvent
 from backend.persistence.database import _set_sqlite_pragmas
 from backend.persistence.job_repo import JobRepository
 from backend.services.events.event_bus import EventBus
@@ -162,7 +162,7 @@ class TestFastForwardMerge:
         assert result.strategy == "ff_only"
         assert (repo / "new_file.py").exists()
 
-        merge_events = [e for e in published if e.kind == DomainEventKind.merge_completed]
+        merge_events = [e for e in published if e.kind == CPEventKind.merge_completed]
         assert len(merge_events) == 1
         assert merge_events[0].payload["strategy"] == "ff_only"
 
@@ -280,7 +280,7 @@ class TestConflictFallback:
         assert result.conflict_files is not None
         assert len(result.conflict_files) > 0
 
-        conflict_events = [e for e in published if e.kind == DomainEventKind.merge_conflict]
+        conflict_events = [e for e in published if e.kind == CPEventKind.merge_conflict]
         assert len(conflict_events) == 1
 
         # Main worktree should be back on main (not stuck in merge state)
@@ -402,7 +402,7 @@ class TestFalsePositiveConflicts:
             "Cherry-pick stopped because one or more branch commits are already present on the "
             "base branch; rebase the branch or create a PR"
         )
-        conflict_events = [e for e in published if e.kind == DomainEventKind.merge_conflict]
+        conflict_events = [e for e in published if e.kind == CPEventKind.merge_conflict]
         assert conflict_events == [], "No merge_conflict event should be published for already-applied commits"
 
     async def test_smart_merge_real_conflict_still_detected(
@@ -436,7 +436,7 @@ class TestFalsePositiveConflicts:
 
         assert result.status == "conflict"
         assert result.conflict_files  # should list the conflicting file
-        conflict_events = [e for e in published if e.kind == DomainEventKind.merge_conflict]
+        conflict_events = [e for e in published if e.kind == CPEventKind.merge_conflict]
         assert len(conflict_events) == 1
 
     async def test_auto_merge_hook_failure_is_not_a_conflict(
@@ -486,7 +486,7 @@ class TestFalsePositiveConflicts:
         )
 
         assert str(result.status) == "error", f"Expected error, got {result.status!r}"
-        conflict_events = [e for e in published if e.kind == DomainEventKind.merge_conflict]
+        conflict_events = [e for e in published if e.kind == CPEventKind.merge_conflict]
         assert conflict_events == [], "No merge_conflict event should be published for non-conflict merge failures"
 
         async with session_factory() as session:
@@ -531,7 +531,7 @@ class TestOperatorMerge:
         result = await service.resolve_job(_make_job(str(repo)), "merge")
 
         assert result.status == "error"
-        conflict_events = [e for e in published if e.kind == DomainEventKind.merge_conflict]
+        conflict_events = [e for e in published if e.kind == CPEventKind.merge_conflict]
         assert conflict_events == []
 
         async with session_factory() as session:
@@ -571,7 +571,7 @@ class TestOperatorMerge:
         assert result.status == "conflict"
         assert result.conflict_files
 
-        conflict_events = [e for e in published if e.kind == DomainEventKind.merge_conflict]
+        conflict_events = [e for e in published if e.kind == CPEventKind.merge_conflict]
         assert len(conflict_events) == 1
 
         # merge_status must be persisted in the DB
@@ -622,7 +622,7 @@ class TestOperatorMerge:
         assert result.status == "conflict"
         assert result.conflict_files
 
-        conflict_events = [e for e in published if e.kind == DomainEventKind.merge_conflict]
+        conflict_events = [e for e in published if e.kind == CPEventKind.merge_conflict]
         assert len(conflict_events) == 1
 
         # merge_status must be persisted in the DB

--- a/backend/tests/unit/test_models.py
+++ b/backend/tests/unit/test_models.py
@@ -13,7 +13,7 @@ from backend.models.api_schemas import (
     JobState,
 )
 from backend.models.domain import Job, MCPServerConfig, SessionConfig
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, new_event
 
 
 def test_camel_model_serializes_to_camel_case() -> None:
@@ -77,15 +77,15 @@ def test_job_state_enum_values() -> None:
 
 def test_domain_event_creation() -> None:
     now = datetime.now(UTC)
-    event = DomainEvent(
+    event = new_event(
         event_id="evt-1",
-        job_id="job-1",
+        session_id="job-1",
         timestamp=now,
         kind=DomainEventKind.job_created,
         payload={"repo": "/repos/a"},
     )
     assert event.kind == DomainEventKind.job_created
-    assert event.kind.value == "JobCreated"
+    assert str(event.kind) == "JobCreated"
 
 
 def test_domain_event_kind_values() -> None:

--- a/backend/tests/unit/test_models.py
+++ b/backend/tests/unit/test_models.py
@@ -13,7 +13,7 @@ from backend.models.api_schemas import (
     JobState,
 )
 from backend.models.domain import Job, MCPServerConfig, SessionConfig
-from backend.models.events import DomainEventKind, new_event
+from backend.models.events import CPEventKind, new_event
 
 
 def test_camel_model_serializes_to_camel_case() -> None:
@@ -81,15 +81,15 @@ def test_domain_event_creation() -> None:
         event_id="evt-1",
         session_id="job-1",
         timestamp=now,
-        kind=DomainEventKind.job_created,
+        kind=CPEventKind.job_created,
         payload={"repo": "/repos/a"},
     )
-    assert event.kind == DomainEventKind.job_created
-    assert str(event.kind) == "JobCreated"
+    assert event.kind == CPEventKind.job_created
+    assert str(event.kind) == "job.created"
 
 
 def test_domain_event_kind_values() -> None:
-    assert len(DomainEventKind) == 54
+    assert len(CPEventKind) == 58
 
 
 def test_job_domain_model() -> None:

--- a/backend/tests/unit/test_models.py
+++ b/backend/tests/unit/test_models.py
@@ -13,7 +13,7 @@ from backend.models.api_schemas import (
     JobState,
 )
 from backend.models.domain import Job, MCPServerConfig, SessionConfig
-from backend.models.events import CPEventKind, new_event
+from backend.models.events import EventKind, new_event
 
 
 def test_camel_model_serializes_to_camel_case() -> None:
@@ -81,15 +81,15 @@ def test_domain_event_creation() -> None:
         event_id="evt-1",
         session_id="job-1",
         timestamp=now,
-        kind=CPEventKind.job_created,
+        kind=EventKind.job_created,
         payload={"repo": "/repos/a"},
     )
-    assert event.kind == CPEventKind.job_created
+    assert event.kind == EventKind.job_created
     assert str(event.kind) == "job.created"
 
 
 def test_domain_event_kind_values() -> None:
-    assert len(CPEventKind) == 58
+    assert len(EventKind) == 58
 
 
 def test_job_domain_model() -> None:

--- a/backend/tests/unit/test_native_plan.py
+++ b/backend/tests/unit/test_native_plan.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from backend.models.events import DomainEventKind, SessionEvent
+from backend.models.events import CPEventKind, SessionEvent
 from backend.services.events.event_bus import EventBus
 from backend.services.trail import TrailService
 from backend.services.trail.models import TrailJobState as _TrailJobState
@@ -59,7 +59,7 @@ def _step_events(event_bus: AsyncMock) -> list[SessionEvent]:
     return [
         call.args[0]
         for call in event_bus.publish.call_args_list
-        if call.args[0].kind == DomainEventKind.plan_step_updated
+        if call.args[0].kind == CPEventKind.plan_step_updated
     ]
 
 

--- a/backend/tests/unit/test_native_plan.py
+++ b/backend/tests/unit/test_native_plan.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, SessionEvent
 from backend.services.events.event_bus import EventBus
 from backend.services.trail import TrailService
 from backend.services.trail.models import TrailJobState as _TrailJobState
@@ -54,7 +54,7 @@ def _init_job(service: TrailService, job_id: str = "job-1") -> None:
 # ---------------------------------------------------------------------------
 
 
-def _step_events(event_bus: AsyncMock) -> list[DomainEvent]:
+def _step_events(event_bus: AsyncMock) -> list[SessionEvent]:
     """Extract all plan_step_updated events from mock publish calls."""
     return [
         call.args[0]
@@ -79,7 +79,7 @@ class TestFeedNativePlan:
 
         step_evts = _step_events(event_bus)
         assert len(step_evts) == 3
-        assert all(e.job_id == "job-1" for e in step_evts)
+        assert all(e.session_id == "job-1" for e in step_evts)
         payloads = [e.payload for e in step_evts]
         assert payloads[0]["label"] == "Explore codebase"
         assert payloads[0]["status"] == "done"

--- a/backend/tests/unit/test_native_plan.py
+++ b/backend/tests/unit/test_native_plan.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from backend.models.events import CPEventKind, SessionEvent
+from backend.models.events import EventKind, SessionEvent
 from backend.services.events.event_bus import EventBus
 from backend.services.trail import TrailService
 from backend.services.trail.models import TrailJobState as _TrailJobState
@@ -59,7 +59,7 @@ def _step_events(event_bus: AsyncMock) -> list[SessionEvent]:
     return [
         call.args[0]
         for call in event_bus.publish.call_args_list
-        if call.args[0].kind == CPEventKind.plan_step_updated
+        if call.args[0].kind == EventKind.plan_step_updated
     ]
 
 

--- a/backend/tests/unit/test_node_builder_extended.py
+++ b/backend/tests/unit/test_node_builder_extended.py
@@ -18,7 +18,7 @@ from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from backend.models.db import Base, JobRow, JobTelemetrySpanRow, TrailNodeRow
-from backend.models.events import CPEventKind, SessionEvent, new_event
+from backend.models.events import EventKind, SessionEvent, new_event
 from backend.persistence.trail_repo import TrailNodeRepository
 from backend.services.trail.models import (
     MESSAGE_SIGNAL_BUFFER_SIZE,
@@ -71,7 +71,7 @@ def builder(session_factory, job_state, trail_repo):
 
 
 def _make_event(
-    kind: CPEventKind = CPEventKind.job_state_changed,
+    kind: EventKind = EventKind.job_state_changed,
     job_id: str = "job-1",
     payload: dict | None = None,
 ) -> SessionEvent:
@@ -80,7 +80,7 @@ def _make_event(
 
 def _started_event(job_id: str = "job-1") -> SessionEvent:
     return _make_event(
-        CPEventKind.job_state_changed,
+        EventKind.job_state_changed,
         job_id=job_id,
         payload={"previous_state": "queued", "new_state": "running"},
     )
@@ -236,13 +236,13 @@ class TestClassifyStepExtended:
 class TestHandleEventDispatch:
     async def test_unknown_event_kind_ignored(self, builder):
         """Events not in the dispatch table are silently ignored."""
-        event = _make_event(CPEventKind.diff_updated, payload={"diff": "..."})
+        event = _make_event(EventKind.diff_updated, payload={"diff": "..."})
         await builder.handle_event(event)  # should not raise
 
     async def test_job_state_changed_non_running_ignored(self, builder, job_state):
         """job_state_changed with new_state != 'running' does nothing."""
         event = _make_event(
-            CPEventKind.job_state_changed,
+            EventKind.job_state_changed,
             payload={"new_state": "queued"},
         )
         await builder.handle_event(event)
@@ -265,7 +265,7 @@ class TestHandleEventDispatch:
         # Patch repo.create to explode
         trail_repo.create = AsyncMock(side_effect=RuntimeError("boom"))
         event = _make_event(
-            CPEventKind.step_completed,
+            EventKind.step_completed,
             payload={"step_id": "s1", "files_read": ["a.py"]},
         )
         # Should not raise
@@ -304,7 +304,7 @@ class TestStepStarted:
     async def test_step_started_sets_active_step_id(self, builder, job_state):
         job_state["job-1"] = TrailJobState()
         event = _make_event(
-            CPEventKind.step_started,
+            EventKind.step_started,
             payload={"step_id": "step-42"},
         )
         await builder.handle_event(event)
@@ -312,7 +312,7 @@ class TestStepStarted:
 
     async def test_step_started_unknown_job_ignored(self, builder, job_state):
         event = _make_event(
-            CPEventKind.step_started,
+            EventKind.step_started,
             job_id="no-such-job",
             payload={"step_id": "s1"},
         )
@@ -330,7 +330,7 @@ class TestStepCompleted:
         """Steps with status='canceled' produce no trail node."""
         job_state["job-1"] = TrailJobState(active_goal_id="g1")
         event = _make_event(
-            CPEventKind.step_completed,
+            EventKind.step_completed,
             payload={"step_id": "s1", "status": "canceled"},
         )
         await builder.handle_event(event)
@@ -341,7 +341,7 @@ class TestStepCompleted:
         """tool_names from payload are JSON-serialized on the node."""
         job_state["job-1"] = TrailJobState(active_goal_id="g1")
         event = _make_event(
-            CPEventKind.step_completed,
+            EventKind.step_completed,
             payload={
                 "step_id": "s1",
                 "tool_names": ["read_file", "write_file"],
@@ -358,7 +358,7 @@ class TestStepCompleted:
         """diff_additions and diff_deletions are stored from payload."""
         job_state["job-1"] = TrailJobState(active_goal_id="g1")
         event = _make_event(
-            CPEventKind.step_completed,
+            EventKind.step_completed,
             payload={
                 "step_id": "s1",
                 "files_written": ["a.py"],
@@ -375,14 +375,14 @@ class TestStepCompleted:
         """Pending events accumulated before step_completed are flushed."""
         state = TrailJobState(active_goal_id="g1", active_step_id="s1")
         pending_event = _make_event(
-            CPEventKind.approval_requested,
+            EventKind.approval_requested,
             payload={"description": "Deploy to prod?"},
         )
         state.pending_events.append(pending_event)
         job_state["job-1"] = state
 
         event = _make_event(
-            CPEventKind.step_completed,
+            EventKind.step_completed,
             payload={"step_id": "s1", "files_read": ["a.py"]},
         )
         await builder.handle_event(event)
@@ -396,11 +396,11 @@ class TestStepCompleted:
     async def test_step_completed_clears_pending(self, builder, job_state):
         """After flushing, pending_events is empty."""
         state = TrailJobState(active_goal_id="g1", active_step_id="s1")
-        state.pending_events.append(_make_event(CPEventKind.approval_requested, payload={"description": "x"}))
+        state.pending_events.append(_make_event(EventKind.approval_requested, payload={"description": "x"}))
         job_state["job-1"] = state
         await builder.handle_event(
             _make_event(
-                CPEventKind.step_completed,
+                EventKind.step_completed,
                 payload={"step_id": "s1"},
             )
         )
@@ -410,7 +410,7 @@ class TestStepCompleted:
         """files list is deduped with writes first."""
         job_state["job-1"] = TrailJobState(active_goal_id="g1")
         event = _make_event(
-            CPEventKind.step_completed,
+            EventKind.step_completed,
             payload={
                 "step_id": "s1",
                 "files_written": ["b.py", "a.py"],
@@ -433,7 +433,7 @@ class TestPhaseChanged:
     async def test_phase_updates_state(self, builder, job_state, trail_repo):
         job_state["job-1"] = TrailJobState(active_goal_id="g1")
         event = _make_event(
-            CPEventKind.execution_phase_changed,
+            EventKind.execution_phase_changed,
             payload={"phase": "verification"},
         )
         await builder.handle_event(event)
@@ -444,7 +444,7 @@ class TestPhaseChanged:
 
     async def test_phase_changed_no_state_ignored(self, builder, job_state, trail_repo):
         event = _make_event(
-            CPEventKind.execution_phase_changed,
+            EventKind.execution_phase_changed,
             job_id="unknown",
             payload={"phase": "coding"},
         )
@@ -463,7 +463,7 @@ class TestApprovalRequested:
         """Without active_step_id, approval creates node immediately."""
         job_state["job-1"] = TrailJobState(active_goal_id="g1", active_step_id=None)
         event = _make_event(
-            CPEventKind.approval_requested,
+            EventKind.approval_requested,
             payload={"description": "Run tests?"},
         )
         await builder.handle_event(event)
@@ -477,7 +477,7 @@ class TestApprovalRequested:
         state = TrailJobState(active_goal_id="g1", active_step_id="s1")
         job_state["job-1"] = state
         event = _make_event(
-            CPEventKind.approval_requested,
+            EventKind.approval_requested,
             payload={"description": "Deploy?"},
         )
         await builder.handle_event(event)
@@ -485,7 +485,7 @@ class TestApprovalRequested:
 
     async def test_approval_no_state_ignored(self, builder, job_state):
         event = _make_event(
-            CPEventKind.approval_requested,
+            EventKind.approval_requested,
             job_id="ghost",
             payload={"description": "hi"},
         )
@@ -501,7 +501,7 @@ class TestApprovalRequested:
 class TestJobTerminal:
     async def test_job_canceled_status(self, builder, trail_repo, job_state):
         job_state["job-1"] = TrailJobState(active_goal_id="g1")
-        event = _make_event(CPEventKind.job_canceled, payload={})
+        event = _make_event(EventKind.job_canceled, payload={})
         await builder.handle_event(event)
         nodes = await trail_repo.get_by_job("job-1")
         assert nodes[0].intent == "Job canceled"
@@ -509,14 +509,14 @@ class TestJobTerminal:
 
     async def test_job_review_status(self, builder, trail_repo, job_state):
         job_state["job-1"] = TrailJobState(active_goal_id="g1")
-        event = _make_event(CPEventKind.job_review, payload={})
+        event = _make_event(EventKind.job_review, payload={})
         await builder.handle_event(event)
         nodes = await trail_repo.get_by_job("job-1")
         assert nodes[0].intent == "Job failed"
         assert "job-1" not in job_state
 
     async def test_job_terminal_no_state_ignored(self, builder, trail_repo, job_state):
-        event = _make_event(CPEventKind.job_completed, job_id="no-state", payload={})
+        event = _make_event(EventKind.job_completed, job_id="no-state", payload={})
         await builder.handle_event(event)
         nodes = await trail_repo.get_by_job("no-state")
         assert len(nodes) == 0
@@ -531,7 +531,7 @@ class TestTranscriptOperator:
     async def test_operator_creates_request_node(self, builder, trail_repo, job_state):
         job_state["job-1"] = TrailJobState(active_goal_id="g1")
         event = _make_event(
-            CPEventKind.message_user,
+            EventKind.message_user,
             payload={"role": "operator", "content": "Focus on auth module"},
         )
         await builder.handle_event(event)
@@ -543,7 +543,7 @@ class TestTranscriptOperator:
     async def test_user_role_also_creates_request_node(self, builder, trail_repo, job_state):
         job_state["job-1"] = TrailJobState(active_goal_id="g1")
         event = _make_event(
-            CPEventKind.message_user,
+            EventKind.message_user,
             payload={"role": "user", "content": "Please check"},
         )
         await builder.handle_event(event)
@@ -554,7 +554,7 @@ class TestTranscriptOperator:
     async def test_operator_empty_content_skipped(self, builder, trail_repo, job_state):
         job_state["job-1"] = TrailJobState(active_goal_id="g1")
         event = _make_event(
-            CPEventKind.message_user,
+            EventKind.message_user,
             payload={"role": "operator", "content": "   "},
         )
         await builder.handle_event(event)
@@ -565,7 +565,7 @@ class TestTranscriptOperator:
         state = TrailJobState(active_goal_id="g1")
         job_state["job-1"] = state
         event = _make_event(
-            CPEventKind.message_user,
+            EventKind.message_user,
             payload={"role": "operator", "content": "hello"},
         )
         await builder.handle_event(event)
@@ -576,7 +576,7 @@ class TestTranscriptOperator:
         state.recent_messages = [f"msg-{i}" for i in range(MESSAGE_SIGNAL_BUFFER_SIZE)]
         job_state["job-1"] = state
         event = _make_event(
-            CPEventKind.message_user,
+            EventKind.message_user,
             payload={"role": "operator", "content": "overflow"},
         )
         await builder.handle_event(event)
@@ -589,7 +589,7 @@ class TestTranscriptAssistant:
         state = TrailJobState(active_goal_id="g1")
         job_state["job-1"] = state
         event = _make_event(
-            CPEventKind.message_assistant,
+            EventKind.message_assistant,
             payload={"role": "assistant", "content": "I will fix the bug"},
         )
         await builder.handle_event(event)
@@ -599,7 +599,7 @@ class TestTranscriptAssistant:
         state = TrailJobState(active_goal_id="g1")
         job_state["job-1"] = state
         event = _make_event(
-            CPEventKind.message_assistant,
+            EventKind.message_assistant,
             payload={"role": "agent", "content": "Working on it"},
         )
         await builder.handle_event(event)
@@ -609,7 +609,7 @@ class TestTranscriptAssistant:
         state = TrailJobState(active_goal_id="g1")
         job_state["job-1"] = state
         event = _make_event(
-            CPEventKind.message_assistant,
+            EventKind.message_assistant,
             payload={"role": "assistant", "content": ""},
         )
         await builder.handle_event(event)
@@ -620,7 +620,7 @@ class TestTranscriptAssistant:
         job_state["job-1"] = state
         long_msg = "x" * 500
         event = _make_event(
-            CPEventKind.message_assistant,
+            EventKind.message_assistant,
             payload={"role": "assistant", "content": long_msg},
         )
         await builder.handle_event(event)
@@ -633,7 +633,7 @@ class TestTranscriptAssistant:
         state.recent_messages = [f"m{i}" for i in range(MESSAGE_SIGNAL_BUFFER_SIZE)]
         job_state["job-1"] = state
         event = _make_event(
-            CPEventKind.message_assistant,
+            EventKind.message_assistant,
             payload={"role": "assistant", "content": "newest"},
         )
         await builder.handle_event(event)
@@ -661,7 +661,7 @@ class TestTranscriptToolCall:
         job_state["job-1"] = TrailJobState(active_goal_id="g1")
 
         event = _make_event(
-            CPEventKind.tool_call_completed,
+            EventKind.tool_call_completed,
             payload={
                 "role": "tool_call",
                 "turn_id": "turn-1",
@@ -682,7 +682,7 @@ class TestTranscriptToolCall:
         """report_intent tool calls are skipped."""
         job_state["job-1"] = TrailJobState(active_goal_id="g1")
         event = _make_event(
-            CPEventKind.tool_call_completed,
+            EventKind.tool_call_completed,
             payload={
                 "role": "tool_call",
                 "turn_id": "turn-1",
@@ -695,7 +695,7 @@ class TestTranscriptToolCall:
     async def test_tool_call_empty_tool_name_skipped(self, builder, job_state):
         job_state["job-1"] = TrailJobState(active_goal_id="g1")
         event = _make_event(
-            CPEventKind.tool_call_completed,
+            EventKind.tool_call_completed,
             payload={"role": "tool_call", "turn_id": "t1", "tool_name": ""},
         )
         await builder.handle_event(event)
@@ -703,7 +703,7 @@ class TestTranscriptToolCall:
     async def test_tool_call_no_turn_id_skipped(self, builder, job_state):
         job_state["job-1"] = TrailJobState(active_goal_id="g1")
         event = _make_event(
-            CPEventKind.tool_call_completed,
+            EventKind.tool_call_completed,
             payload={"role": "tool_call", "tool_name": "write_file"},
         )
         await builder.handle_event(event)
@@ -712,7 +712,7 @@ class TestTranscriptToolCall:
         """tool_call with no job_id on the event is skipped."""
         job_state["job-1"] = TrailJobState(active_goal_id="g1")
         event = _make_event(
-            CPEventKind.tool_call_completed,
+            EventKind.tool_call_completed,
             job_id="job-1",
             payload={
                 "role": "tool_call",
@@ -742,7 +742,7 @@ class TestTranscriptToolCall:
         job_state["job-1"] = TrailJobState(active_goal_id="g1")
 
         event = _make_event(
-            CPEventKind.tool_call_completed,
+            EventKind.tool_call_completed,
             payload={
                 "role": "tool_call",
                 "turn_id": "turn-1",
@@ -757,7 +757,7 @@ class TestTranscriptToolCall:
     async def test_transcript_unknown_role_ignored(self, builder, job_state, trail_repo):
         job_state["job-1"] = TrailJobState(active_goal_id="g1")
         event = _make_event(
-            CPEventKind.message_assistant,
+            EventKind.message_assistant,
             payload={"role": "system", "content": "internal"},
         )
         await builder.handle_event(event)
@@ -766,7 +766,7 @@ class TestTranscriptToolCall:
 
     async def test_transcript_no_state_ignored(self, builder, job_state):
         event = _make_event(
-            CPEventKind.message_user,
+            EventKind.message_user,
             job_id="ghost",
             payload={"role": "operator", "content": "hi"},
         )
@@ -794,7 +794,7 @@ class TestClassifyAndEmit:
         job_state["job-1"] = state
 
         event = _make_event(
-            CPEventKind.step_completed,
+            EventKind.step_completed,
             payload={"step_id": "s1", "files_read": ["a.py"]},
         )
         # Should not raise
@@ -822,7 +822,7 @@ class TestClassifyAndEmit:
         job_state["job-1"] = state
 
         event = _make_event(
-            CPEventKind.step_completed,
+            EventKind.step_completed,
             payload={
                 "step_id": "s1",
                 "turn_id": "turn-1",
@@ -867,7 +867,7 @@ class TestWriteSubNodeErrors:
         trail_repo.create_many = AsyncMock(side_effect=DBAPIError("fake", {}, Exception("db down")))
 
         event = _make_event(
-            CPEventKind.step_completed,
+            EventKind.step_completed,
             payload={
                 "step_id": "s1",
                 "turn_id": "turn-1",
@@ -944,7 +944,7 @@ class TestSessionResumed:
     async def test_session_resumed_already_tracked_is_noop(self, builder, job_state):
         """If job is already in _job_state, session_resumed does nothing."""
         job_state["job-1"] = TrailJobState(next_seq=42)
-        event = _make_event(CPEventKind.session_resumed, payload={})
+        event = _make_event(EventKind.session_resumed, payload={})
         await builder.handle_event(event)
         assert job_state["job-1"].next_seq == 42  # unchanged
 
@@ -970,7 +970,7 @@ class TestSessionResumed:
             trail_state_snapshot=snapshot_json,
         )
 
-        event = _make_event(CPEventKind.session_resumed, payload={})
+        event = _make_event(EventKind.session_resumed, payload={})
         await builder.handle_event(event)
 
         restored = job_state["job-1"]
@@ -997,7 +997,7 @@ class TestSessionResumed:
         )
         await trail_repo.create(node)
 
-        event = _make_event(CPEventKind.session_resumed, payload={})
+        event = _make_event(EventKind.session_resumed, payload={})
         await builder.handle_event(event)
 
         assert job_state["job-1"].next_seq == 11  # max_seq(10) + 1
@@ -1038,7 +1038,7 @@ class TestSessionResumed:
         )
         await trail_repo.create(work)
 
-        event = _make_event(CPEventKind.session_resumed, payload={})
+        event = _make_event(EventKind.session_resumed, payload={})
         await builder.handle_event(event)
 
         restored = job_state["job-1"]
@@ -1054,7 +1054,7 @@ class TestSessionResumed:
     async def test_session_resumed_lossy_no_goal(self, builder, session_factory, job_state, trail_repo):
         """Lossy fallback without a goal node still initializes state."""
         await _insert_job_row(session_factory, "job-1", prompt="test")
-        event = _make_event(CPEventKind.session_resumed, payload={})
+        event = _make_event(EventKind.session_resumed, payload={})
         await builder.handle_event(event)
         restored = job_state["job-1"]
         assert restored.next_seq == 1  # no nodes → max_seq = 0, next = 1
@@ -1073,7 +1073,7 @@ class TestSessionResumed:
                 ev = new_event(
                     session_id="job-1",
                     timestamp=datetime.now(UTC),
-                    kind=CPEventKind.plan_step_updated,
+                    kind=EventKind.plan_step_updated,
                     payload={
                         "plan_step_id": f"ps-{i}",
                         "label": f"Step {i}",
@@ -1084,7 +1084,7 @@ class TestSessionResumed:
                 await event_repo.append(ev)
             await session.commit()
 
-        event = _make_event(CPEventKind.session_resumed, payload={})
+        event = _make_event(EventKind.session_resumed, payload={})
         await builder.handle_event(event)
 
         restored = job_state["job-1"]
@@ -1117,7 +1117,7 @@ class TestSessionResumed:
             )
             await trail_repo.create(node)
 
-        event = _make_event(CPEventKind.session_resumed, payload={})
+        event = _make_event(EventKind.session_resumed, payload={})
         await builder.handle_event(event)
 
         restored = job_state["job-1"]
@@ -1138,7 +1138,7 @@ class TestJobTerminalSnapshot:
         state = TrailJobState(active_goal_id="g1", next_seq=5, job_prompt="Fix it")
         job_state["job-1"] = state
 
-        event = _make_event(CPEventKind.job_completed, payload={})
+        event = _make_event(EventKind.job_completed, payload={})
         await builder.handle_event(event)
 
         # State should be cleaned up
@@ -1170,7 +1170,7 @@ class TestStepCompletedIntegration:
 
         # Complete a step
         event = _make_event(
-            CPEventKind.step_completed,
+            EventKind.step_completed,
             payload={"step_id": "s1", "files_read": ["a.py"]},
         )
         await builder.handle_event(event)

--- a/backend/tests/unit/test_node_builder_extended.py
+++ b/backend/tests/unit/test_node_builder_extended.py
@@ -18,7 +18,7 @@ from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from backend.models.db import Base, JobRow, JobTelemetrySpanRow, TrailNodeRow
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, SessionEvent, new_event
 from backend.persistence.trail_repo import TrailNodeRepository
 from backend.services.trail.models import (
     MESSAGE_SIGNAL_BUFFER_SIZE,
@@ -74,17 +74,11 @@ def _make_event(
     kind: DomainEventKind = DomainEventKind.job_state_changed,
     job_id: str = "job-1",
     payload: dict | None = None,
-) -> DomainEvent:
-    return DomainEvent(
-        event_id=DomainEvent.make_event_id(),
-        job_id=job_id,
-        timestamp=datetime.now(UTC),
-        kind=kind,
-        payload=payload or {},
-    )
+) -> SessionEvent:
+    return new_event(session_id=job_id, timestamp=datetime.now(UTC), kind=kind, payload=payload or {})
 
 
-def _started_event(job_id: str = "job-1") -> DomainEvent:
+def _started_event(job_id: str = "job-1") -> SessionEvent:
     return _make_event(
         DomainEventKind.job_state_changed,
         job_id=job_id,
@@ -726,8 +720,8 @@ class TestTranscriptToolCall:
                 "tool_name": "write_file",
             },
         )
-        # Override event job_id to None to test the guard
-        event.job_id = None
+        # Override event session_id to empty to test the guard
+        event = event.model_copy(update={"session_id": ""})
         await builder.handle_event(event)
 
     async def test_tool_success_false(self, builder, trail_repo, job_state):
@@ -1076,9 +1070,8 @@ class TestSessionResumed:
         async with session_factory() as session:
             event_repo = EventRepository(session)
             for i, status in enumerate(["pending", "active"]):
-                ev = DomainEvent(
-                    event_id=DomainEvent.make_event_id(),
-                    job_id="job-1",
+                ev = new_event(
+                    session_id="job-1",
                     timestamp=datetime.now(UTC),
                     kind=DomainEventKind.plan_step_updated,
                     payload={

--- a/backend/tests/unit/test_node_builder_extended.py
+++ b/backend/tests/unit/test_node_builder_extended.py
@@ -18,7 +18,7 @@ from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from backend.models.db import Base, JobRow, JobTelemetrySpanRow, TrailNodeRow
-from backend.models.events import DomainEventKind, SessionEvent, new_event
+from backend.models.events import CPEventKind, SessionEvent, new_event
 from backend.persistence.trail_repo import TrailNodeRepository
 from backend.services.trail.models import (
     MESSAGE_SIGNAL_BUFFER_SIZE,
@@ -71,7 +71,7 @@ def builder(session_factory, job_state, trail_repo):
 
 
 def _make_event(
-    kind: DomainEventKind = DomainEventKind.job_state_changed,
+    kind: CPEventKind = CPEventKind.job_state_changed,
     job_id: str = "job-1",
     payload: dict | None = None,
 ) -> SessionEvent:
@@ -80,7 +80,7 @@ def _make_event(
 
 def _started_event(job_id: str = "job-1") -> SessionEvent:
     return _make_event(
-        DomainEventKind.job_state_changed,
+        CPEventKind.job_state_changed,
         job_id=job_id,
         payload={"previous_state": "queued", "new_state": "running"},
     )
@@ -236,13 +236,13 @@ class TestClassifyStepExtended:
 class TestHandleEventDispatch:
     async def test_unknown_event_kind_ignored(self, builder):
         """Events not in the dispatch table are silently ignored."""
-        event = _make_event(DomainEventKind.diff_updated, payload={"diff": "..."})
+        event = _make_event(CPEventKind.diff_updated, payload={"diff": "..."})
         await builder.handle_event(event)  # should not raise
 
     async def test_job_state_changed_non_running_ignored(self, builder, job_state):
         """job_state_changed with new_state != 'running' does nothing."""
         event = _make_event(
-            DomainEventKind.job_state_changed,
+            CPEventKind.job_state_changed,
             payload={"new_state": "queued"},
         )
         await builder.handle_event(event)
@@ -265,7 +265,7 @@ class TestHandleEventDispatch:
         # Patch repo.create to explode
         trail_repo.create = AsyncMock(side_effect=RuntimeError("boom"))
         event = _make_event(
-            DomainEventKind.step_completed,
+            CPEventKind.step_completed,
             payload={"step_id": "s1", "files_read": ["a.py"]},
         )
         # Should not raise
@@ -304,7 +304,7 @@ class TestStepStarted:
     async def test_step_started_sets_active_step_id(self, builder, job_state):
         job_state["job-1"] = TrailJobState()
         event = _make_event(
-            DomainEventKind.step_started,
+            CPEventKind.step_started,
             payload={"step_id": "step-42"},
         )
         await builder.handle_event(event)
@@ -312,7 +312,7 @@ class TestStepStarted:
 
     async def test_step_started_unknown_job_ignored(self, builder, job_state):
         event = _make_event(
-            DomainEventKind.step_started,
+            CPEventKind.step_started,
             job_id="no-such-job",
             payload={"step_id": "s1"},
         )
@@ -330,7 +330,7 @@ class TestStepCompleted:
         """Steps with status='canceled' produce no trail node."""
         job_state["job-1"] = TrailJobState(active_goal_id="g1")
         event = _make_event(
-            DomainEventKind.step_completed,
+            CPEventKind.step_completed,
             payload={"step_id": "s1", "status": "canceled"},
         )
         await builder.handle_event(event)
@@ -341,7 +341,7 @@ class TestStepCompleted:
         """tool_names from payload are JSON-serialized on the node."""
         job_state["job-1"] = TrailJobState(active_goal_id="g1")
         event = _make_event(
-            DomainEventKind.step_completed,
+            CPEventKind.step_completed,
             payload={
                 "step_id": "s1",
                 "tool_names": ["read_file", "write_file"],
@@ -358,7 +358,7 @@ class TestStepCompleted:
         """diff_additions and diff_deletions are stored from payload."""
         job_state["job-1"] = TrailJobState(active_goal_id="g1")
         event = _make_event(
-            DomainEventKind.step_completed,
+            CPEventKind.step_completed,
             payload={
                 "step_id": "s1",
                 "files_written": ["a.py"],
@@ -375,14 +375,14 @@ class TestStepCompleted:
         """Pending events accumulated before step_completed are flushed."""
         state = TrailJobState(active_goal_id="g1", active_step_id="s1")
         pending_event = _make_event(
-            DomainEventKind.approval_requested,
+            CPEventKind.approval_requested,
             payload={"description": "Deploy to prod?"},
         )
         state.pending_events.append(pending_event)
         job_state["job-1"] = state
 
         event = _make_event(
-            DomainEventKind.step_completed,
+            CPEventKind.step_completed,
             payload={"step_id": "s1", "files_read": ["a.py"]},
         )
         await builder.handle_event(event)
@@ -396,11 +396,11 @@ class TestStepCompleted:
     async def test_step_completed_clears_pending(self, builder, job_state):
         """After flushing, pending_events is empty."""
         state = TrailJobState(active_goal_id="g1", active_step_id="s1")
-        state.pending_events.append(_make_event(DomainEventKind.approval_requested, payload={"description": "x"}))
+        state.pending_events.append(_make_event(CPEventKind.approval_requested, payload={"description": "x"}))
         job_state["job-1"] = state
         await builder.handle_event(
             _make_event(
-                DomainEventKind.step_completed,
+                CPEventKind.step_completed,
                 payload={"step_id": "s1"},
             )
         )
@@ -410,7 +410,7 @@ class TestStepCompleted:
         """files list is deduped with writes first."""
         job_state["job-1"] = TrailJobState(active_goal_id="g1")
         event = _make_event(
-            DomainEventKind.step_completed,
+            CPEventKind.step_completed,
             payload={
                 "step_id": "s1",
                 "files_written": ["b.py", "a.py"],
@@ -433,7 +433,7 @@ class TestPhaseChanged:
     async def test_phase_updates_state(self, builder, job_state, trail_repo):
         job_state["job-1"] = TrailJobState(active_goal_id="g1")
         event = _make_event(
-            DomainEventKind.execution_phase_changed,
+            CPEventKind.execution_phase_changed,
             payload={"phase": "verification"},
         )
         await builder.handle_event(event)
@@ -444,7 +444,7 @@ class TestPhaseChanged:
 
     async def test_phase_changed_no_state_ignored(self, builder, job_state, trail_repo):
         event = _make_event(
-            DomainEventKind.execution_phase_changed,
+            CPEventKind.execution_phase_changed,
             job_id="unknown",
             payload={"phase": "coding"},
         )
@@ -463,7 +463,7 @@ class TestApprovalRequested:
         """Without active_step_id, approval creates node immediately."""
         job_state["job-1"] = TrailJobState(active_goal_id="g1", active_step_id=None)
         event = _make_event(
-            DomainEventKind.approval_requested,
+            CPEventKind.approval_requested,
             payload={"description": "Run tests?"},
         )
         await builder.handle_event(event)
@@ -477,7 +477,7 @@ class TestApprovalRequested:
         state = TrailJobState(active_goal_id="g1", active_step_id="s1")
         job_state["job-1"] = state
         event = _make_event(
-            DomainEventKind.approval_requested,
+            CPEventKind.approval_requested,
             payload={"description": "Deploy?"},
         )
         await builder.handle_event(event)
@@ -485,7 +485,7 @@ class TestApprovalRequested:
 
     async def test_approval_no_state_ignored(self, builder, job_state):
         event = _make_event(
-            DomainEventKind.approval_requested,
+            CPEventKind.approval_requested,
             job_id="ghost",
             payload={"description": "hi"},
         )
@@ -501,7 +501,7 @@ class TestApprovalRequested:
 class TestJobTerminal:
     async def test_job_canceled_status(self, builder, trail_repo, job_state):
         job_state["job-1"] = TrailJobState(active_goal_id="g1")
-        event = _make_event(DomainEventKind.job_canceled, payload={})
+        event = _make_event(CPEventKind.job_canceled, payload={})
         await builder.handle_event(event)
         nodes = await trail_repo.get_by_job("job-1")
         assert nodes[0].intent == "Job canceled"
@@ -509,14 +509,14 @@ class TestJobTerminal:
 
     async def test_job_review_status(self, builder, trail_repo, job_state):
         job_state["job-1"] = TrailJobState(active_goal_id="g1")
-        event = _make_event(DomainEventKind.job_review, payload={})
+        event = _make_event(CPEventKind.job_review, payload={})
         await builder.handle_event(event)
         nodes = await trail_repo.get_by_job("job-1")
         assert nodes[0].intent == "Job failed"
         assert "job-1" not in job_state
 
     async def test_job_terminal_no_state_ignored(self, builder, trail_repo, job_state):
-        event = _make_event(DomainEventKind.job_completed, job_id="no-state", payload={})
+        event = _make_event(CPEventKind.job_completed, job_id="no-state", payload={})
         await builder.handle_event(event)
         nodes = await trail_repo.get_by_job("no-state")
         assert len(nodes) == 0
@@ -531,7 +531,7 @@ class TestTranscriptOperator:
     async def test_operator_creates_request_node(self, builder, trail_repo, job_state):
         job_state["job-1"] = TrailJobState(active_goal_id="g1")
         event = _make_event(
-            DomainEventKind.transcript_updated,
+            CPEventKind.message_user,
             payload={"role": "operator", "content": "Focus on auth module"},
         )
         await builder.handle_event(event)
@@ -543,7 +543,7 @@ class TestTranscriptOperator:
     async def test_user_role_also_creates_request_node(self, builder, trail_repo, job_state):
         job_state["job-1"] = TrailJobState(active_goal_id="g1")
         event = _make_event(
-            DomainEventKind.transcript_updated,
+            CPEventKind.message_user,
             payload={"role": "user", "content": "Please check"},
         )
         await builder.handle_event(event)
@@ -554,7 +554,7 @@ class TestTranscriptOperator:
     async def test_operator_empty_content_skipped(self, builder, trail_repo, job_state):
         job_state["job-1"] = TrailJobState(active_goal_id="g1")
         event = _make_event(
-            DomainEventKind.transcript_updated,
+            CPEventKind.message_user,
             payload={"role": "operator", "content": "   "},
         )
         await builder.handle_event(event)
@@ -565,7 +565,7 @@ class TestTranscriptOperator:
         state = TrailJobState(active_goal_id="g1")
         job_state["job-1"] = state
         event = _make_event(
-            DomainEventKind.transcript_updated,
+            CPEventKind.message_user,
             payload={"role": "operator", "content": "hello"},
         )
         await builder.handle_event(event)
@@ -576,7 +576,7 @@ class TestTranscriptOperator:
         state.recent_messages = [f"msg-{i}" for i in range(MESSAGE_SIGNAL_BUFFER_SIZE)]
         job_state["job-1"] = state
         event = _make_event(
-            DomainEventKind.transcript_updated,
+            CPEventKind.message_user,
             payload={"role": "operator", "content": "overflow"},
         )
         await builder.handle_event(event)
@@ -589,7 +589,7 @@ class TestTranscriptAssistant:
         state = TrailJobState(active_goal_id="g1")
         job_state["job-1"] = state
         event = _make_event(
-            DomainEventKind.transcript_updated,
+            CPEventKind.message_assistant,
             payload={"role": "assistant", "content": "I will fix the bug"},
         )
         await builder.handle_event(event)
@@ -599,7 +599,7 @@ class TestTranscriptAssistant:
         state = TrailJobState(active_goal_id="g1")
         job_state["job-1"] = state
         event = _make_event(
-            DomainEventKind.transcript_updated,
+            CPEventKind.message_assistant,
             payload={"role": "agent", "content": "Working on it"},
         )
         await builder.handle_event(event)
@@ -609,7 +609,7 @@ class TestTranscriptAssistant:
         state = TrailJobState(active_goal_id="g1")
         job_state["job-1"] = state
         event = _make_event(
-            DomainEventKind.transcript_updated,
+            CPEventKind.message_assistant,
             payload={"role": "assistant", "content": ""},
         )
         await builder.handle_event(event)
@@ -620,7 +620,7 @@ class TestTranscriptAssistant:
         job_state["job-1"] = state
         long_msg = "x" * 500
         event = _make_event(
-            DomainEventKind.transcript_updated,
+            CPEventKind.message_assistant,
             payload={"role": "assistant", "content": long_msg},
         )
         await builder.handle_event(event)
@@ -633,7 +633,7 @@ class TestTranscriptAssistant:
         state.recent_messages = [f"m{i}" for i in range(MESSAGE_SIGNAL_BUFFER_SIZE)]
         job_state["job-1"] = state
         event = _make_event(
-            DomainEventKind.transcript_updated,
+            CPEventKind.message_assistant,
             payload={"role": "assistant", "content": "newest"},
         )
         await builder.handle_event(event)
@@ -661,7 +661,7 @@ class TestTranscriptToolCall:
         job_state["job-1"] = TrailJobState(active_goal_id="g1")
 
         event = _make_event(
-            DomainEventKind.transcript_updated,
+            CPEventKind.tool_call_completed,
             payload={
                 "role": "tool_call",
                 "turn_id": "turn-1",
@@ -682,7 +682,7 @@ class TestTranscriptToolCall:
         """report_intent tool calls are skipped."""
         job_state["job-1"] = TrailJobState(active_goal_id="g1")
         event = _make_event(
-            DomainEventKind.transcript_updated,
+            CPEventKind.tool_call_completed,
             payload={
                 "role": "tool_call",
                 "turn_id": "turn-1",
@@ -695,7 +695,7 @@ class TestTranscriptToolCall:
     async def test_tool_call_empty_tool_name_skipped(self, builder, job_state):
         job_state["job-1"] = TrailJobState(active_goal_id="g1")
         event = _make_event(
-            DomainEventKind.transcript_updated,
+            CPEventKind.tool_call_completed,
             payload={"role": "tool_call", "turn_id": "t1", "tool_name": ""},
         )
         await builder.handle_event(event)
@@ -703,7 +703,7 @@ class TestTranscriptToolCall:
     async def test_tool_call_no_turn_id_skipped(self, builder, job_state):
         job_state["job-1"] = TrailJobState(active_goal_id="g1")
         event = _make_event(
-            DomainEventKind.transcript_updated,
+            CPEventKind.tool_call_completed,
             payload={"role": "tool_call", "tool_name": "write_file"},
         )
         await builder.handle_event(event)
@@ -712,7 +712,7 @@ class TestTranscriptToolCall:
         """tool_call with no job_id on the event is skipped."""
         job_state["job-1"] = TrailJobState(active_goal_id="g1")
         event = _make_event(
-            DomainEventKind.transcript_updated,
+            CPEventKind.tool_call_completed,
             job_id="job-1",
             payload={
                 "role": "tool_call",
@@ -742,7 +742,7 @@ class TestTranscriptToolCall:
         job_state["job-1"] = TrailJobState(active_goal_id="g1")
 
         event = _make_event(
-            DomainEventKind.transcript_updated,
+            CPEventKind.tool_call_completed,
             payload={
                 "role": "tool_call",
                 "turn_id": "turn-1",
@@ -757,7 +757,7 @@ class TestTranscriptToolCall:
     async def test_transcript_unknown_role_ignored(self, builder, job_state, trail_repo):
         job_state["job-1"] = TrailJobState(active_goal_id="g1")
         event = _make_event(
-            DomainEventKind.transcript_updated,
+            CPEventKind.message_assistant,
             payload={"role": "system", "content": "internal"},
         )
         await builder.handle_event(event)
@@ -766,7 +766,7 @@ class TestTranscriptToolCall:
 
     async def test_transcript_no_state_ignored(self, builder, job_state):
         event = _make_event(
-            DomainEventKind.transcript_updated,
+            CPEventKind.message_user,
             job_id="ghost",
             payload={"role": "operator", "content": "hi"},
         )
@@ -794,7 +794,7 @@ class TestClassifyAndEmit:
         job_state["job-1"] = state
 
         event = _make_event(
-            DomainEventKind.step_completed,
+            CPEventKind.step_completed,
             payload={"step_id": "s1", "files_read": ["a.py"]},
         )
         # Should not raise
@@ -822,7 +822,7 @@ class TestClassifyAndEmit:
         job_state["job-1"] = state
 
         event = _make_event(
-            DomainEventKind.step_completed,
+            CPEventKind.step_completed,
             payload={
                 "step_id": "s1",
                 "turn_id": "turn-1",
@@ -867,7 +867,7 @@ class TestWriteSubNodeErrors:
         trail_repo.create_many = AsyncMock(side_effect=DBAPIError("fake", {}, Exception("db down")))
 
         event = _make_event(
-            DomainEventKind.step_completed,
+            CPEventKind.step_completed,
             payload={
                 "step_id": "s1",
                 "turn_id": "turn-1",
@@ -944,7 +944,7 @@ class TestSessionResumed:
     async def test_session_resumed_already_tracked_is_noop(self, builder, job_state):
         """If job is already in _job_state, session_resumed does nothing."""
         job_state["job-1"] = TrailJobState(next_seq=42)
-        event = _make_event(DomainEventKind.session_resumed, payload={})
+        event = _make_event(CPEventKind.session_resumed, payload={})
         await builder.handle_event(event)
         assert job_state["job-1"].next_seq == 42  # unchanged
 
@@ -970,7 +970,7 @@ class TestSessionResumed:
             trail_state_snapshot=snapshot_json,
         )
 
-        event = _make_event(DomainEventKind.session_resumed, payload={})
+        event = _make_event(CPEventKind.session_resumed, payload={})
         await builder.handle_event(event)
 
         restored = job_state["job-1"]
@@ -997,7 +997,7 @@ class TestSessionResumed:
         )
         await trail_repo.create(node)
 
-        event = _make_event(DomainEventKind.session_resumed, payload={})
+        event = _make_event(CPEventKind.session_resumed, payload={})
         await builder.handle_event(event)
 
         assert job_state["job-1"].next_seq == 11  # max_seq(10) + 1
@@ -1038,7 +1038,7 @@ class TestSessionResumed:
         )
         await trail_repo.create(work)
 
-        event = _make_event(DomainEventKind.session_resumed, payload={})
+        event = _make_event(CPEventKind.session_resumed, payload={})
         await builder.handle_event(event)
 
         restored = job_state["job-1"]
@@ -1054,7 +1054,7 @@ class TestSessionResumed:
     async def test_session_resumed_lossy_no_goal(self, builder, session_factory, job_state, trail_repo):
         """Lossy fallback without a goal node still initializes state."""
         await _insert_job_row(session_factory, "job-1", prompt="test")
-        event = _make_event(DomainEventKind.session_resumed, payload={})
+        event = _make_event(CPEventKind.session_resumed, payload={})
         await builder.handle_event(event)
         restored = job_state["job-1"]
         assert restored.next_seq == 1  # no nodes → max_seq = 0, next = 1
@@ -1073,7 +1073,7 @@ class TestSessionResumed:
                 ev = new_event(
                     session_id="job-1",
                     timestamp=datetime.now(UTC),
-                    kind=DomainEventKind.plan_step_updated,
+                    kind=CPEventKind.plan_step_updated,
                     payload={
                         "plan_step_id": f"ps-{i}",
                         "label": f"Step {i}",
@@ -1084,7 +1084,7 @@ class TestSessionResumed:
                 await event_repo.append(ev)
             await session.commit()
 
-        event = _make_event(DomainEventKind.session_resumed, payload={})
+        event = _make_event(CPEventKind.session_resumed, payload={})
         await builder.handle_event(event)
 
         restored = job_state["job-1"]
@@ -1117,7 +1117,7 @@ class TestSessionResumed:
             )
             await trail_repo.create(node)
 
-        event = _make_event(DomainEventKind.session_resumed, payload={})
+        event = _make_event(CPEventKind.session_resumed, payload={})
         await builder.handle_event(event)
 
         restored = job_state["job-1"]
@@ -1138,7 +1138,7 @@ class TestJobTerminalSnapshot:
         state = TrailJobState(active_goal_id="g1", next_seq=5, job_prompt="Fix it")
         job_state["job-1"] = state
 
-        event = _make_event(DomainEventKind.job_completed, payload={})
+        event = _make_event(CPEventKind.job_completed, payload={})
         await builder.handle_event(event)
 
         # State should be cleaned up
@@ -1170,7 +1170,7 @@ class TestStepCompletedIntegration:
 
         # Complete a step
         event = _make_event(
-            DomainEventKind.step_completed,
+            CPEventKind.step_completed,
             payload={"step_id": "s1", "files_read": ["a.py"]},
         )
         await builder.handle_event(event)

--- a/backend/tests/unit/test_plan_manager.py
+++ b/backend/tests/unit/test_plan_manager.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from backend.models.events import CPEventKind, SessionEvent
+from backend.models.events import EventKind, SessionEvent
 from backend.services.events.event_bus import EventBus
 from backend.services.trail.models import (
     PlanStep,
@@ -121,7 +121,7 @@ class TestInferPlan:
         events: list[SessionEvent] = []
 
         async def _handler(e: SessionEvent) -> None:
-            if e.kind == CPEventKind.plan_step_updated:
+            if e.kind == EventKind.plan_step_updated:
                 events.append(e)
 
         event_bus.subscribe(_handler)
@@ -272,7 +272,7 @@ class TestClassifyAndUpdatePlan:
         events: list[SessionEvent] = []
 
         async def _handler(e: SessionEvent) -> None:
-            if e.kind == CPEventKind.step_entries_reassigned:
+            if e.kind == EventKind.step_entries_reassigned:
                 events.append(e)
 
         event_bus.subscribe(_handler)
@@ -314,7 +314,7 @@ class TestFeedNativePlan:
         events: list[SessionEvent] = []
 
         async def _handler(e: SessionEvent) -> None:
-            if e.kind == CPEventKind.plan_step_updated:
+            if e.kind == EventKind.plan_step_updated:
                 events.append(e)
 
         event_bus.subscribe(_handler)

--- a/backend/tests/unit/test_plan_manager.py
+++ b/backend/tests/unit/test_plan_manager.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from backend.models.events import DomainEventKind, SessionEvent
+from backend.models.events import CPEventKind, SessionEvent
 from backend.services.events.event_bus import EventBus
 from backend.services.trail.models import (
     PlanStep,
@@ -121,7 +121,7 @@ class TestInferPlan:
         events: list[SessionEvent] = []
 
         async def _handler(e: SessionEvent) -> None:
-            if e.kind == DomainEventKind.plan_step_updated:
+            if e.kind == CPEventKind.plan_step_updated:
                 events.append(e)
 
         event_bus.subscribe(_handler)
@@ -272,7 +272,7 @@ class TestClassifyAndUpdatePlan:
         events: list[SessionEvent] = []
 
         async def _handler(e: SessionEvent) -> None:
-            if e.kind == DomainEventKind.step_entries_reassigned:
+            if e.kind == CPEventKind.step_entries_reassigned:
                 events.append(e)
 
         event_bus.subscribe(_handler)
@@ -314,7 +314,7 @@ class TestFeedNativePlan:
         events: list[SessionEvent] = []
 
         async def _handler(e: SessionEvent) -> None:
-            if e.kind == DomainEventKind.plan_step_updated:
+            if e.kind == CPEventKind.plan_step_updated:
                 events.append(e)
 
         event_bus.subscribe(_handler)

--- a/backend/tests/unit/test_plan_manager.py
+++ b/backend/tests/unit/test_plan_manager.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, SessionEvent
 from backend.services.events.event_bus import EventBus
 from backend.services.trail.models import (
     PlanStep,
@@ -118,9 +118,9 @@ class TestInferPlan:
             }
         )
 
-        events: list[DomainEvent] = []
+        events: list[SessionEvent] = []
 
-        async def _handler(e: DomainEvent) -> None:
+        async def _handler(e: SessionEvent) -> None:
             if e.kind == DomainEventKind.plan_step_updated:
                 events.append(e)
 
@@ -269,9 +269,9 @@ class TestClassifyAndUpdatePlan:
             }
         )
 
-        events: list[DomainEvent] = []
+        events: list[SessionEvent] = []
 
-        async def _handler(e: DomainEvent) -> None:
+        async def _handler(e: SessionEvent) -> None:
             if e.kind == DomainEventKind.step_entries_reassigned:
                 events.append(e)
 
@@ -311,9 +311,9 @@ class TestFeedNativePlan:
         state = _state()
         job_state["j1"] = state
 
-        events: list[DomainEvent] = []
+        events: list[SessionEvent] = []
 
-        async def _handler(e: DomainEvent) -> None:
+        async def _handler(e: SessionEvent) -> None:
             if e.kind == DomainEventKind.plan_step_updated:
                 events.append(e)
 

--- a/backend/tests/unit/test_plan_mode_flow.py
+++ b/backend/tests/unit/test_plan_mode_flow.py
@@ -26,7 +26,7 @@ from backend.models.domain import (
     SessionEvent,
     SessionEventKind,
 )
-from backend.models.events import TRANSCRIPT_KINDS, CPEventKind
+from backend.models.events import TRANSCRIPT_KINDS, EventKind
 from backend.persistence.database import _set_sqlite_pragmas
 from backend.persistence.job_repo import JobRepository
 from backend.services.adapters.adapter_registry import AdapterRegistry
@@ -203,7 +203,7 @@ async def runtime(
         if event.kind in TRANSCRIPT_KINDS:
             await trail_svc._on_transcript_event(event)
         # Auto-create job state on state change to running
-        if event.kind == CPEventKind.job_state_changed:
+        if event.kind == EventKind.job_state_changed:
             payload = event.payload or {}
             if payload.get("new_state") == "running" and event.session_id and event.session_id not in trail_state:
                 trail_state[event.session_id] = _TrailJobState()
@@ -334,7 +334,7 @@ async def test_plan_mode_reaches_approval_gate(
     await _wait_for_state(session_factory, job.id, JobState.waiting_for_approval)
 
     # Verify approval_requested event was emitted
-    approval_events = [e for e in events if e.kind == CPEventKind.approval_requested]
+    approval_events = [e for e in events if e.kind == EventKind.approval_requested]
     assert len(approval_events) >= 1
     assert approval_events[0].payload["proposed_action"] == "execute_plan"
 
@@ -361,7 +361,7 @@ async def test_plan_mode_approval_transitions_to_implementing(
     await _wait_for_state(session_factory, job.id, JobState.waiting_for_approval)
 
     # Approve the plan
-    approval_events = [e for e in events if e.kind == CPEventKind.approval_requested]
+    approval_events = [e for e in events if e.kind == EventKind.approval_requested]
     approval_id = approval_events[0].payload["approval_id"]
     await runtime._approval_service.resolve(approval_id, ApprovalResolution.approved)
 
@@ -369,7 +369,7 @@ async def test_plan_mode_approval_transitions_to_implementing(
     await _wait_for_state(session_factory, job.id, JobState.review, timeout=15.0)
 
     # Verify mode_changed event
-    mode_events = [e for e in events if e.kind == CPEventKind.job_mode_changed]
+    mode_events = [e for e in events if e.kind == EventKind.job_mode_changed]
     assert len(mode_events) == 1
     assert mode_events[0].payload["previous_mode"] == "plan"
     assert mode_events[0].payload["new_mode"] == "plan_implementing"
@@ -404,7 +404,7 @@ async def test_plan_mode_rejection_triggers_replan(
     await _wait_for_state(session_factory, job.id, JobState.waiting_for_approval)
 
     # Reject the plan
-    approval_events = [e for e in events if e.kind == CPEventKind.approval_requested]
+    approval_events = [e for e in events if e.kind == EventKind.approval_requested]
     approval_id = approval_events[0].payload["approval_id"]
     await runtime._approval_service.resolve(approval_id, ApprovalResolution.rejected, notes="Needs more detail")
 
@@ -413,7 +413,7 @@ async def test_plan_mode_rejection_triggers_replan(
     await asyncio.sleep(0.2)
 
     # A second approval_requested event should have been emitted
-    approval_events_after = [e for e in events if e.kind == CPEventKind.approval_requested]
+    approval_events_after = [e for e in events if e.kind == EventKind.approval_requested]
     assert len(approval_events_after) >= 2
 
     # Now approve the second plan
@@ -445,7 +445,7 @@ async def test_plan_mode_max_rejections_fails_job(
     # Reject 6 times (limit is 5)
     for i in range(6):
         await _wait_for_state(session_factory, job.id, JobState.waiting_for_approval, timeout=10.0)
-        approval_events = [e for e in events if e.kind == CPEventKind.approval_requested]
+        approval_events = [e for e in events if e.kind == EventKind.approval_requested]
         latest_approval_id = approval_events[-1].payload["approval_id"]
         await runtime._approval_service.resolve(latest_approval_id, ApprovalResolution.rejected)
 

--- a/backend/tests/unit/test_plan_mode_flow.py
+++ b/backend/tests/unit/test_plan_mode_flow.py
@@ -26,7 +26,7 @@ from backend.models.domain import (
     SessionEvent,
     SessionEventKind,
 )
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind
 from backend.persistence.database import _set_sqlite_pragmas
 from backend.persistence.job_repo import JobRepository
 from backend.services.adapters.adapter_registry import AdapterRegistry
@@ -199,14 +199,14 @@ async def runtime(
 
     # Subscribe trail service's transcript handler to the event bus
     # so manage_todo_list calls get captured as plan steps.
-    async def _trail_event_handler(event: DomainEvent) -> None:
+    async def _trail_event_handler(event: SessionEvent) -> None:
         if event.kind == DomainEventKind.transcript_updated:
             await trail_svc._on_transcript_event(event)
         # Auto-create job state on state change to running
         if event.kind == DomainEventKind.job_state_changed:
             payload = event.payload or {}
-            if payload.get("new_state") == "running" and event.job_id and event.job_id not in trail_state:
-                trail_state[event.job_id] = _TrailJobState()
+            if payload.get("new_state") == "running" and event.session_id and event.session_id not in trail_state:
+                trail_state[event.session_id] = _TrailJobState()
 
     event_bus.subscribe(_trail_event_handler)
 
@@ -323,9 +323,9 @@ async def test_plan_mode_reaches_approval_gate(
     await _create_db_job(session_factory, job)
 
     # Collect events
-    events: list[DomainEvent] = []
+    events: list[SessionEvent] = []
 
-    async def _capture(e: DomainEvent) -> None:
+    async def _capture(e: SessionEvent) -> None:
         events.append(e)
 
     event_bus.subscribe(_capture)
@@ -350,9 +350,9 @@ async def test_plan_mode_approval_transitions_to_implementing(
     job = _make_plan_job()
     await _create_db_job(session_factory, job)
 
-    events: list[DomainEvent] = []
+    events: list[SessionEvent] = []
 
-    async def _capture(e: DomainEvent) -> None:
+    async def _capture(e: SessionEvent) -> None:
         events.append(e)
 
     event_bus.subscribe(_capture)
@@ -393,9 +393,9 @@ async def test_plan_mode_rejection_triggers_replan(
     job = _make_plan_job()
     await _create_db_job(session_factory, job)
 
-    events: list[DomainEvent] = []
+    events: list[SessionEvent] = []
 
-    async def _capture(e: DomainEvent) -> None:
+    async def _capture(e: SessionEvent) -> None:
         events.append(e)
 
     event_bus.subscribe(_capture)
@@ -433,9 +433,9 @@ async def test_plan_mode_max_rejections_fails_job(
     job = _make_plan_job()
     await _create_db_job(session_factory, job)
 
-    events: list[DomainEvent] = []
+    events: list[SessionEvent] = []
 
-    async def _capture(e: DomainEvent) -> None:
+    async def _capture(e: SessionEvent) -> None:
         events.append(e)
 
     event_bus.subscribe(_capture)

--- a/backend/tests/unit/test_plan_mode_flow.py
+++ b/backend/tests/unit/test_plan_mode_flow.py
@@ -26,7 +26,7 @@ from backend.models.domain import (
     SessionEvent,
     SessionEventKind,
 )
-from backend.models.events import DomainEventKind
+from backend.models.events import TRANSCRIPT_KINDS, CPEventKind
 from backend.persistence.database import _set_sqlite_pragmas
 from backend.persistence.job_repo import JobRepository
 from backend.services.adapters.adapter_registry import AdapterRegistry
@@ -200,10 +200,10 @@ async def runtime(
     # Subscribe trail service's transcript handler to the event bus
     # so manage_todo_list calls get captured as plan steps.
     async def _trail_event_handler(event: SessionEvent) -> None:
-        if event.kind == DomainEventKind.transcript_updated:
+        if event.kind in TRANSCRIPT_KINDS:
             await trail_svc._on_transcript_event(event)
         # Auto-create job state on state change to running
-        if event.kind == DomainEventKind.job_state_changed:
+        if event.kind == CPEventKind.job_state_changed:
             payload = event.payload or {}
             if payload.get("new_state") == "running" and event.session_id and event.session_id not in trail_state:
                 trail_state[event.session_id] = _TrailJobState()
@@ -334,7 +334,7 @@ async def test_plan_mode_reaches_approval_gate(
     await _wait_for_state(session_factory, job.id, JobState.waiting_for_approval)
 
     # Verify approval_requested event was emitted
-    approval_events = [e for e in events if e.kind == DomainEventKind.approval_requested]
+    approval_events = [e for e in events if e.kind == CPEventKind.approval_requested]
     assert len(approval_events) >= 1
     assert approval_events[0].payload["proposed_action"] == "execute_plan"
 
@@ -361,7 +361,7 @@ async def test_plan_mode_approval_transitions_to_implementing(
     await _wait_for_state(session_factory, job.id, JobState.waiting_for_approval)
 
     # Approve the plan
-    approval_events = [e for e in events if e.kind == DomainEventKind.approval_requested]
+    approval_events = [e for e in events if e.kind == CPEventKind.approval_requested]
     approval_id = approval_events[0].payload["approval_id"]
     await runtime._approval_service.resolve(approval_id, ApprovalResolution.approved)
 
@@ -369,7 +369,7 @@ async def test_plan_mode_approval_transitions_to_implementing(
     await _wait_for_state(session_factory, job.id, JobState.review, timeout=15.0)
 
     # Verify mode_changed event
-    mode_events = [e for e in events if e.kind == DomainEventKind.job_mode_changed]
+    mode_events = [e for e in events if e.kind == CPEventKind.job_mode_changed]
     assert len(mode_events) == 1
     assert mode_events[0].payload["previous_mode"] == "plan"
     assert mode_events[0].payload["new_mode"] == "plan_implementing"
@@ -404,7 +404,7 @@ async def test_plan_mode_rejection_triggers_replan(
     await _wait_for_state(session_factory, job.id, JobState.waiting_for_approval)
 
     # Reject the plan
-    approval_events = [e for e in events if e.kind == DomainEventKind.approval_requested]
+    approval_events = [e for e in events if e.kind == CPEventKind.approval_requested]
     approval_id = approval_events[0].payload["approval_id"]
     await runtime._approval_service.resolve(approval_id, ApprovalResolution.rejected, notes="Needs more detail")
 
@@ -413,7 +413,7 @@ async def test_plan_mode_rejection_triggers_replan(
     await asyncio.sleep(0.2)
 
     # A second approval_requested event should have been emitted
-    approval_events_after = [e for e in events if e.kind == DomainEventKind.approval_requested]
+    approval_events_after = [e for e in events if e.kind == CPEventKind.approval_requested]
     assert len(approval_events_after) >= 2
 
     # Now approve the second plan
@@ -445,7 +445,7 @@ async def test_plan_mode_max_rejections_fails_job(
     # Reject 6 times (limit is 5)
     for i in range(6):
         await _wait_for_state(session_factory, job.id, JobState.waiting_for_approval, timeout=10.0)
-        approval_events = [e for e in events if e.kind == DomainEventKind.approval_requested]
+        approval_events = [e for e in events if e.kind == CPEventKind.approval_requested]
         latest_approval_id = approval_events[-1].payload["approval_id"]
         await runtime._approval_service.resolve(latest_approval_id, ApprovalResolution.rejected)
 

--- a/backend/tests/unit/test_redteam_persistence.py
+++ b/backend/tests/unit/test_redteam_persistence.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 from backend.models.db import Base
 from backend.models.domain import Artifact, Job, JobNotFoundError, JobState
-from backend.models.events import CPEventKind, new_event
+from backend.models.events import EventKind, new_event
 from backend.persistence.artifact_repo import ArtifactRepository
 from backend.persistence.database import _set_sqlite_pragmas
 from backend.persistence.event_repo import EventRepository
@@ -131,7 +131,7 @@ class TestSQLInjection:
             event_id="evt-1",
             session_id="job-1",
             timestamp=now,
-            kind=CPEventKind.log_line_emitted,
+            kind=EventKind.log_line_emitted,
             payload=evil_payload,
         )
         await event_repo.append(event)
@@ -151,7 +151,7 @@ class TestFKViolations:
         event_repo = EventRepository(session)
         now = datetime.now(UTC)
         event = new_event(
-            event_id="evt-1", session_id="nonexistent-job", timestamp=now, kind=CPEventKind.job_created, payload={}
+            event_id="evt-1", session_id="nonexistent-job", timestamp=now, kind=EventKind.job_created, payload={}
         )
         # flush() inside append() triggers the FK check
         with pytest.raises(IntegrityError):
@@ -200,14 +200,14 @@ class TestDuplicatePKs:
         now = datetime.now(UTC)
         await event_repo.append(
             new_event(
-                event_id="evt-dup", session_id="job-1", timestamp=now, kind=CPEventKind.job_created, payload={}
+                event_id="evt-dup", session_id="job-1", timestamp=now, kind=EventKind.job_created, payload={}
             )
         )
         await session.flush()
         with pytest.raises(IntegrityError):
             await event_repo.append(
                 new_event(
-                    event_id="evt-dup", session_id="job-1", timestamp=now, kind=CPEventKind.job_created, payload={}
+                    event_id="evt-dup", session_id="job-1", timestamp=now, kind=EventKind.job_created, payload={}
                 )
             )
             await session.flush()
@@ -452,7 +452,7 @@ class TestPaginationEdgeCases:
         event_repo = EventRepository(session)
         now = datetime.now(UTC)
         await event_repo.append(
-            new_event(event_id="evt-1", session_id="job-1", timestamp=now, kind=CPEventKind.job_created, payload={})
+            new_event(event_id="evt-1", session_id="job-1", timestamp=now, kind=EventKind.job_created, payload={})
         )
         await session.commit()
 
@@ -469,7 +469,7 @@ class TestPaginationEdgeCases:
         event_repo = EventRepository(session)
         now = datetime.now(UTC)
         await event_repo.append(
-            new_event(event_id="evt-1", session_id="job-1", timestamp=now, kind=CPEventKind.job_created, payload={})
+            new_event(event_id="evt-1", session_id="job-1", timestamp=now, kind=EventKind.job_created, payload={})
         )
         await session.commit()
 
@@ -535,7 +535,7 @@ class TestEventPayloadEdgeCases:
         event_repo = EventRepository(session)
         now = datetime.now(UTC)
         await event_repo.append(
-            new_event(event_id="evt-1", session_id="job-1", timestamp=now, kind=CPEventKind.job_created, payload={})
+            new_event(event_id="evt-1", session_id="job-1", timestamp=now, kind=EventKind.job_created, payload={})
         )
         await session.commit()
         events = await event_repo.list_after(0)
@@ -558,7 +558,7 @@ class TestEventPayloadEdgeCases:
         now = datetime.now(UTC)
         await event_repo.append(
             new_event(
-                event_id="evt-1", session_id="job-1", timestamp=now, kind=CPEventKind.job_created, payload=deep
+                event_id="evt-1", session_id="job-1", timestamp=now, kind=EventKind.job_created, payload=deep
             )
         )
         await session.commit()
@@ -584,7 +584,7 @@ class TestEventPayloadEdgeCases:
         now = datetime.now(UTC)
         await event_repo.append(
             new_event(
-                event_id="evt-1", session_id="job-1", timestamp=now, kind=CPEventKind.job_created, payload=payload
+                event_id="evt-1", session_id="job-1", timestamp=now, kind=EventKind.job_created, payload=payload
             )
         )
         await session.commit()

--- a/backend/tests/unit/test_redteam_persistence.py
+++ b/backend/tests/unit/test_redteam_persistence.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 from backend.models.db import Base
 from backend.models.domain import Artifact, Job, JobNotFoundError, JobState
-from backend.models.events import DomainEventKind, new_event
+from backend.models.events import CPEventKind, new_event
 from backend.persistence.artifact_repo import ArtifactRepository
 from backend.persistence.database import _set_sqlite_pragmas
 from backend.persistence.event_repo import EventRepository
@@ -131,7 +131,7 @@ class TestSQLInjection:
             event_id="evt-1",
             session_id="job-1",
             timestamp=now,
-            kind=DomainEventKind.log_line_emitted,
+            kind=CPEventKind.log_line_emitted,
             payload=evil_payload,
         )
         await event_repo.append(event)
@@ -151,7 +151,7 @@ class TestFKViolations:
         event_repo = EventRepository(session)
         now = datetime.now(UTC)
         event = new_event(
-            event_id="evt-1", session_id="nonexistent-job", timestamp=now, kind=DomainEventKind.job_created, payload={}
+            event_id="evt-1", session_id="nonexistent-job", timestamp=now, kind=CPEventKind.job_created, payload={}
         )
         # flush() inside append() triggers the FK check
         with pytest.raises(IntegrityError):
@@ -200,14 +200,14 @@ class TestDuplicatePKs:
         now = datetime.now(UTC)
         await event_repo.append(
             new_event(
-                event_id="evt-dup", session_id="job-1", timestamp=now, kind=DomainEventKind.job_created, payload={}
+                event_id="evt-dup", session_id="job-1", timestamp=now, kind=CPEventKind.job_created, payload={}
             )
         )
         await session.flush()
         with pytest.raises(IntegrityError):
             await event_repo.append(
                 new_event(
-                    event_id="evt-dup", session_id="job-1", timestamp=now, kind=DomainEventKind.job_created, payload={}
+                    event_id="evt-dup", session_id="job-1", timestamp=now, kind=CPEventKind.job_created, payload={}
                 )
             )
             await session.flush()
@@ -452,7 +452,7 @@ class TestPaginationEdgeCases:
         event_repo = EventRepository(session)
         now = datetime.now(UTC)
         await event_repo.append(
-            new_event(event_id="evt-1", session_id="job-1", timestamp=now, kind=DomainEventKind.job_created, payload={})
+            new_event(event_id="evt-1", session_id="job-1", timestamp=now, kind=CPEventKind.job_created, payload={})
         )
         await session.commit()
 
@@ -469,7 +469,7 @@ class TestPaginationEdgeCases:
         event_repo = EventRepository(session)
         now = datetime.now(UTC)
         await event_repo.append(
-            new_event(event_id="evt-1", session_id="job-1", timestamp=now, kind=DomainEventKind.job_created, payload={})
+            new_event(event_id="evt-1", session_id="job-1", timestamp=now, kind=CPEventKind.job_created, payload={})
         )
         await session.commit()
 
@@ -535,7 +535,7 @@ class TestEventPayloadEdgeCases:
         event_repo = EventRepository(session)
         now = datetime.now(UTC)
         await event_repo.append(
-            new_event(event_id="evt-1", session_id="job-1", timestamp=now, kind=DomainEventKind.job_created, payload={})
+            new_event(event_id="evt-1", session_id="job-1", timestamp=now, kind=CPEventKind.job_created, payload={})
         )
         await session.commit()
         events = await event_repo.list_after(0)
@@ -558,7 +558,7 @@ class TestEventPayloadEdgeCases:
         now = datetime.now(UTC)
         await event_repo.append(
             new_event(
-                event_id="evt-1", session_id="job-1", timestamp=now, kind=DomainEventKind.job_created, payload=deep
+                event_id="evt-1", session_id="job-1", timestamp=now, kind=CPEventKind.job_created, payload=deep
             )
         )
         await session.commit()
@@ -584,7 +584,7 @@ class TestEventPayloadEdgeCases:
         now = datetime.now(UTC)
         await event_repo.append(
             new_event(
-                event_id="evt-1", session_id="job-1", timestamp=now, kind=DomainEventKind.job_created, payload=payload
+                event_id="evt-1", session_id="job-1", timestamp=now, kind=CPEventKind.job_created, payload=payload
             )
         )
         await session.commit()

--- a/backend/tests/unit/test_redteam_persistence.py
+++ b/backend/tests/unit/test_redteam_persistence.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 from backend.models.db import Base
 from backend.models.domain import Artifact, Job, JobNotFoundError, JobState
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, new_event
 from backend.persistence.artifact_repo import ArtifactRepository
 from backend.persistence.database import _set_sqlite_pragmas
 from backend.persistence.event_repo import EventRepository
@@ -127,9 +127,9 @@ class TestSQLInjection:
         event_repo = EventRepository(session)
         now = datetime.now(UTC)
         evil_payload = {"key": "'; DROP TABLE events; --", "nested": {"sql": "1=1"}}
-        event = DomainEvent(
+        event = new_event(
             event_id="evt-1",
-            job_id="job-1",
+            session_id="job-1",
             timestamp=now,
             kind=DomainEventKind.log_line_emitted,
             payload=evil_payload,
@@ -150,12 +150,8 @@ class TestFKViolations:
     async def test_event_for_nonexistent_job_fails(self, session: AsyncSession) -> None:
         event_repo = EventRepository(session)
         now = datetime.now(UTC)
-        event = DomainEvent(
-            event_id="evt-1",
-            job_id="nonexistent-job",
-            timestamp=now,
-            kind=DomainEventKind.job_created,
-            payload={},
+        event = new_event(
+            event_id="evt-1", session_id="nonexistent-job", timestamp=now, kind=DomainEventKind.job_created, payload={}
         )
         # flush() inside append() triggers the FK check
         with pytest.raises(IntegrityError):
@@ -203,13 +199,15 @@ class TestDuplicatePKs:
         event_repo = EventRepository(session)
         now = datetime.now(UTC)
         await event_repo.append(
-            DomainEvent(event_id="evt-dup", job_id="job-1", timestamp=now, kind=DomainEventKind.job_created, payload={})
+            new_event(
+                event_id="evt-dup", session_id="job-1", timestamp=now, kind=DomainEventKind.job_created, payload={}
+            )
         )
         await session.flush()
         with pytest.raises(IntegrityError):
             await event_repo.append(
-                DomainEvent(
-                    event_id="evt-dup", job_id="job-1", timestamp=now, kind=DomainEventKind.job_created, payload={}
+                new_event(
+                    event_id="evt-dup", session_id="job-1", timestamp=now, kind=DomainEventKind.job_created, payload={}
                 )
             )
             await session.flush()
@@ -454,7 +452,7 @@ class TestPaginationEdgeCases:
         event_repo = EventRepository(session)
         now = datetime.now(UTC)
         await event_repo.append(
-            DomainEvent(event_id="evt-1", job_id="job-1", timestamp=now, kind=DomainEventKind.job_created, payload={})
+            new_event(event_id="evt-1", session_id="job-1", timestamp=now, kind=DomainEventKind.job_created, payload={})
         )
         await session.commit()
 
@@ -471,7 +469,7 @@ class TestPaginationEdgeCases:
         event_repo = EventRepository(session)
         now = datetime.now(UTC)
         await event_repo.append(
-            DomainEvent(event_id="evt-1", job_id="job-1", timestamp=now, kind=DomainEventKind.job_created, payload={})
+            new_event(event_id="evt-1", session_id="job-1", timestamp=now, kind=DomainEventKind.job_created, payload={})
         )
         await session.commit()
 
@@ -537,7 +535,7 @@ class TestEventPayloadEdgeCases:
         event_repo = EventRepository(session)
         now = datetime.now(UTC)
         await event_repo.append(
-            DomainEvent(event_id="evt-1", job_id="job-1", timestamp=now, kind=DomainEventKind.job_created, payload={})
+            new_event(event_id="evt-1", session_id="job-1", timestamp=now, kind=DomainEventKind.job_created, payload={})
         )
         await session.commit()
         events = await event_repo.list_after(0)
@@ -559,7 +557,9 @@ class TestEventPayloadEdgeCases:
         event_repo = EventRepository(session)
         now = datetime.now(UTC)
         await event_repo.append(
-            DomainEvent(event_id="evt-1", job_id="job-1", timestamp=now, kind=DomainEventKind.job_created, payload=deep)
+            new_event(
+                event_id="evt-1", session_id="job-1", timestamp=now, kind=DomainEventKind.job_created, payload=deep
+            )
         )
         await session.commit()
         events = await event_repo.list_after(0)
@@ -583,8 +583,8 @@ class TestEventPayloadEdgeCases:
         event_repo = EventRepository(session)
         now = datetime.now(UTC)
         await event_repo.append(
-            DomainEvent(
-                event_id="evt-1", job_id="job-1", timestamp=now, kind=DomainEventKind.job_created, payload=payload
+            new_event(
+                event_id="evt-1", session_id="job-1", timestamp=now, kind=DomainEventKind.job_created, payload=payload
             )
         )
         await session.commit()

--- a/backend/tests/unit/test_repositories.py
+++ b/backend/tests/unit/test_repositories.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 from backend.models.db import Base
 from backend.models.domain import Artifact
-from backend.models.events import DomainEventKind, new_event
+from backend.models.events import CPEventKind, new_event
 from backend.persistence.artifact_repo import ArtifactRepository
 from backend.persistence.database import _set_sqlite_pragmas
 from backend.persistence.event_repo import EventRepository
@@ -155,7 +155,7 @@ async def test_event_append_and_list(session: AsyncSession) -> None:
         event_id="evt-1",
         session_id="job-1",
         timestamp=now,
-        kind=DomainEventKind.job_created,
+        kind=CPEventKind.job_created,
         payload={"repo": "/repos/test"},
     )
     await event_repo.append(event)
@@ -164,7 +164,7 @@ async def test_event_append_and_list(session: AsyncSession) -> None:
     events = await event_repo.list_after(0)
     assert len(events) == 1
     assert events[0].id == "evt-1"
-    assert events[0].kind == DomainEventKind.job_created
+    assert events[0].kind == CPEventKind.job_created
     assert events[0].payload == {"repo": "/repos/test"}
 
 
@@ -182,7 +182,7 @@ async def test_event_list_after_filters_by_id(session: AsyncSession) -> None:
                 event_id=f"evt-{i}",
                 session_id="job-1",
                 timestamp=now,
-                kind=DomainEventKind.log_line_emitted,
+                kind=CPEventKind.log_line_emitted,
                 payload={"seq": i},
             )
         )
@@ -203,10 +203,10 @@ async def test_event_list_after_scoped_to_job(session: AsyncSession) -> None:
     event_repo = EventRepository(session)
     now = datetime.now(UTC)
     await event_repo.append(
-        new_event(event_id="evt-1", session_id="job-1", timestamp=now, kind=DomainEventKind.job_created, payload={})
+        new_event(event_id="evt-1", session_id="job-1", timestamp=now, kind=CPEventKind.job_created, payload={})
     )
     await event_repo.append(
-        new_event(event_id="evt-2", session_id="job-2", timestamp=now, kind=DomainEventKind.job_created, payload={})
+        new_event(event_id="evt-2", session_id="job-2", timestamp=now, kind=CPEventKind.job_created, payload={})
     )
     await session.commit()
 

--- a/backend/tests/unit/test_repositories.py
+++ b/backend/tests/unit/test_repositories.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 from backend.models.db import Base
 from backend.models.domain import Artifact
-from backend.models.events import CPEventKind, new_event
+from backend.models.events import EventKind, new_event
 from backend.persistence.artifact_repo import ArtifactRepository
 from backend.persistence.database import _set_sqlite_pragmas
 from backend.persistence.event_repo import EventRepository
@@ -155,7 +155,7 @@ async def test_event_append_and_list(session: AsyncSession) -> None:
         event_id="evt-1",
         session_id="job-1",
         timestamp=now,
-        kind=CPEventKind.job_created,
+        kind=EventKind.job_created,
         payload={"repo": "/repos/test"},
     )
     await event_repo.append(event)
@@ -164,7 +164,7 @@ async def test_event_append_and_list(session: AsyncSession) -> None:
     events = await event_repo.list_after(0)
     assert len(events) == 1
     assert events[0].id == "evt-1"
-    assert events[0].kind == CPEventKind.job_created
+    assert events[0].kind == EventKind.job_created
     assert events[0].payload == {"repo": "/repos/test"}
 
 
@@ -182,7 +182,7 @@ async def test_event_list_after_filters_by_id(session: AsyncSession) -> None:
                 event_id=f"evt-{i}",
                 session_id="job-1",
                 timestamp=now,
-                kind=CPEventKind.log_line_emitted,
+                kind=EventKind.log_line_emitted,
                 payload={"seq": i},
             )
         )
@@ -203,10 +203,10 @@ async def test_event_list_after_scoped_to_job(session: AsyncSession) -> None:
     event_repo = EventRepository(session)
     now = datetime.now(UTC)
     await event_repo.append(
-        new_event(event_id="evt-1", session_id="job-1", timestamp=now, kind=CPEventKind.job_created, payload={})
+        new_event(event_id="evt-1", session_id="job-1", timestamp=now, kind=EventKind.job_created, payload={})
     )
     await event_repo.append(
-        new_event(event_id="evt-2", session_id="job-2", timestamp=now, kind=CPEventKind.job_created, payload={})
+        new_event(event_id="evt-2", session_id="job-2", timestamp=now, kind=EventKind.job_created, payload={})
     )
     await session.commit()
 

--- a/backend/tests/unit/test_repositories.py
+++ b/backend/tests/unit/test_repositories.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 from backend.models.db import Base
 from backend.models.domain import Artifact
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, new_event
 from backend.persistence.artifact_repo import ArtifactRepository
 from backend.persistence.database import _set_sqlite_pragmas
 from backend.persistence.event_repo import EventRepository
@@ -151,9 +151,9 @@ async def test_event_append_and_list(session: AsyncSession) -> None:
 
     event_repo = EventRepository(session)
     now = datetime.now(UTC)
-    event = DomainEvent(
+    event = new_event(
         event_id="evt-1",
-        job_id="job-1",
+        session_id="job-1",
         timestamp=now,
         kind=DomainEventKind.job_created,
         payload={"repo": "/repos/test"},
@@ -163,7 +163,7 @@ async def test_event_append_and_list(session: AsyncSession) -> None:
 
     events = await event_repo.list_after(0)
     assert len(events) == 1
-    assert events[0].event_id == "evt-1"
+    assert events[0].id == "evt-1"
     assert events[0].kind == DomainEventKind.job_created
     assert events[0].payload == {"repo": "/repos/test"}
 
@@ -178,9 +178,9 @@ async def test_event_list_after_filters_by_id(session: AsyncSession) -> None:
     now = datetime.now(UTC)
     for i in range(5):
         await event_repo.append(
-            DomainEvent(
+            new_event(
                 event_id=f"evt-{i}",
-                job_id="job-1",
+                session_id="job-1",
                 timestamp=now,
                 kind=DomainEventKind.log_line_emitted,
                 payload={"seq": i},
@@ -203,16 +203,16 @@ async def test_event_list_after_scoped_to_job(session: AsyncSession) -> None:
     event_repo = EventRepository(session)
     now = datetime.now(UTC)
     await event_repo.append(
-        DomainEvent(event_id="evt-1", job_id="job-1", timestamp=now, kind=DomainEventKind.job_created, payload={})
+        new_event(event_id="evt-1", session_id="job-1", timestamp=now, kind=DomainEventKind.job_created, payload={})
     )
     await event_repo.append(
-        DomainEvent(event_id="evt-2", job_id="job-2", timestamp=now, kind=DomainEventKind.job_created, payload={})
+        new_event(event_id="evt-2", session_id="job-2", timestamp=now, kind=DomainEventKind.job_created, payload={})
     )
     await session.commit()
 
     events = await event_repo.list_after(0, job_id="job-1")
     assert len(events) == 1
-    assert events[0].job_id == "job-1"
+    assert events[0].session_id == "job-1"
 
 
 # --- ArtifactRepository tests ---

--- a/backend/tests/unit/test_runtime_service.py
+++ b/backend/tests/unit/test_runtime_service.py
@@ -40,7 +40,7 @@ from backend.models.domain import (
     SessionEventKind,
     StateConflictError,
 )
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind
 from backend.persistence.database import _set_sqlite_pragmas
 from backend.services.adapters.adapter_registry import AdapterRegistry
 from backend.services.adapters.agent_adapter import AgentAdapterInterface, CompletionResult
@@ -449,7 +449,7 @@ class TestEventTranslation:
         result = runtime._translate_event("job-1", event)
         assert result is not None
         assert result.kind == DomainEventKind.log_line_emitted
-        assert result.job_id == "job-1"
+        assert result.session_id == "job-1"
 
     def test_transcript_event_translated(self, runtime: RuntimeService) -> None:
         event = SessionEvent(
@@ -506,9 +506,9 @@ class TestJobLifecycle:
         session_factory: async_sessionmaker[AsyncSession],
         config: CPLConfig,
     ) -> None:
-        published: list[DomainEvent] = []
+        published: list[SessionEvent] = []
 
-        async def _collect(e: DomainEvent) -> None:
+        async def _collect(e: SessionEvent) -> None:
             published.append(e)
 
         event_bus.subscribe(_collect)
@@ -602,9 +602,9 @@ class TestJobLifecycle:
         config: CPLConfig,
     ) -> None:
         """send_message on a job with no live session but a terminal DB state auto-resumes it."""
-        published: list[DomainEvent] = []
+        published: list[SessionEvent] = []
 
-        async def _collect(e: DomainEvent) -> None:
+        async def _collect(e: SessionEvent) -> None:
             published.append(e)
 
         event_bus.subscribe(_collect)
@@ -636,9 +636,9 @@ class TestJobLifecycle:
         config: CPLConfig,
     ) -> None:
         """send_message on a job in 'running' state with no live session recovers it in place."""
-        published: list[DomainEvent] = []
+        published: list[SessionEvent] = []
 
-        async def _collect(e: DomainEvent) -> None:
+        async def _collect(e: SessionEvent) -> None:
             published.append(e)
 
         event_bus.subscribe(_collect)
@@ -773,9 +773,9 @@ class TestResumeFallback:
             merge_service=merge_service,
         )
 
-        published: list[DomainEvent] = []
+        published: list[SessionEvent] = []
 
-        async def _collect(event: DomainEvent) -> None:
+        async def _collect(event: SessionEvent) -> None:
             published.append(event)
 
         event_bus.subscribe(_collect)
@@ -828,9 +828,9 @@ class TestResumeFallback:
             config=config,
         )
 
-        published: list[DomainEvent] = []
+        published: list[SessionEvent] = []
 
-        async def _collect(event: DomainEvent) -> None:
+        async def _collect(event: SessionEvent) -> None:
             published.append(event)
 
         event_bus.subscribe(_collect)
@@ -1101,9 +1101,9 @@ class TestRecovery:
         session_factory: async_sessionmaker[AsyncSession],
         config: CPLConfig,
     ) -> None:
-        published: list[DomainEvent] = []
+        published: list[SessionEvent] = []
 
-        async def _collect(e: DomainEvent) -> None:
+        async def _collect(e: SessionEvent) -> None:
             published.append(e)
 
         event_bus.subscribe(_collect)
@@ -1138,7 +1138,7 @@ class TestRecovery:
     ) -> None:
         observed_states: list[str] = []
 
-        async def _assert_running_state_visible(event: DomainEvent) -> None:
+        async def _assert_running_state_visible(event: SessionEvent) -> None:
             if event.kind != DomainEventKind.session_resumed:
                 return
             async with session_factory() as session:
@@ -1550,9 +1550,9 @@ class TestJobStateChangedEvent:
         config: CPLConfig,
     ) -> None:
         """_publish_state_event should use job_state_changed, not job_created."""
-        published: list[DomainEvent] = []
+        published: list[SessionEvent] = []
 
-        async def _collect(e: DomainEvent) -> None:
+        async def _collect(e: SessionEvent) -> None:
             published.append(e)
 
         event_bus.subscribe(_collect)
@@ -1568,17 +1568,6 @@ class TestJobStateChangedEvent:
         # Should NOT have published any job_created events
         created_events = [e for e in published if e.kind == DomainEventKind.job_created]
         assert len(created_events) == 0
-
-
-class TestMakeEventId:
-    def test_format(self) -> None:
-        eid = DomainEvent.make_event_id()
-        assert eid.startswith("evt-")
-        assert len(eid) == 16  # "evt-" + 12 hex chars
-
-    def test_unique(self) -> None:
-        ids = {DomainEvent.make_event_id() for _ in range(100)}
-        assert len(ids) == 100
 
 
 # ---------------------------------------------------------------------------
@@ -1628,9 +1617,9 @@ class TestErrorEventCausesFailure:
             config=config,
         )
 
-        published: list[DomainEvent] = []
+        published: list[SessionEvent] = []
 
-        async def _collect(e: DomainEvent) -> None:
+        async def _collect(e: SessionEvent) -> None:
             published.append(e)
 
         event_bus.subscribe(_collect)

--- a/backend/tests/unit/test_runtime_service.py
+++ b/backend/tests/unit/test_runtime_service.py
@@ -40,7 +40,7 @@ from backend.models.domain import (
     SessionEventKind,
     StateConflictError,
 )
-from backend.models.events import DomainEventKind
+from backend.models.events import TRANSCRIPT_KINDS, CPEventKind
 from backend.persistence.database import _set_sqlite_pragmas
 from backend.services.adapters.adapter_registry import AdapterRegistry
 from backend.services.adapters.agent_adapter import AgentAdapterInterface, CompletionResult
@@ -448,7 +448,7 @@ class TestEventTranslation:
         )
         result = runtime._translate_event("job-1", event)
         assert result is not None
-        assert result.kind == DomainEventKind.log_line_emitted
+        assert result.kind == CPEventKind.log_line_emitted
         assert result.session_id == "job-1"
 
     def test_transcript_event_translated(self, runtime: RuntimeService) -> None:
@@ -458,7 +458,7 @@ class TestEventTranslation:
         )
         result = runtime._translate_event("job-1", event)
         assert result is not None
-        assert result.kind == DomainEventKind.transcript_updated
+        assert result.kind == CPEventKind.message_assistant
 
     def test_file_changed_not_translated(self, runtime: RuntimeService) -> None:
         """file_changed events are handled by DiffService, not _translate_event."""
@@ -476,7 +476,7 @@ class TestEventTranslation:
         )
         result = runtime._translate_event("job-1", event)
         assert result is not None
-        assert result.kind == DomainEventKind.approval_requested
+        assert result.kind == CPEventKind.approval_requested
 
     def test_error_event_translated(self, runtime: RuntimeService) -> None:
         event = SessionEvent(
@@ -485,7 +485,7 @@ class TestEventTranslation:
         )
         result = runtime._translate_event("job-1", event)
         assert result is not None
-        assert result.kind == DomainEventKind.job_failed
+        assert result.kind == CPEventKind.job_failed
 
     def test_done_event_returns_none(self, runtime: RuntimeService) -> None:
         event = SessionEvent(kind=SessionEventKind.done, payload={})
@@ -518,16 +518,16 @@ class TestJobLifecycle:
 
         await runtime.start_or_enqueue(job)
         await _wait_until(
-            lambda: any(e.kind == DomainEventKind.job_review for e in published),
+            lambda: any(e.kind == CPEventKind.job_review for e in published),
             msg="job_review event not published",
         )
 
         # Should have log, transcript events + job_review
         # (diff_updated events now come from DiffService which requires a real git worktree)
         kinds = [e.kind for e in published]
-        assert DomainEventKind.log_line_emitted in kinds
-        assert DomainEventKind.transcript_updated in kinds
-        assert DomainEventKind.job_review in kinds
+        assert CPEventKind.log_line_emitted in kinds
+        assert any(k in TRANSCRIPT_KINDS for k in kinds)
+        assert CPEventKind.job_review in kinds
 
     async def test_cancel_running_job(
         self, runtime: RuntimeService, session_factory: async_sessionmaker[AsyncSession], config: CPLConfig
@@ -621,10 +621,10 @@ class TestJobLifecycle:
 
         # The auto-resume should have published a session_resumed event
         kinds = [e.kind for e in published]
-        assert DomainEventKind.session_resumed in kinds
+        assert CPEventKind.session_resumed in kinds
 
         # The operator message should appear as a transcript entry
-        transcript_events = [e for e in published if e.kind == DomainEventKind.transcript_updated]
+        transcript_events = [e for e in published if e.kind in TRANSCRIPT_KINDS]
         operator_msgs = [e for e in transcript_events if e.payload.get("role") == "operator"]
         assert any("please continue" in e.payload.get("content", "") for e in operator_msgs)
 
@@ -652,14 +652,14 @@ class TestJobLifecycle:
 
         # Wait for the resumed task to finish
         await _wait_until(
-            lambda: any(e.kind == DomainEventKind.session_resumed for e in published),
+            lambda: any(e.kind == CPEventKind.session_resumed for e in published),
             msg="session_resumed event not published",
         )
         await _wait_until(lambda: runtime.running_count == 0, msg="resumed job did not finish")
 
         kinds = [e.kind for e in published]
-        assert DomainEventKind.job_failed not in kinds
-        assert DomainEventKind.session_resumed in kinds
+        assert CPEventKind.job_failed not in kinds
+        assert CPEventKind.session_resumed in kinds
 
         # DB should end in review/failed/canceled after the resumed run
         async with session_factory() as session:
@@ -791,7 +791,7 @@ class TestResumeFallback:
         assert resumed.state == JobState.running
 
         await _wait_until(
-            lambda: any(e.kind == DomainEventKind.job_completed for e in published),
+            lambda: any(e.kind == CPEventKind.job_completed for e in published),
             msg="job_completed event not published",
         )
 
@@ -807,7 +807,7 @@ class TestResumeFallback:
             assert row.resolution == Resolution.merged
             assert row.merge_status == Resolution.merged
 
-        completed_events = [event for event in published if event.kind == DomainEventKind.job_completed]
+        completed_events = [event for event in published if event.kind == CPEventKind.job_completed]
         assert completed_events
         assert completed_events[-1].payload["resolution"] == Resolution.merged
         assert completed_events[-1].payload["merge_status"] == Resolution.merged
@@ -1113,7 +1113,7 @@ class TestRecovery:
 
         await runtime.recover_on_startup()
         await _wait_until(
-            lambda: any(e.kind == DomainEventKind.job_review for e in published),
+            lambda: any(e.kind == CPEventKind.job_review for e in published),
             msg="job_review event not published after recovery",
         )
 
@@ -1125,7 +1125,7 @@ class TestRecovery:
             assert row is not None
             assert row.state == JobState.review
 
-        resumed_events = [e for e in published if e.kind == DomainEventKind.session_resumed]
+        resumed_events = [e for e in published if e.kind == CPEventKind.session_resumed]
         assert len(resumed_events) == 1
         assert resumed_events[0].payload["reason"] == "process_restarted"
 
@@ -1139,7 +1139,7 @@ class TestRecovery:
         observed_states: list[str] = []
 
         async def _assert_running_state_visible(event: SessionEvent) -> None:
-            if event.kind != DomainEventKind.session_resumed:
+            if event.kind != CPEventKind.session_resumed:
                 return
             async with session_factory() as session:
                 from backend.persistence.job_repo import JobRepository
@@ -1563,10 +1563,10 @@ class TestJobStateChangedEvent:
         await runtime.start_or_enqueue(job)
         await asyncio.sleep(0.5)
 
-        state_change_events = [e for e in published if e.kind == DomainEventKind.job_state_changed]
+        state_change_events = [e for e in published if e.kind == CPEventKind.job_state_changed]
         assert len(state_change_events) >= 1
         # Should NOT have published any job_created events
-        created_events = [e for e in published if e.kind == DomainEventKind.job_created]
+        created_events = [e for e in published if e.kind == CPEventKind.job_created]
         assert len(created_events) == 0
 
 
@@ -1629,14 +1629,14 @@ class TestErrorEventCausesFailure:
 
         await runtime.start_or_enqueue(job)
         await _wait_until(
-            lambda: any(e.kind == DomainEventKind.job_failed for e in published),
+            lambda: any(e.kind == CPEventKind.job_failed for e in published),
             msg="job_failed event not published",
         )
 
         # Should have a job_failed event, NOT job_review
         kinds = [e.kind for e in published]
-        assert DomainEventKind.job_failed in kinds
-        assert DomainEventKind.job_review not in kinds
+        assert CPEventKind.job_failed in kinds
+        assert CPEventKind.job_review not in kinds
 
         # DB state should be failed
         from backend.models.db import JobRow

--- a/backend/tests/unit/test_runtime_service.py
+++ b/backend/tests/unit/test_runtime_service.py
@@ -40,7 +40,7 @@ from backend.models.domain import (
     SessionEventKind,
     StateConflictError,
 )
-from backend.models.events import TRANSCRIPT_KINDS, CPEventKind
+from backend.models.events import TRANSCRIPT_KINDS, EventKind
 from backend.persistence.database import _set_sqlite_pragmas
 from backend.services.adapters.adapter_registry import AdapterRegistry
 from backend.services.adapters.agent_adapter import AgentAdapterInterface, CompletionResult
@@ -448,7 +448,7 @@ class TestEventTranslation:
         )
         result = runtime._translate_event("job-1", event)
         assert result is not None
-        assert result.kind == CPEventKind.log_line_emitted
+        assert result.kind == EventKind.log_line_emitted
         assert result.session_id == "job-1"
 
     def test_transcript_event_translated(self, runtime: RuntimeService) -> None:
@@ -458,7 +458,7 @@ class TestEventTranslation:
         )
         result = runtime._translate_event("job-1", event)
         assert result is not None
-        assert result.kind == CPEventKind.message_assistant
+        assert result.kind == EventKind.message_assistant
 
     def test_file_changed_not_translated(self, runtime: RuntimeService) -> None:
         """file_changed events are handled by DiffService, not _translate_event."""
@@ -476,7 +476,7 @@ class TestEventTranslation:
         )
         result = runtime._translate_event("job-1", event)
         assert result is not None
-        assert result.kind == CPEventKind.approval_requested
+        assert result.kind == EventKind.approval_requested
 
     def test_error_event_translated(self, runtime: RuntimeService) -> None:
         event = SessionEvent(
@@ -485,7 +485,7 @@ class TestEventTranslation:
         )
         result = runtime._translate_event("job-1", event)
         assert result is not None
-        assert result.kind == CPEventKind.job_failed
+        assert result.kind == EventKind.job_failed
 
     def test_done_event_returns_none(self, runtime: RuntimeService) -> None:
         event = SessionEvent(kind=SessionEventKind.done, payload={})
@@ -518,16 +518,16 @@ class TestJobLifecycle:
 
         await runtime.start_or_enqueue(job)
         await _wait_until(
-            lambda: any(e.kind == CPEventKind.job_review for e in published),
+            lambda: any(e.kind == EventKind.job_review for e in published),
             msg="job_review event not published",
         )
 
         # Should have log, transcript events + job_review
         # (diff_updated events now come from DiffService which requires a real git worktree)
         kinds = [e.kind for e in published]
-        assert CPEventKind.log_line_emitted in kinds
+        assert EventKind.log_line_emitted in kinds
         assert any(k in TRANSCRIPT_KINDS for k in kinds)
-        assert CPEventKind.job_review in kinds
+        assert EventKind.job_review in kinds
 
     async def test_cancel_running_job(
         self, runtime: RuntimeService, session_factory: async_sessionmaker[AsyncSession], config: CPLConfig
@@ -621,7 +621,7 @@ class TestJobLifecycle:
 
         # The auto-resume should have published a session_resumed event
         kinds = [e.kind for e in published]
-        assert CPEventKind.session_resumed in kinds
+        assert EventKind.session_resumed in kinds
 
         # The operator message should appear as a transcript entry
         transcript_events = [e for e in published if e.kind in TRANSCRIPT_KINDS]
@@ -652,14 +652,14 @@ class TestJobLifecycle:
 
         # Wait for the resumed task to finish
         await _wait_until(
-            lambda: any(e.kind == CPEventKind.session_resumed for e in published),
+            lambda: any(e.kind == EventKind.session_resumed for e in published),
             msg="session_resumed event not published",
         )
         await _wait_until(lambda: runtime.running_count == 0, msg="resumed job did not finish")
 
         kinds = [e.kind for e in published]
-        assert CPEventKind.job_failed not in kinds
-        assert CPEventKind.session_resumed in kinds
+        assert EventKind.job_failed not in kinds
+        assert EventKind.session_resumed in kinds
 
         # DB should end in review/failed/canceled after the resumed run
         async with session_factory() as session:
@@ -791,7 +791,7 @@ class TestResumeFallback:
         assert resumed.state == JobState.running
 
         await _wait_until(
-            lambda: any(e.kind == CPEventKind.job_completed for e in published),
+            lambda: any(e.kind == EventKind.job_completed for e in published),
             msg="job_completed event not published",
         )
 
@@ -807,7 +807,7 @@ class TestResumeFallback:
             assert row.resolution == Resolution.merged
             assert row.merge_status == Resolution.merged
 
-        completed_events = [event for event in published if event.kind == CPEventKind.job_completed]
+        completed_events = [event for event in published if event.kind == EventKind.job_completed]
         assert completed_events
         assert completed_events[-1].payload["resolution"] == Resolution.merged
         assert completed_events[-1].payload["merge_status"] == Resolution.merged
@@ -1113,7 +1113,7 @@ class TestRecovery:
 
         await runtime.recover_on_startup()
         await _wait_until(
-            lambda: any(e.kind == CPEventKind.job_review for e in published),
+            lambda: any(e.kind == EventKind.job_review for e in published),
             msg="job_review event not published after recovery",
         )
 
@@ -1125,7 +1125,7 @@ class TestRecovery:
             assert row is not None
             assert row.state == JobState.review
 
-        resumed_events = [e for e in published if e.kind == CPEventKind.session_resumed]
+        resumed_events = [e for e in published if e.kind == EventKind.session_resumed]
         assert len(resumed_events) == 1
         assert resumed_events[0].payload["reason"] == "process_restarted"
 
@@ -1139,7 +1139,7 @@ class TestRecovery:
         observed_states: list[str] = []
 
         async def _assert_running_state_visible(event: SessionEvent) -> None:
-            if event.kind != CPEventKind.session_resumed:
+            if event.kind != EventKind.session_resumed:
                 return
             async with session_factory() as session:
                 from backend.persistence.job_repo import JobRepository
@@ -1563,10 +1563,10 @@ class TestJobStateChangedEvent:
         await runtime.start_or_enqueue(job)
         await asyncio.sleep(0.5)
 
-        state_change_events = [e for e in published if e.kind == CPEventKind.job_state_changed]
+        state_change_events = [e for e in published if e.kind == EventKind.job_state_changed]
         assert len(state_change_events) >= 1
         # Should NOT have published any job_created events
-        created_events = [e for e in published if e.kind == CPEventKind.job_created]
+        created_events = [e for e in published if e.kind == EventKind.job_created]
         assert len(created_events) == 0
 
 
@@ -1629,14 +1629,14 @@ class TestErrorEventCausesFailure:
 
         await runtime.start_or_enqueue(job)
         await _wait_until(
-            lambda: any(e.kind == CPEventKind.job_failed for e in published),
+            lambda: any(e.kind == EventKind.job_failed for e in published),
             msg="job_failed event not published",
         )
 
         # Should have a job_failed event, NOT job_review
         kinds = [e.kind for e in published]
-        assert CPEventKind.job_failed in kinds
-        assert CPEventKind.job_review not in kinds
+        assert EventKind.job_failed in kinds
+        assert EventKind.job_review not in kinds
 
         # DB state should be failed
         from backend.models.db import JobRow

--- a/backend/tests/unit/test_sidecar_dispatcher.py
+++ b/backend/tests/unit/test_sidecar_dispatcher.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from backend.models.events import CPEventKind, new_event
+from backend.models.events import EventKind, new_event
 from backend.services.sidecar.dispatcher import (
     AgentMessageRoute,
     CallbackRoute,
@@ -281,31 +281,31 @@ class TestConcurrency:
 
 class TestExtractContent:
     def test_messages_agent_content(self):
-        ev = new_event("j", CPEventKind.message_assistant, {"role": "agent", "content": "hello"})
+        ev = new_event("j", EventKind.message_assistant, {"role": "agent", "content": "hello"})
         assert SidecarDispatcher._extract_content(ev, "messages") == "hello"
 
     def test_messages_agent_delta_content(self):
-        ev = new_event("j", CPEventKind.message_delta, {"role": "agent_delta", "content": "part"})
+        ev = new_event("j", EventKind.message_delta, {"role": "agent_delta", "content": "part"})
         assert SidecarDispatcher._extract_content(ev, "messages") == "part"
 
     def test_messages_operator_role_ignored(self):
-        ev = new_event("j", CPEventKind.message_user, {"role": "operator", "content": "hi"})
+        ev = new_event("j", EventKind.message_user, {"role": "operator", "content": "hi"})
         assert SidecarDispatcher._extract_content(ev, "messages") is None
 
     def test_messages_non_transcript_kind_ignored(self):
-        ev = new_event("j", CPEventKind.log_line_emitted, {"role": "agent", "content": "x"})
+        ev = new_event("j", EventKind.log_line_emitted, {"role": "agent", "content": "x"})
         assert SidecarDispatcher._extract_content(ev, "messages") is None
 
     def test_tool_calls_returns_tool_name(self):
-        ev = new_event("j", CPEventKind.tool_call_completed, {"role": "tool_call", "tool_name": "Bash"})
+        ev = new_event("j", EventKind.tool_call_completed, {"role": "tool_call", "tool_name": "Bash"})
         assert SidecarDispatcher._extract_content(ev, "tool_calls") == "Bash"
 
     def test_tool_output_returns_result(self):
         ev = new_event(
-            "j", CPEventKind.tool_call_completed, {"role": "tool_call", "tool_result": "done"}
+            "j", EventKind.tool_call_completed, {"role": "tool_call", "tool_result": "done"}
         )
         assert SidecarDispatcher._extract_content(ev, "tool_output") == "done"
 
     def test_tool_calls_non_transcript_kind_ignored(self):
-        ev = new_event("j", CPEventKind.diff_updated, {"role": "tool_call", "tool_name": "Bash"})
+        ev = new_event("j", EventKind.diff_updated, {"role": "tool_call", "tool_name": "Bash"})
         assert SidecarDispatcher._extract_content(ev, "tool_calls") is None

--- a/backend/tests/unit/test_sidecar_dispatcher.py
+++ b/backend/tests/unit/test_sidecar_dispatcher.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from backend.models.events import CPEventKind, new_event
 from backend.services.sidecar.dispatcher import (
     AgentMessageRoute,
     CallbackRoute,
@@ -21,6 +22,7 @@ from backend.services.sidecar.dispatcher import (
     PlainText,
     RegexCondition,
     SidecarDefinition,
+    SidecarDispatcher,
     ThresholdCondition,
     TimerCondition,
     _hydrate_condition,
@@ -267,3 +269,43 @@ class TestConcurrency:
         assert Concurrency.skip_if_running == "skip_if_running"
         assert Concurrency.queue == "queue"
         assert Concurrency.parallel == "parallel"
+
+
+# ── _extract_content: dotted transcript kinds ──
+#
+# Regression guard for the traceforge migration: transcript events fan out to
+# role-specific dotted kinds (message.assistant, tool.call.completed, …) instead
+# of the retired single "TranscriptUpdated" kind. _extract_content must key off
+# TRANSCRIPT_KINDS membership, not the dead literal.
+
+
+class TestExtractContent:
+    def test_messages_agent_content(self):
+        ev = new_event("j", CPEventKind.message_assistant, {"role": "agent", "content": "hello"})
+        assert SidecarDispatcher._extract_content(ev, "messages") == "hello"
+
+    def test_messages_agent_delta_content(self):
+        ev = new_event("j", CPEventKind.message_delta, {"role": "agent_delta", "content": "part"})
+        assert SidecarDispatcher._extract_content(ev, "messages") == "part"
+
+    def test_messages_operator_role_ignored(self):
+        ev = new_event("j", CPEventKind.message_user, {"role": "operator", "content": "hi"})
+        assert SidecarDispatcher._extract_content(ev, "messages") is None
+
+    def test_messages_non_transcript_kind_ignored(self):
+        ev = new_event("j", CPEventKind.log_line_emitted, {"role": "agent", "content": "x"})
+        assert SidecarDispatcher._extract_content(ev, "messages") is None
+
+    def test_tool_calls_returns_tool_name(self):
+        ev = new_event("j", CPEventKind.tool_call_completed, {"role": "tool_call", "tool_name": "Bash"})
+        assert SidecarDispatcher._extract_content(ev, "tool_calls") == "Bash"
+
+    def test_tool_output_returns_result(self):
+        ev = new_event(
+            "j", CPEventKind.tool_call_completed, {"role": "tool_call", "tool_result": "done"}
+        )
+        assert SidecarDispatcher._extract_content(ev, "tool_output") == "done"
+
+    def test_tool_calls_non_transcript_kind_ignored(self):
+        ev = new_event("j", CPEventKind.diff_updated, {"role": "tool_call", "tool_name": "Bash"})
+        assert SidecarDispatcher._extract_content(ev, "tool_calls") is None

--- a/backend/tests/unit/test_snapshot_helpers.py
+++ b/backend/tests/unit/test_snapshot_helpers.py
@@ -18,7 +18,7 @@ def _event(
     timestamp: str = "2025-01-01T00:00:00Z",
     **payload: Any,
 ) -> SimpleNamespace:
-    return SimpleNamespace(job_id=job_id, timestamp=timestamp, payload=payload)
+    return SimpleNamespace(session_id=job_id, timestamp=timestamp, payload=payload)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_sse_fidelity.py
+++ b/backend/tests/unit/test_sse_fidelity.py
@@ -11,7 +11,7 @@ from datetime import UTC, datetime
 
 import pytest
 
-from backend.models.events import CPEventKind, new_event
+from backend.models.events import EventKind, new_event
 from backend.services.events.sse_manager import SSEConnection, SSEManager, _format_sse
 
 
@@ -61,7 +61,7 @@ class TestSSEManagerBroadcast:
             event_id="evt-1",
             session_id="job-1",
             timestamp=datetime.now(UTC),
-            kind=CPEventKind.log_line_emitted,
+            kind=EventKind.log_line_emitted,
             payload={"seq": 1, "message": "hello", "level": "info"},
             sequence=100,
         )
@@ -82,7 +82,7 @@ class TestSSEManagerBroadcast:
             event_id="evt-1",
             session_id="job-2",
             timestamp=datetime.now(UTC),
-            kind=CPEventKind.log_line_emitted,
+            kind=EventKind.log_line_emitted,
             payload={"seq": 1, "message": "hello", "level": "info"},
             sequence=100,
         )
@@ -103,7 +103,7 @@ class TestSSEManagerBroadcast:
             event_id="evt-1",
             session_id="job-1",
             timestamp=datetime.now(UTC),
-            kind=CPEventKind.log_line_emitted,
+            kind=EventKind.log_line_emitted,
             payload={"seq": 1, "message": "hello", "level": "info"},
             sequence=100,
         )
@@ -147,7 +147,7 @@ class TestBulkEventsOverflow:
                 event_id=f"evt-{i}",
                 session_id="job-1",
                 timestamp=datetime.now(UTC),
-                kind=CPEventKind.log_line_emitted,
+                kind=EventKind.log_line_emitted,
                 payload={"seq": i, "message": f"line-{i}", "level": "info"},
                 sequence=i + 1,
             )

--- a/backend/tests/unit/test_sse_fidelity.py
+++ b/backend/tests/unit/test_sse_fidelity.py
@@ -11,7 +11,7 @@ from datetime import UTC, datetime
 
 import pytest
 
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, new_event
 from backend.services.events.sse_manager import SSEConnection, SSEManager, _format_sse
 
 
@@ -57,13 +57,13 @@ class TestSSEManagerBroadcast:
         conn = SSEConnection(job_id="job-1")
         manager.register(conn)
 
-        event = DomainEvent(
+        event = new_event(
             event_id="evt-1",
-            job_id="job-1",
+            session_id="job-1",
             timestamp=datetime.now(UTC),
             kind=DomainEventKind.log_line_emitted,
             payload={"seq": 1, "message": "hello", "level": "info"},
-            db_id=100,
+            sequence=100,
         )
         await manager.broadcast_domain_event(event)
 
@@ -78,13 +78,13 @@ class TestSSEManagerBroadcast:
         conn = SSEConnection(job_id="job-1")
         manager.register(conn)
 
-        event = DomainEvent(
+        event = new_event(
             event_id="evt-1",
-            job_id="job-2",  # Different job
+            session_id="job-2",
             timestamp=datetime.now(UTC),
             kind=DomainEventKind.log_line_emitted,
             payload={"seq": 1, "message": "hello", "level": "info"},
-            db_id=100,
+            sequence=100,
         )
         await manager.broadcast_domain_event(event)
 
@@ -99,13 +99,13 @@ class TestSSEManagerBroadcast:
         conn = SSEConnection(job_id=None)
         manager.register(conn)
 
-        event = DomainEvent(
+        event = new_event(
             event_id="evt-1",
-            job_id="job-1",
+            session_id="job-1",
             timestamp=datetime.now(UTC),
             kind=DomainEventKind.log_line_emitted,
             payload={"seq": 1, "message": "hello", "level": "info"},
-            db_id=100,
+            sequence=100,
         )
         await manager.broadcast_domain_event(event)
 
@@ -143,13 +143,13 @@ class TestBulkEventsOverflow:
             if conn.closed:
                 closed_after = i
                 break
-            event = DomainEvent(
+            event = new_event(
                 event_id=f"evt-{i}",
-                job_id="job-1",
+                session_id="job-1",
                 timestamp=datetime.now(UTC),
                 kind=DomainEventKind.log_line_emitted,
                 payload={"seq": i, "message": f"line-{i}", "level": "info"},
-                db_id=i + 1,
+                sequence=i + 1,
             )
             await manager.broadcast_domain_event(event)
 

--- a/backend/tests/unit/test_sse_fidelity.py
+++ b/backend/tests/unit/test_sse_fidelity.py
@@ -11,7 +11,7 @@ from datetime import UTC, datetime
 
 import pytest
 
-from backend.models.events import DomainEventKind, new_event
+from backend.models.events import CPEventKind, new_event
 from backend.services.events.sse_manager import SSEConnection, SSEManager, _format_sse
 
 
@@ -61,7 +61,7 @@ class TestSSEManagerBroadcast:
             event_id="evt-1",
             session_id="job-1",
             timestamp=datetime.now(UTC),
-            kind=DomainEventKind.log_line_emitted,
+            kind=CPEventKind.log_line_emitted,
             payload={"seq": 1, "message": "hello", "level": "info"},
             sequence=100,
         )
@@ -82,7 +82,7 @@ class TestSSEManagerBroadcast:
             event_id="evt-1",
             session_id="job-2",
             timestamp=datetime.now(UTC),
-            kind=DomainEventKind.log_line_emitted,
+            kind=CPEventKind.log_line_emitted,
             payload={"seq": 1, "message": "hello", "level": "info"},
             sequence=100,
         )
@@ -103,7 +103,7 @@ class TestSSEManagerBroadcast:
             event_id="evt-1",
             session_id="job-1",
             timestamp=datetime.now(UTC),
-            kind=DomainEventKind.log_line_emitted,
+            kind=CPEventKind.log_line_emitted,
             payload={"seq": 1, "message": "hello", "level": "info"},
             sequence=100,
         )
@@ -147,7 +147,7 @@ class TestBulkEventsOverflow:
                 event_id=f"evt-{i}",
                 session_id="job-1",
                 timestamp=datetime.now(UTC),
-                kind=DomainEventKind.log_line_emitted,
+                kind=CPEventKind.log_line_emitted,
                 payload={"seq": i, "message": f"line-{i}", "level": "info"},
                 sequence=i + 1,
             )
@@ -155,9 +155,8 @@ class TestBulkEventsOverflow:
 
         # Connection should have been closed due to backpressure
         assert conn.closed
-        # Should close around 1024 events (queue size) — each broadcast may
-        # produce multiple frames (main + derived state), so the threshold
-        # is hit at or shortly after 1024 raw events.
+        # One frame per event (no derived frames), so the queue (size 1024)
+        # overflows at or shortly after 1024 raw events.
         assert closed_after is not None
         assert closed_after <= 1030
 

--- a/backend/tests/unit/test_sse_manager.py
+++ b/backend/tests/unit/test_sse_manager.py
@@ -1,4 +1,11 @@
-"""Tests for the SSE manager — connection tracking, broadcast, selective streaming, replay."""
+"""Tests for the SSE manager — connection tracking, broadcast, selective streaming, replay.
+
+Post-nuke contract: the SSE wire carries the ``traceforge.SessionEvent`` as-is —
+``event:`` is the dotted ``kind`` and ``data:`` is the TF event serialized verbatim
+(snake_case ``session_id`` / ``payload`` / ``metadata``). There is no translation to any
+legacy payload model, and no derived ``job_state_changed`` frames (the frontend derives
+job state from the dotted kinds).
+"""
 
 from __future__ import annotations
 
@@ -10,19 +17,19 @@ import pytest
 
 from backend.models.api_schemas import SnapshotPayload
 from backend.models.domain import Job
-from backend.models.events import DomainEventKind, SessionEvent, new_event
+from backend.models.events import CPEventKind, SessionEvent, new_event
 from backend.services.events.sse_manager import (
     MAX_REPLAY_AGE,
     MAX_REPLAY_EVENTS,
     SSEConnection,
     SSEManager,
-    _build_sse_data,
     _format_sse,
+    _serialize_tf_event,
 )
 
 
 def _make_event(
-    kind: DomainEventKind = DomainEventKind.job_created,
+    kind: CPEventKind = CPEventKind.job_created,
     job_id: str = "job-1",
     event_id: str = "evt-1",
     payload: dict[str, object] | None = None,
@@ -54,13 +61,20 @@ def _make_job_domain(job_id: str = "job-1", state: str = "running") -> Job:
     )
 
 
+def _frames(conn: SSEConnection) -> list[str]:
+    out: list[str] = []
+    while not conn.queue.empty():
+        out.append(conn.queue.get_nowait())
+    return out
+
+
 # --- Unit tests for helper functions ---
 
 
 class TestFormatSSE:
     def test_basic_format(self) -> None:
-        result = _format_sse("42", "job_state_changed", '{"hello":"world"}')
-        assert result == 'id: 42\nevent: job_state_changed\ndata: {"hello":"world"}\n\n'
+        result = _format_sse("42", "job.created", '{"hello":"world"}')
+        assert result == 'id: 42\nevent: job.created\ndata: {"hello":"world"}\n\n'
 
     def test_json_data(self) -> None:
         data = json.dumps({"job_id": "job-1", "state": "running"})
@@ -76,34 +90,27 @@ class TestFormatSSE:
         assert 'data: {"jobs":[]}\n' in result
 
 
-class TestBuildSSEData:
-    def test_serializes_log_line_camel_case(self) -> None:
+class TestSerializeTFEvent:
+    def test_serializes_dotted_kind_and_payload(self) -> None:
         event = _make_event(
-            kind=DomainEventKind.log_line_emitted,
+            kind=CPEventKind.log_line_emitted,
             payload={"seq": 1, "message": "hello", "level": "info"},
         )
-        result = _build_sse_data(event, "log_line")
-        parsed = json.loads(result)
-        # CamelModel serialization: keys must be camelCase
-        assert "jobId" in parsed
-        assert parsed["message"] == "hello"
+        parsed = json.loads(_serialize_tf_event(event))
+        # Wire carries the TF event as-is: dotted kind + verbatim snake_case payload.
+        assert parsed["kind"] == "log"
+        assert parsed["session_id"] == "job-1"
+        assert parsed["payload"]["message"] == "hello"
+        assert parsed["payload"]["level"] == "info"
 
-    def test_serializes_job_state_changed(self) -> None:
-        event = _make_event(kind=DomainEventKind.job_review)
-        result = _build_sse_data(event, "job_state_changed")
-        parsed = json.loads(result)
-        assert parsed["newState"] == "review"
-        assert "jobId" in parsed
+    def test_carries_metadata_sequence(self) -> None:
+        event = _make_event(kind=CPEventKind.job_created, db_id=7)
+        parsed = json.loads(_serialize_tf_event(event))
+        assert parsed["metadata"]["sequence"] == 7
 
-    def test_job_created_maps_to_running(self) -> None:
-        event = _make_event(kind=DomainEventKind.job_created)
-        result = _build_sse_data(event, "job_state_changed")
-        parsed = json.loads(result)
-        assert parsed["newState"] == "running"
-
-    def test_transcript_update_includes_tool_issue(self) -> None:
+    def test_transcript_payload_is_verbatim(self) -> None:
         event = _make_event(
-            kind=DomainEventKind.transcript_updated,
+            kind=CPEventKind.tool_call_completed,
             payload={
                 "seq": 3,
                 "role": "tool_call",
@@ -113,23 +120,12 @@ class TestBuildSSEData:
                 "tool_issue": "oldString not found",
             },
         )
-        result = _build_sse_data(event, "transcript_update")
-        parsed = json.loads(result)
-        assert parsed["toolSuccess"] is False
-        assert parsed["toolIssue"] == "oldString not found"
-
-    def test_job_resolved_includes_error(self) -> None:
-        event = _make_event(
-            kind=DomainEventKind.job_resolved,
-            payload={
-                "resolution": "unresolved",
-                "error": "Cherry-pick failed without conflict markers; check git configuration or hooks",
-            },
-        )
-        result = _build_sse_data(event, "job_resolved")
-        parsed = json.loads(result)
-        assert parsed["resolution"] == "unresolved"
-        assert parsed["error"] == "Cherry-pick failed without conflict markers; check git configuration or hooks"
+        parsed = json.loads(_serialize_tf_event(event))
+        assert parsed["kind"] == "tool.call.completed"
+        # No camelCase remapping — payload keys are exactly as authored.
+        assert parsed["payload"]["tool_success"] is False
+        assert parsed["payload"]["tool_issue"] == "oldString not found"
+        assert parsed["payload"]["role"] == "tool_call"
 
 
 # --- SSEConnection tests ---
@@ -189,12 +185,32 @@ class TestSSEManager:
         conn = SSEConnection()
         mgr.register(conn)
 
-        event = _make_event(kind=DomainEventKind.job_created, db_id=42)
+        event = _make_event(kind=CPEventKind.job_created, db_id=42)
         await mgr.broadcast_domain_event(event)
 
         data = conn.queue.get_nowait()
-        assert "event: job_state_changed" in data
+        # Wire event type is the dotted kind; id is the metadata.sequence cursor.
+        assert "event: job.created" in data
         assert "id: 42\n" in data
+
+    @pytest.mark.asyncio
+    async def test_broadcast_emits_single_frame(self) -> None:
+        """No derived secondary frames — exactly one frame per broadcast event."""
+        mgr = SSEManager()
+        conn = SSEConnection()
+        mgr.register(conn)
+
+        event = _make_event(
+            kind=CPEventKind.approval_requested,
+            payload={"approval_id": "apr-1", "description": "approve?"},
+            db_id=5,
+        )
+        await mgr.broadcast_domain_event(event)
+
+        frames = _frames(conn)
+        assert len(frames) == 1
+        assert "event: permission.requested" in frames[0]
+        assert "id: 5\n" in frames[0]
 
     @pytest.mark.asyncio
     async def test_broadcast_domain_event_routes_to_scoped_connection(self) -> None:
@@ -204,7 +220,7 @@ class TestSSEManager:
         mgr.register(conn1)
         mgr.register(conn2)
 
-        event = _make_event(kind=DomainEventKind.job_created, job_id="job-1", db_id=10)
+        event = _make_event(kind=CPEventKind.job_created, job_id="job-1", db_id=10)
         await mgr.broadcast_domain_event(event)
 
         assert not conn1.queue.empty()
@@ -216,7 +232,7 @@ class TestSSEManager:
         conn = SSEConnection()
         mgr.register(conn)
 
-        event = _make_event(kind=DomainEventKind.workspace_prepared)
+        event = _make_event(kind=CPEventKind.workspace_prepared)
         await mgr.broadcast_domain_event(event)
 
         assert conn.queue.empty()
@@ -227,8 +243,20 @@ class TestSSEManager:
         conn = SSEConnection()
         mgr.register(conn)
 
-        event = _make_event(kind=DomainEventKind.agent_session_started)
+        event = _make_event(kind=CPEventKind.agent_session_started)
         await mgr.broadcast_domain_event(event)
+
+        assert conn.queue.empty()
+
+    @pytest.mark.asyncio
+    async def test_step_events_are_internal(self) -> None:
+        """Step-system kinds stay internal — never broadcast to the frontend."""
+        mgr = SSEManager()
+        conn = SSEConnection()
+        mgr.register(conn)
+
+        for kind in (CPEventKind.step_started, CPEventKind.step_completed, CPEventKind.agent_plan_updated):
+            await mgr.broadcast_domain_event(_make_event(kind=kind))
 
         assert conn.queue.empty()
 
@@ -241,10 +269,11 @@ class TestSSEManager:
         mgr.register(conn)
 
         for kind in [
-            DomainEventKind.log_line_emitted,
-            DomainEventKind.transcript_updated,
-            DomainEventKind.diff_updated,
-            DomainEventKind.session_heartbeat,
+            CPEventKind.log_line_emitted,
+            CPEventKind.message_assistant,
+            CPEventKind.tool_call_completed,
+            CPEventKind.diff_updated,
+            CPEventKind.session_heartbeat,
         ]:
             await mgr.broadcast_domain_event(_make_event(kind=kind))
 
@@ -258,7 +287,7 @@ class TestSSEManager:
         conn = SSEConnection()
         mgr.register(conn)
 
-        await mgr.broadcast_domain_event(_make_event(kind=DomainEventKind.job_review))
+        await mgr.broadcast_domain_event(_make_event(kind=CPEventKind.job_review))
         assert not conn.queue.empty()
 
     @pytest.mark.asyncio
@@ -269,7 +298,7 @@ class TestSSEManager:
         conn = SSEConnection(job_id="job-1")
         mgr.register(conn)
 
-        await mgr.broadcast_domain_event(_make_event(kind=DomainEventKind.log_line_emitted, job_id="job-1"))
+        await mgr.broadcast_domain_event(_make_event(kind=CPEventKind.log_line_emitted, job_id="job-1"))
         assert not conn.queue.empty()
 
     @pytest.mark.asyncio
@@ -280,73 +309,22 @@ class TestSSEManager:
         conn = SSEConnection()
         mgr.register(conn)
 
-        await mgr.broadcast_domain_event(_make_event(kind=DomainEventKind.log_line_emitted))
+        await mgr.broadcast_domain_event(_make_event(kind=CPEventKind.log_line_emitted))
         assert not conn.queue.empty()
 
     @pytest.mark.asyncio
-    async def test_approval_requested_emits_secondary_state_event(self) -> None:
+    async def test_job_scoped_only_kinds_skip_global(self) -> None:
+        """telemetry.updated / secondary_session.entry only reach job-scoped connections."""
         mgr = SSEManager()
-        conn = SSEConnection()
-        mgr.register(conn)
+        global_conn = SSEConnection()
+        scoped_conn = SSEConnection(job_id="job-1")
+        mgr.register(global_conn)
+        mgr.register(scoped_conn)
 
-        event = _make_event(
-            kind=DomainEventKind.approval_requested,
-            payload={"approval_id": "apr-1", "description": "approve?"},
-        )
-        await mgr.broadcast_domain_event(event)
+        await mgr.broadcast_domain_event(_make_event(kind=CPEventKind.telemetry_updated, job_id="job-1"))
 
-        # Should have 2 frames: approval_requested + job_state_changed
-        frames = []
-        while not conn.queue.empty():
-            frames.append(conn.queue.get_nowait())
-
-        assert len(frames) == 2
-        assert "event: approval_requested" in frames[0]
-        assert "event: job_state_changed" in frames[1]
-        assert "waiting_for_approval" in frames[1]
-        # Secondary frame must not carry an id: line (would break replay)
-        assert "id:" not in frames[1]
-
-    @pytest.mark.asyncio
-    async def test_approval_resolved_approved_emits_running(self) -> None:
-        mgr = SSEManager()
-        conn = SSEConnection()
-        mgr.register(conn)
-
-        event = _make_event(
-            kind=DomainEventKind.approval_resolved,
-            payload={"resolution": "approved"},
-        )
-        await mgr.broadcast_domain_event(event)
-
-        frames = []
-        while not conn.queue.empty():
-            frames.append(conn.queue.get_nowait())
-
-        assert len(frames) == 2
-        assert "event: approval_resolved" in frames[0]
-        assert "event: job_state_changed" in frames[1]
-        assert '"running"' in frames[1] or "running" in frames[1]
-
-    @pytest.mark.asyncio
-    async def test_approval_resolved_rejected_emits_failed(self) -> None:
-        mgr = SSEManager()
-        conn = SSEConnection()
-        mgr.register(conn)
-
-        event = _make_event(
-            kind=DomainEventKind.approval_resolved,
-            payload={"resolution": "rejected"},
-        )
-        await mgr.broadcast_domain_event(event)
-
-        frames = []
-        while not conn.queue.empty():
-            frames.append(conn.queue.get_nowait())
-
-        assert len(frames) == 2
-        state_data = frames[1]
-        assert "failed" in state_data
+        assert global_conn.queue.empty()
+        assert not scoped_conn.queue.empty()
 
     @pytest.mark.asyncio
     async def test_closed_connections_skipped(self) -> None:
@@ -390,14 +368,13 @@ class TestSSEManager:
         conn = SSEConnection()
         mgr.register(conn)
 
-        # Create mock repos
         now = datetime.now(UTC)
         events = [
             new_event(
                 event_id="evt-1",
                 session_id="job-1",
                 timestamp=now,
-                kind=DomainEventKind.job_created,
+                kind=CPEventKind.job_created,
                 payload={"state": "running"},
                 sequence=1,
             ),
@@ -405,7 +382,7 @@ class TestSSEManager:
                 event_id="evt-2",
                 session_id="job-1",
                 timestamp=now,
-                kind=DomainEventKind.log_line_emitted,
+                kind=CPEventKind.log_line_emitted,
                 payload={"seq": 1, "message": "hello"},
                 sequence=2,
             ),
@@ -418,13 +395,13 @@ class TestSSEManager:
 
         await mgr.replay_events(conn, event_repo, job_repo, last_event_id=0)
 
-        # Should have 2 replayed frames with numeric IDs
-        frames = []
-        while not conn.queue.empty():
-            frames.append(conn.queue.get_nowait())
+        # Should have 2 replayed frames with numeric IDs and dotted event types.
+        frames = _frames(conn)
         assert len(frames) == 2
         assert "id: 1\n" in frames[0]
+        assert "event: job.created" in frames[0]
         assert "id: 2\n" in frames[1]
+        assert "event: log" in frames[1]
 
     @pytest.mark.asyncio
     async def test_replay_events_sends_snapshot_on_overflow(self) -> None:
@@ -434,13 +411,12 @@ class TestSSEManager:
         mgr.register(conn)
 
         now = datetime.now(UTC)
-        # Create MAX_REPLAY_EVENTS + 1 events to trigger snapshot
         events = [
             new_event(
                 event_id=f"evt-{i}",
                 session_id="job-1",
                 timestamp=now,
-                kind=DomainEventKind.log_line_emitted,
+                kind=CPEventKind.log_line_emitted,
                 payload={"seq": i},
             )
             for i in range(MAX_REPLAY_EVENTS + 1)
@@ -455,11 +431,7 @@ class TestSSEManager:
 
         await mgr.replay_events(conn, event_repo, job_repo, last_event_id=0)
 
-        frames = []
-        while not conn.queue.empty():
-            frames.append(conn.queue.get_nowait())
-
-        # First frame should be a snapshot
+        frames = _frames(conn)
         assert len(frames) > 0
         assert "event: snapshot" in frames[0]
 
@@ -473,7 +445,7 @@ class TestSSEManager:
         old_time = datetime.now(UTC) - MAX_REPLAY_AGE - timedelta(minutes=1)
         events = [
             new_event(
-                event_id="evt-old", session_id="job-1", timestamp=old_time, kind=DomainEventKind.job_created, payload={}
+                event_id="evt-old", session_id="job-1", timestamp=old_time, kind=CPEventKind.job_created, payload={}
             ),
         ]
 
@@ -486,10 +458,7 @@ class TestSSEManager:
 
         await mgr.replay_events(conn, event_repo, job_repo, last_event_id=0)
 
-        frames = []
-        while not conn.queue.empty():
-            frames.append(conn.queue.get_nowait())
-
+        frames = _frames(conn)
         assert any("event: snapshot" in f for f in frames)
 
     @pytest.mark.asyncio
@@ -502,7 +471,7 @@ class TestSSEManager:
         now = datetime.now(UTC)
         events = [
             new_event(
-                event_id="evt-1", session_id="job-1", timestamp=now, kind=DomainEventKind.workspace_prepared, payload={}
+                event_id="evt-1", session_id="job-1", timestamp=now, kind=CPEventKind.workspace_prepared, payload={}
             ),
         ]
 
@@ -515,70 +484,33 @@ class TestSSEManager:
         assert conn.queue.empty()
 
     @pytest.mark.asyncio
-    async def test_all_mappable_event_types(self) -> None:
-        """Every domain event kind that maps to an SSE type gets delivered."""
+    async def test_all_broadcast_kinds_deliver_one_frame_each(self) -> None:
+        """Every allowlisted kind is delivered as exactly one frame (no secondaries)."""
         mgr = SSEManager()
         conn = SSEConnection()
         mgr.register(conn)
 
-        mappable_kinds = [
-            DomainEventKind.job_created,
-            DomainEventKind.log_line_emitted,
-            DomainEventKind.transcript_updated,
-            DomainEventKind.diff_updated,
-            DomainEventKind.approval_requested,
-            DomainEventKind.approval_resolved,
-            DomainEventKind.job_review,
-            DomainEventKind.job_completed,
-            DomainEventKind.job_failed,
-            DomainEventKind.job_canceled,
-            DomainEventKind.session_heartbeat,
-            DomainEventKind.job_resolved,
-            DomainEventKind.job_archived,
+        kinds = [
+            CPEventKind.job_created,
+            CPEventKind.log_line_emitted,
+            CPEventKind.message_assistant,
+            CPEventKind.diff_updated,
+            CPEventKind.approval_requested,
+            CPEventKind.approval_resolved,
+            CPEventKind.job_review,
+            CPEventKind.job_completed,
+            CPEventKind.job_failed,
+            CPEventKind.job_canceled,
+            CPEventKind.session_heartbeat,
+            CPEventKind.job_resolved,
+            CPEventKind.job_archived,
         ]
 
-        for i, kind in enumerate(mappable_kinds):
-            payload: dict[str, object] = {}
-            if kind == DomainEventKind.approval_resolved:
-                payload = {"resolution": "approved"}
-            if kind == DomainEventKind.job_failed:
-                payload = {"reason": "test error"}
-            if kind == DomainEventKind.job_resolved:
-                payload = {"resolution": "merged"}
-            await mgr.broadcast_domain_event(_make_event(kind=kind, event_id=f"evt-{i}", payload=payload))
+        for i, kind in enumerate(kinds):
+            await mgr.broadcast_domain_event(_make_event(kind=kind, event_id=f"evt-{i}"))
 
-        frames = []
-        while not conn.queue.empty():
-            frames.append(conn.queue.get_nowait())
-
-        # 13 kinds. approval_requested/resolved produce 2 each (secondary job_state_changed).
-        # job_review/job_completed/job_failed produce 2 each (secondary job_state_changed).
-        # That's 13 primary + 5 secondary = 18 total.
-        assert len(frames) == 18
-
-    @pytest.mark.asyncio
-    async def test_approval_resolved_secondary_frame_has_no_id(self) -> None:
-        """Secondary job_state_changed from approval_resolved must omit id: line."""
-        mgr = SSEManager()
-        conn = SSEConnection()
-        mgr.register(conn)
-
-        event = _make_event(
-            kind=DomainEventKind.approval_resolved,
-            payload={"resolution": "approved"},
-            db_id=99,
-        )
-        await mgr.broadcast_domain_event(event)
-
-        frames = []
-        while not conn.queue.empty():
-            frames.append(conn.queue.get_nowait())
-
-        assert len(frames) == 2
-        # Primary frame has the db_id
-        assert "id: 99\n" in frames[0]
-        # Secondary frame must NOT have an id: line (same as approval_requested)
-        assert "id:" not in frames[1]
+        frames = _frames(conn)
+        assert len(frames) == len(kinds)
 
     @pytest.mark.asyncio
     async def test_replay_scoped_connection_uses_job_repo_get(self) -> None:
@@ -588,13 +520,12 @@ class TestSSEManager:
         mgr.register(conn)
 
         now = datetime.now(UTC)
-        # Create overflow to trigger snapshot
         events = [
             new_event(
                 event_id=f"evt-{i}",
                 session_id="job-1",
                 timestamp=now,
-                kind=DomainEventKind.log_line_emitted,
+                kind=CPEventKind.log_line_emitted,
                 payload={"seq": i},
             )
             for i in range(MAX_REPLAY_EVENTS + 1)
@@ -613,13 +544,8 @@ class TestSSEManager:
         job_repo.get.assert_called_once_with("job-1")
         job_repo.list.assert_not_called()
 
-        frames = []
-        while not conn.queue.empty():
-            frames.append(conn.queue.get_nowait())
-
-        # First frame is a snapshot
+        frames = _frames(conn)
         assert "event: snapshot" in frames[0]
-        # Snapshot should contain the scoped job
         assert "job-1" in frames[0]
 
     @pytest.mark.asyncio
@@ -635,7 +561,7 @@ class TestSSEManager:
                 event_id=f"evt-{i}",
                 session_id="deleted-job",
                 timestamp=now,
-                kind=DomainEventKind.log_line_emitted,
+                kind=CPEventKind.log_line_emitted,
                 payload={"seq": i},
             )
             for i in range(MAX_REPLAY_EVENTS + 1)
@@ -650,11 +576,7 @@ class TestSSEManager:
 
         await mgr.replay_events(conn, event_repo, job_repo, last_event_id=0)
 
-        frames = []
-        while not conn.queue.empty():
-            frames.append(conn.queue.get_nowait())
-
-        # Snapshot with empty jobs list
+        frames = _frames(conn)
         assert "event: snapshot" in frames[0]
         assert '"jobs": []' in frames[0] or '"jobs":[]' in frames[0]
 
@@ -673,7 +595,7 @@ class TestSSEManager:
                 event_id=f"evt-{i}",
                 session_id="job-1",
                 timestamp=now,
-                kind=DomainEventKind.log_line_emitted,
+                kind=CPEventKind.log_line_emitted,
                 payload={"seq": i},
             )
             for i in range(MAX_REPLAY_EVENTS + 1)
@@ -705,10 +627,7 @@ class TestSSEManager:
             approval_repo=approval_repo,
         )
 
-        frames: list[str] = []
-        while not conn.queue.empty():
-            frames.append(conn.queue.get_nowait())
-
+        frames = _frames(conn)
         assert "event: snapshot" in frames[0]
         snapshot_data = json.loads(frames[0].split("data: ", 1)[1].split("\n")[0])
         assert len(snapshot_data["pendingApprovals"]) == 1
@@ -716,166 +635,3 @@ class TestSSEManager:
         assert snapshot_data["pendingApprovals"][0]["description"] == "Delete file?"
         assert snapshot_data["pendingApprovals"][0]["proposedAction"] == "rm file.txt"
         approval_repo.list_pending.assert_called_once_with(job_id="job-1")
-
-    """Test _build_sse_data for every SSE event type."""
-
-    def test_approval_requested_payload(self) -> None:
-        event = _make_event(
-            kind=DomainEventKind.approval_requested,
-            payload={
-                "approval_id": "apr-1",
-                "description": "Delete file?",
-                "proposed_action": "rm file.txt",
-            },
-        )
-        result = _build_sse_data(event, "approval_requested")
-        parsed = json.loads(result)
-        assert parsed["jobId"] == "job-1"
-        assert parsed["approvalId"] == "apr-1"
-        assert parsed["description"] == "Delete file?"
-        assert parsed["proposedAction"] == "rm file.txt"
-        assert "timestamp" in parsed
-
-    def test_approval_requested_missing_fields_use_defaults(self) -> None:
-        event = _make_event(
-            kind=DomainEventKind.approval_requested,
-            payload={},
-        )
-        result = _build_sse_data(event, "approval_requested")
-        parsed = json.loads(result)
-        assert parsed["approvalId"] == ""
-        assert parsed["description"] == ""
-        assert parsed["proposedAction"] is None
-
-    def test_approval_resolved_payload(self) -> None:
-        event = _make_event(
-            kind=DomainEventKind.approval_resolved,
-            payload={
-                "approval_id": "apr-1",
-                "resolution": "approved",
-            },
-        )
-        result = _build_sse_data(event, "approval_resolved")
-        parsed = json.loads(result)
-        assert parsed["approvalId"] == "apr-1"
-        assert parsed["resolution"] == "approved"
-        assert "timestamp" in parsed
-
-    def test_diff_update_payload(self) -> None:
-        sample_file = {
-            "path": "src/main.py",
-            "status": "modified",
-            "additions": 3,
-            "deletions": 1,
-            "hunks": [],
-        }
-        event = _make_event(
-            kind=DomainEventKind.diff_updated,
-            payload={"changed_files": [sample_file]},
-        )
-        result = _build_sse_data(event, "diff_update")
-        parsed = json.loads(result)
-        assert parsed["jobId"] == "job-1"
-        assert len(parsed["changedFiles"]) == 1
-        assert parsed["changedFiles"][0]["path"] == "src/main.py"
-
-    def test_session_heartbeat_payload(self) -> None:
-        event = _make_event(
-            kind=DomainEventKind.session_heartbeat,
-            payload={"session_id": "sess-1"},
-        )
-        result = _build_sse_data(event, "session_heartbeat")
-        parsed = json.loads(result)
-        assert parsed["jobId"] == "job-1"
-        assert parsed["sessionId"] == "sess-1"
-        assert "timestamp" in parsed
-
-    def test_transcript_update_payload(self) -> None:
-        event = _make_event(
-            kind=DomainEventKind.transcript_updated,
-            payload={"seq": 5, "role": "agent", "content": "I found the bug"},
-        )
-        result = _build_sse_data(event, "transcript_update")
-        parsed = json.loads(result)
-        assert parsed["jobId"] == "job-1"
-        assert parsed["seq"] == 5
-        assert parsed["role"] == "agent"
-        assert parsed["content"] == "I found the bug"
-
-    def test_fallback_for_unknown_type(self) -> None:
-        event = _make_event(payload={"custom": "data"})
-        result = _build_sse_data(event, "unknown_type")
-        parsed = json.loads(result)
-        assert parsed["custom"] == "data"
-
-
-class TestReplayDerivedFrames:
-    """Replay must emit derived job_state_changed frames for approval events."""
-
-    @pytest.mark.asyncio
-    async def test_replay_approval_requested_emits_derived_frame(self) -> None:
-        mgr = SSEManager()
-        conn = SSEConnection()
-        mgr.register(conn)
-
-        now = datetime.now(UTC)
-        events = [
-            new_event(
-                event_id="evt-1",
-                session_id="job-1",
-                timestamp=now,
-                kind=DomainEventKind.approval_requested,
-                payload={"approval_id": "apr-1", "description": "ok?"},
-                sequence=10,
-            ),
-        ]
-        event_repo = AsyncMock()
-        event_repo.list_after.return_value = events
-        job_repo = AsyncMock()
-
-        await mgr.replay_events(conn, event_repo, job_repo, last_event_id=0)
-
-        frames: list[str] = []
-        while not conn.queue.empty():
-            frames.append(conn.queue.get_nowait())
-
-        assert len(frames) == 2
-        assert "event: approval_requested" in frames[0]
-        assert "event: job_state_changed" in frames[1]
-        assert "waiting_for_approval" in frames[1]
-        # Derived frame reuses the same SSE id (no cursor advancement)
-        assert "id: 10\n" in frames[1]
-
-    @pytest.mark.asyncio
-    async def test_replay_approval_resolved_emits_derived_frame(self) -> None:
-        mgr = SSEManager()
-        conn = SSEConnection()
-        mgr.register(conn)
-
-        now = datetime.now(UTC)
-        events = [
-            new_event(
-                event_id="evt-2",
-                session_id="job-1",
-                timestamp=now,
-                kind=DomainEventKind.approval_resolved,
-                payload={"approval_id": "apr-1", "resolution": "rejected"},
-                sequence=20,
-            ),
-        ]
-        event_repo = AsyncMock()
-        event_repo.list_after.return_value = events
-        job_repo = AsyncMock()
-
-        await mgr.replay_events(conn, event_repo, job_repo, last_event_id=0)
-
-        frames: list[str] = []
-        while not conn.queue.empty():
-            frames.append(conn.queue.get_nowait())
-
-        assert len(frames) == 2
-        assert "event: approval_resolved" in frames[0]
-        assert "event: job_state_changed" in frames[1]
-        # rejected → failed
-        assert '"failed"' in frames[1] or "failed" in frames[1]
-        assert "id: 20\n" in frames[1]

--- a/backend/tests/unit/test_sse_manager.py
+++ b/backend/tests/unit/test_sse_manager.py
@@ -10,7 +10,7 @@ import pytest
 
 from backend.models.api_schemas import SnapshotPayload
 from backend.models.domain import Job
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, SessionEvent, new_event
 from backend.services.events.sse_manager import (
     MAX_REPLAY_AGE,
     MAX_REPLAY_EVENTS,
@@ -27,14 +27,14 @@ def _make_event(
     event_id: str = "evt-1",
     payload: dict[str, object] | None = None,
     db_id: int | None = None,
-) -> DomainEvent:
-    return DomainEvent(
+) -> SessionEvent:
+    return new_event(
         event_id=event_id,
-        job_id=job_id,
+        session_id=job_id,
         timestamp=datetime.now(UTC),
         kind=kind,
         payload=payload or {"test": True},
-        db_id=db_id,
+        sequence=db_id,
     )
 
 
@@ -393,21 +393,21 @@ class TestSSEManager:
         # Create mock repos
         now = datetime.now(UTC)
         events = [
-            DomainEvent(
+            new_event(
                 event_id="evt-1",
-                job_id="job-1",
+                session_id="job-1",
                 timestamp=now,
                 kind=DomainEventKind.job_created,
                 payload={"state": "running"},
-                db_id=1,
+                sequence=1,
             ),
-            DomainEvent(
+            new_event(
                 event_id="evt-2",
-                job_id="job-1",
+                session_id="job-1",
                 timestamp=now,
                 kind=DomainEventKind.log_line_emitted,
                 payload={"seq": 1, "message": "hello"},
-                db_id=2,
+                sequence=2,
             ),
         ]
 
@@ -436,9 +436,9 @@ class TestSSEManager:
         now = datetime.now(UTC)
         # Create MAX_REPLAY_EVENTS + 1 events to trigger snapshot
         events = [
-            DomainEvent(
+            new_event(
                 event_id=f"evt-{i}",
-                job_id="job-1",
+                session_id="job-1",
                 timestamp=now,
                 kind=DomainEventKind.log_line_emitted,
                 payload={"seq": i},
@@ -472,12 +472,8 @@ class TestSSEManager:
 
         old_time = datetime.now(UTC) - MAX_REPLAY_AGE - timedelta(minutes=1)
         events = [
-            DomainEvent(
-                event_id="evt-old",
-                job_id="job-1",
-                timestamp=old_time,
-                kind=DomainEventKind.job_created,
-                payload={},
+            new_event(
+                event_id="evt-old", session_id="job-1", timestamp=old_time, kind=DomainEventKind.job_created, payload={}
             ),
         ]
 
@@ -505,12 +501,8 @@ class TestSSEManager:
 
         now = datetime.now(UTC)
         events = [
-            DomainEvent(
-                event_id="evt-1",
-                job_id="job-1",
-                timestamp=now,
-                kind=DomainEventKind.workspace_prepared,
-                payload={},
+            new_event(
+                event_id="evt-1", session_id="job-1", timestamp=now, kind=DomainEventKind.workspace_prepared, payload={}
             ),
         ]
 
@@ -598,9 +590,9 @@ class TestSSEManager:
         now = datetime.now(UTC)
         # Create overflow to trigger snapshot
         events = [
-            DomainEvent(
+            new_event(
                 event_id=f"evt-{i}",
-                job_id="job-1",
+                session_id="job-1",
                 timestamp=now,
                 kind=DomainEventKind.log_line_emitted,
                 payload={"seq": i},
@@ -639,9 +631,9 @@ class TestSSEManager:
 
         now = datetime.now(UTC)
         events = [
-            DomainEvent(
+            new_event(
                 event_id=f"evt-{i}",
-                job_id="deleted-job",
+                session_id="deleted-job",
                 timestamp=now,
                 kind=DomainEventKind.log_line_emitted,
                 payload={"seq": i},
@@ -677,9 +669,9 @@ class TestSSEManager:
 
         now = datetime.now(UTC)
         events = [
-            DomainEvent(
+            new_event(
                 event_id=f"evt-{i}",
-                job_id="job-1",
+                session_id="job-1",
                 timestamp=now,
                 kind=DomainEventKind.log_line_emitted,
                 payload={"seq": i},
@@ -828,13 +820,13 @@ class TestReplayDerivedFrames:
 
         now = datetime.now(UTC)
         events = [
-            DomainEvent(
+            new_event(
                 event_id="evt-1",
-                job_id="job-1",
+                session_id="job-1",
                 timestamp=now,
                 kind=DomainEventKind.approval_requested,
                 payload={"approval_id": "apr-1", "description": "ok?"},
-                db_id=10,
+                sequence=10,
             ),
         ]
         event_repo = AsyncMock()
@@ -862,13 +854,13 @@ class TestReplayDerivedFrames:
 
         now = datetime.now(UTC)
         events = [
-            DomainEvent(
+            new_event(
                 event_id="evt-2",
-                job_id="job-1",
+                session_id="job-1",
                 timestamp=now,
                 kind=DomainEventKind.approval_resolved,
                 payload={"approval_id": "apr-1", "resolution": "rejected"},
-                db_id=20,
+                sequence=20,
             ),
         ]
         event_repo = AsyncMock()

--- a/backend/tests/unit/test_sse_manager.py
+++ b/backend/tests/unit/test_sse_manager.py
@@ -17,7 +17,7 @@ import pytest
 
 from backend.models.api_schemas import SnapshotPayload
 from backend.models.domain import Job
-from backend.models.events import CPEventKind, SessionEvent, new_event
+from backend.models.events import EventKind, SessionEvent, new_event
 from backend.services.events.sse_manager import (
     MAX_REPLAY_AGE,
     MAX_REPLAY_EVENTS,
@@ -29,7 +29,7 @@ from backend.services.events.sse_manager import (
 
 
 def _make_event(
-    kind: CPEventKind = CPEventKind.job_created,
+    kind: EventKind = EventKind.job_created,
     job_id: str = "job-1",
     event_id: str = "evt-1",
     payload: dict[str, object] | None = None,
@@ -93,7 +93,7 @@ class TestFormatSSE:
 class TestSerializeTFEvent:
     def test_serializes_dotted_kind_and_payload(self) -> None:
         event = _make_event(
-            kind=CPEventKind.log_line_emitted,
+            kind=EventKind.log_line_emitted,
             payload={"seq": 1, "message": "hello", "level": "info"},
         )
         parsed = json.loads(_serialize_tf_event(event))
@@ -104,13 +104,13 @@ class TestSerializeTFEvent:
         assert parsed["payload"]["level"] == "info"
 
     def test_carries_metadata_sequence(self) -> None:
-        event = _make_event(kind=CPEventKind.job_created, db_id=7)
+        event = _make_event(kind=EventKind.job_created, db_id=7)
         parsed = json.loads(_serialize_tf_event(event))
         assert parsed["metadata"]["sequence"] == 7
 
     def test_transcript_payload_is_verbatim(self) -> None:
         event = _make_event(
-            kind=CPEventKind.tool_call_completed,
+            kind=EventKind.tool_call_completed,
             payload={
                 "seq": 3,
                 "role": "tool_call",
@@ -185,7 +185,7 @@ class TestSSEManager:
         conn = SSEConnection()
         mgr.register(conn)
 
-        event = _make_event(kind=CPEventKind.job_created, db_id=42)
+        event = _make_event(kind=EventKind.job_created, db_id=42)
         await mgr.broadcast_domain_event(event)
 
         data = conn.queue.get_nowait()
@@ -201,7 +201,7 @@ class TestSSEManager:
         mgr.register(conn)
 
         event = _make_event(
-            kind=CPEventKind.approval_requested,
+            kind=EventKind.approval_requested,
             payload={"approval_id": "apr-1", "description": "approve?"},
             db_id=5,
         )
@@ -220,7 +220,7 @@ class TestSSEManager:
         mgr.register(conn1)
         mgr.register(conn2)
 
-        event = _make_event(kind=CPEventKind.job_created, job_id="job-1", db_id=10)
+        event = _make_event(kind=EventKind.job_created, job_id="job-1", db_id=10)
         await mgr.broadcast_domain_event(event)
 
         assert not conn1.queue.empty()
@@ -232,7 +232,7 @@ class TestSSEManager:
         conn = SSEConnection()
         mgr.register(conn)
 
-        event = _make_event(kind=CPEventKind.workspace_prepared)
+        event = _make_event(kind=EventKind.workspace_prepared)
         await mgr.broadcast_domain_event(event)
 
         assert conn.queue.empty()
@@ -243,7 +243,7 @@ class TestSSEManager:
         conn = SSEConnection()
         mgr.register(conn)
 
-        event = _make_event(kind=CPEventKind.agent_session_started)
+        event = _make_event(kind=EventKind.agent_session_started)
         await mgr.broadcast_domain_event(event)
 
         assert conn.queue.empty()
@@ -255,7 +255,7 @@ class TestSSEManager:
         conn = SSEConnection()
         mgr.register(conn)
 
-        for kind in (CPEventKind.step_started, CPEventKind.step_completed, CPEventKind.agent_plan_updated):
+        for kind in (EventKind.step_started, EventKind.step_completed, EventKind.agent_plan_updated):
             await mgr.broadcast_domain_event(_make_event(kind=kind))
 
         assert conn.queue.empty()
@@ -269,11 +269,11 @@ class TestSSEManager:
         mgr.register(conn)
 
         for kind in [
-            CPEventKind.log_line_emitted,
-            CPEventKind.message_assistant,
-            CPEventKind.tool_call_completed,
-            CPEventKind.diff_updated,
-            CPEventKind.session_heartbeat,
+            EventKind.log_line_emitted,
+            EventKind.message_assistant,
+            EventKind.tool_call_completed,
+            EventKind.diff_updated,
+            EventKind.session_heartbeat,
         ]:
             await mgr.broadcast_domain_event(_make_event(kind=kind))
 
@@ -287,7 +287,7 @@ class TestSSEManager:
         conn = SSEConnection()
         mgr.register(conn)
 
-        await mgr.broadcast_domain_event(_make_event(kind=CPEventKind.job_review))
+        await mgr.broadcast_domain_event(_make_event(kind=EventKind.job_review))
         assert not conn.queue.empty()
 
     @pytest.mark.asyncio
@@ -298,7 +298,7 @@ class TestSSEManager:
         conn = SSEConnection(job_id="job-1")
         mgr.register(conn)
 
-        await mgr.broadcast_domain_event(_make_event(kind=CPEventKind.log_line_emitted, job_id="job-1"))
+        await mgr.broadcast_domain_event(_make_event(kind=EventKind.log_line_emitted, job_id="job-1"))
         assert not conn.queue.empty()
 
     @pytest.mark.asyncio
@@ -309,7 +309,7 @@ class TestSSEManager:
         conn = SSEConnection()
         mgr.register(conn)
 
-        await mgr.broadcast_domain_event(_make_event(kind=CPEventKind.log_line_emitted))
+        await mgr.broadcast_domain_event(_make_event(kind=EventKind.log_line_emitted))
         assert not conn.queue.empty()
 
     @pytest.mark.asyncio
@@ -321,7 +321,7 @@ class TestSSEManager:
         mgr.register(global_conn)
         mgr.register(scoped_conn)
 
-        await mgr.broadcast_domain_event(_make_event(kind=CPEventKind.telemetry_updated, job_id="job-1"))
+        await mgr.broadcast_domain_event(_make_event(kind=EventKind.telemetry_updated, job_id="job-1"))
 
         assert global_conn.queue.empty()
         assert not scoped_conn.queue.empty()
@@ -374,7 +374,7 @@ class TestSSEManager:
                 event_id="evt-1",
                 session_id="job-1",
                 timestamp=now,
-                kind=CPEventKind.job_created,
+                kind=EventKind.job_created,
                 payload={"state": "running"},
                 sequence=1,
             ),
@@ -382,7 +382,7 @@ class TestSSEManager:
                 event_id="evt-2",
                 session_id="job-1",
                 timestamp=now,
-                kind=CPEventKind.log_line_emitted,
+                kind=EventKind.log_line_emitted,
                 payload={"seq": 1, "message": "hello"},
                 sequence=2,
             ),
@@ -416,7 +416,7 @@ class TestSSEManager:
                 event_id=f"evt-{i}",
                 session_id="job-1",
                 timestamp=now,
-                kind=CPEventKind.log_line_emitted,
+                kind=EventKind.log_line_emitted,
                 payload={"seq": i},
             )
             for i in range(MAX_REPLAY_EVENTS + 1)
@@ -445,7 +445,7 @@ class TestSSEManager:
         old_time = datetime.now(UTC) - MAX_REPLAY_AGE - timedelta(minutes=1)
         events = [
             new_event(
-                event_id="evt-old", session_id="job-1", timestamp=old_time, kind=CPEventKind.job_created, payload={}
+                event_id="evt-old", session_id="job-1", timestamp=old_time, kind=EventKind.job_created, payload={}
             ),
         ]
 
@@ -471,7 +471,7 @@ class TestSSEManager:
         now = datetime.now(UTC)
         events = [
             new_event(
-                event_id="evt-1", session_id="job-1", timestamp=now, kind=CPEventKind.workspace_prepared, payload={}
+                event_id="evt-1", session_id="job-1", timestamp=now, kind=EventKind.workspace_prepared, payload={}
             ),
         ]
 
@@ -491,19 +491,19 @@ class TestSSEManager:
         mgr.register(conn)
 
         kinds = [
-            CPEventKind.job_created,
-            CPEventKind.log_line_emitted,
-            CPEventKind.message_assistant,
-            CPEventKind.diff_updated,
-            CPEventKind.approval_requested,
-            CPEventKind.approval_resolved,
-            CPEventKind.job_review,
-            CPEventKind.job_completed,
-            CPEventKind.job_failed,
-            CPEventKind.job_canceled,
-            CPEventKind.session_heartbeat,
-            CPEventKind.job_resolved,
-            CPEventKind.job_archived,
+            EventKind.job_created,
+            EventKind.log_line_emitted,
+            EventKind.message_assistant,
+            EventKind.diff_updated,
+            EventKind.approval_requested,
+            EventKind.approval_resolved,
+            EventKind.job_review,
+            EventKind.job_completed,
+            EventKind.job_failed,
+            EventKind.job_canceled,
+            EventKind.session_heartbeat,
+            EventKind.job_resolved,
+            EventKind.job_archived,
         ]
 
         for i, kind in enumerate(kinds):
@@ -525,7 +525,7 @@ class TestSSEManager:
                 event_id=f"evt-{i}",
                 session_id="job-1",
                 timestamp=now,
-                kind=CPEventKind.log_line_emitted,
+                kind=EventKind.log_line_emitted,
                 payload={"seq": i},
             )
             for i in range(MAX_REPLAY_EVENTS + 1)
@@ -561,7 +561,7 @@ class TestSSEManager:
                 event_id=f"evt-{i}",
                 session_id="deleted-job",
                 timestamp=now,
-                kind=CPEventKind.log_line_emitted,
+                kind=EventKind.log_line_emitted,
                 payload={"seq": i},
             )
             for i in range(MAX_REPLAY_EVENTS + 1)
@@ -595,7 +595,7 @@ class TestSSEManager:
                 event_id=f"evt-{i}",
                 session_id="job-1",
                 timestamp=now,
-                kind=CPEventKind.log_line_emitted,
+                kind=EventKind.log_line_emitted,
                 payload={"seq": i},
             )
             for i in range(MAX_REPLAY_EVENTS + 1)

--- a/backend/tests/unit/test_step_persistence.py
+++ b/backend/tests/unit/test_step_persistence.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from backend.models.events import CPEventKind, new_event
+from backend.models.events import EventKind, new_event
 from backend.services.steps.persistence import StepPersistenceSubscriber
 
 
@@ -29,7 +29,7 @@ class TestStepPersistence:
             event_id="evt-1",
             session_id="job-1",
             timestamp=now,
-            kind=CPEventKind.step_started,
+            kind=EventKind.step_started,
             payload={
                 "step_id": "step-1",
                 "step_number": 1,
@@ -56,7 +56,7 @@ class TestStepPersistence:
             event_id="evt-2",
             session_id="job-1",
             timestamp=now,
-            kind=CPEventKind.step_completed,
+            kind=EventKind.step_completed,
             payload={
                 "step_id": "step-1",
                 "status": "done",
@@ -71,7 +71,7 @@ class TestStepPersistence:
     async def test_unrelated_event_is_noop(self, subscriber: StepPersistenceSubscriber, step_repo: AsyncMock) -> None:
         now = datetime.now(UTC)
         event = new_event(
-            event_id="evt-3", session_id="job-1", timestamp=now, kind=CPEventKind.job_created, payload={}
+            event_id="evt-3", session_id="job-1", timestamp=now, kind=EventKind.job_created, payload={}
         )
         await subscriber(event)
         step_repo.create.assert_not_called()

--- a/backend/tests/unit/test_step_persistence.py
+++ b/backend/tests/unit/test_step_persistence.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from backend.models.events import DomainEventKind, new_event
+from backend.models.events import CPEventKind, new_event
 from backend.services.steps.persistence import StepPersistenceSubscriber
 
 
@@ -29,7 +29,7 @@ class TestStepPersistence:
             event_id="evt-1",
             session_id="job-1",
             timestamp=now,
-            kind=DomainEventKind.step_started,
+            kind=CPEventKind.step_started,
             payload={
                 "step_id": "step-1",
                 "step_number": 1,
@@ -56,7 +56,7 @@ class TestStepPersistence:
             event_id="evt-2",
             session_id="job-1",
             timestamp=now,
-            kind=DomainEventKind.step_completed,
+            kind=CPEventKind.step_completed,
             payload={
                 "step_id": "step-1",
                 "status": "done",
@@ -71,7 +71,7 @@ class TestStepPersistence:
     async def test_unrelated_event_is_noop(self, subscriber: StepPersistenceSubscriber, step_repo: AsyncMock) -> None:
         now = datetime.now(UTC)
         event = new_event(
-            event_id="evt-3", session_id="job-1", timestamp=now, kind=DomainEventKind.job_created, payload={}
+            event_id="evt-3", session_id="job-1", timestamp=now, kind=CPEventKind.job_created, payload={}
         )
         await subscriber(event)
         step_repo.create.assert_not_called()

--- a/backend/tests/unit/test_step_persistence.py
+++ b/backend/tests/unit/test_step_persistence.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, new_event
 from backend.services.steps.persistence import StepPersistenceSubscriber
 
 
@@ -25,9 +25,9 @@ class TestStepPersistence:
     @pytest.mark.asyncio
     async def test_step_started_persists_row(self, subscriber: StepPersistenceSubscriber, step_repo: AsyncMock) -> None:
         now = datetime.now(UTC)
-        event = DomainEvent(
+        event = new_event(
             event_id="evt-1",
-            job_id="job-1",
+            session_id="job-1",
             timestamp=now,
             kind=DomainEventKind.step_started,
             payload={
@@ -52,9 +52,9 @@ class TestStepPersistence:
         step_repo: AsyncMock,
     ) -> None:
         now = datetime.now(UTC)
-        event = DomainEvent(
+        event = new_event(
             event_id="evt-2",
-            job_id="job-1",
+            session_id="job-1",
             timestamp=now,
             kind=DomainEventKind.step_completed,
             payload={
@@ -70,12 +70,8 @@ class TestStepPersistence:
     @pytest.mark.asyncio
     async def test_unrelated_event_is_noop(self, subscriber: StepPersistenceSubscriber, step_repo: AsyncMock) -> None:
         now = datetime.now(UTC)
-        event = DomainEvent(
-            event_id="evt-3",
-            job_id="job-1",
-            timestamp=now,
-            kind=DomainEventKind.job_created,
-            payload={},
+        event = new_event(
+            event_id="evt-3", session_id="job-1", timestamp=now, kind=DomainEventKind.job_created, payload={}
         )
         await subscriber(event)
         step_repo.create.assert_not_called()

--- a/backend/tests/unit/test_step_tracker.py
+++ b/backend/tests/unit/test_step_tracker.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from backend.models.events import CPEventKind, SessionEvent, new_event, transcript_kind_for_role
+from backend.models.events import EventKind, SessionEvent, new_event, transcript_kind_for_role
 from backend.services.steps.tracker import StepTracker, _extract_file_path
 
 
@@ -66,7 +66,7 @@ class TestStepLifecycle:
         # Should have published step_started
         event_bus.publish.assert_called_once()
         published = event_bus.publish.call_args[0][0]
-        assert published.kind == CPEventKind.step_started
+        assert published.kind == EventKind.step_started
 
     @pytest.mark.asyncio
     async def test_turn_change_creates_new_step(self, tracker: StepTracker, event_bus: AsyncMock) -> None:
@@ -106,7 +106,7 @@ class TestStepLifecycle:
         assert tracker.current_step("job-1") is None
         # Should have published step_completed
         calls = event_bus.publish.call_args_list
-        completed_events = [c for c in calls if c[0][0].kind == CPEventKind.step_completed]
+        completed_events = [c for c in calls if c[0][0].kind == EventKind.step_completed]
         assert len(completed_events) == 1
         assert completed_events[0][0][0].payload["status"] == "completed"
 

--- a/backend/tests/unit/test_step_tracker.py
+++ b/backend/tests/unit/test_step_tracker.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from backend.models.events import DomainEventKind, SessionEvent, new_event
+from backend.models.events import CPEventKind, SessionEvent, new_event, transcript_kind_for_role
 from backend.services.steps.tracker import StepTracker, _extract_file_path
 
 
@@ -20,7 +20,7 @@ def _make_event(
 ) -> SessionEvent:
     payload = {"role": role, "content": content, "turn_id": turn_id, **extra}
     return new_event(
-        session_id=job_id, timestamp=datetime.now(UTC), kind=DomainEventKind.transcript_updated, payload=payload
+        session_id=job_id, timestamp=datetime.now(UTC), kind=transcript_kind_for_role(role), payload=payload
     )
 
 
@@ -66,7 +66,7 @@ class TestStepLifecycle:
         # Should have published step_started
         event_bus.publish.assert_called_once()
         published = event_bus.publish.call_args[0][0]
-        assert published.kind == DomainEventKind.step_started
+        assert published.kind == CPEventKind.step_started
 
     @pytest.mark.asyncio
     async def test_turn_change_creates_new_step(self, tracker: StepTracker, event_bus: AsyncMock) -> None:
@@ -106,7 +106,7 @@ class TestStepLifecycle:
         assert tracker.current_step("job-1") is None
         # Should have published step_completed
         calls = event_bus.publish.call_args_list
-        completed_events = [c for c in calls if c[0][0].kind == DomainEventKind.step_completed]
+        completed_events = [c for c in calls if c[0][0].kind == CPEventKind.step_completed]
         assert len(completed_events) == 1
         assert completed_events[0][0][0].payload["status"] == "completed"
 

--- a/backend/tests/unit/test_step_tracker.py
+++ b/backend/tests/unit/test_step_tracker.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, SessionEvent, new_event
 from backend.services.steps.tracker import StepTracker, _extract_file_path
 
 
@@ -17,14 +17,10 @@ def _make_event(
     content: str = "hello",
     turn_id: str = "turn-1",
     **extra: str,
-) -> DomainEvent:
+) -> SessionEvent:
     payload = {"role": role, "content": content, "turn_id": turn_id, **extra}
-    return DomainEvent(
-        event_id=DomainEvent.make_event_id(),
-        job_id=job_id,
-        timestamp=datetime.now(UTC),
-        kind=DomainEventKind.transcript_updated,
-        payload=payload,
+    return new_event(
+        session_id=job_id, timestamp=datetime.now(UTC), kind=DomainEventKind.transcript_updated, payload=payload
     )
 
 

--- a/backend/tests/unit/test_structural_endpoints.py
+++ b/backend/tests/unit/test_structural_endpoints.py
@@ -33,7 +33,7 @@ from backend.models.api_schemas import (
     StructuralDiffResponse,
 )
 from backend.models.domain import Job, JobState
-from backend.models.events import DomainEventKind, new_event
+from backend.models.events import CPEventKind, new_event
 
 # -- Fixtures ------------------------------------------------------------------
 
@@ -695,7 +695,7 @@ async def test_multi_session_partitions_by_event_boundaries() -> None:
         event_id="evt-1",
         session_id="job-1",
         timestamp=base_time,
-        kind=DomainEventKind.session_resumed,
+        kind=CPEventKind.session_resumed,
         payload={"session_number": 2},
     )
     event_repo = SimpleNamespace(list_by_job=AsyncMock(return_value=[resumed_event]))
@@ -752,7 +752,7 @@ async def test_multi_session_direction_change_detection() -> None:
         event_id="evt-1",
         session_id="job-1",
         timestamp=base_time,
-        kind=DomainEventKind.session_resumed,
+        kind=CPEventKind.session_resumed,
         payload={"session_number": 2},
     )
     event_repo = SimpleNamespace(list_by_job=AsyncMock(return_value=[resumed_event]))

--- a/backend/tests/unit/test_structural_endpoints.py
+++ b/backend/tests/unit/test_structural_endpoints.py
@@ -33,7 +33,7 @@ from backend.models.api_schemas import (
     StructuralDiffResponse,
 )
 from backend.models.domain import Job, JobState
-from backend.models.events import CPEventKind, new_event
+from backend.models.events import EventKind, new_event
 
 # -- Fixtures ------------------------------------------------------------------
 
@@ -695,7 +695,7 @@ async def test_multi_session_partitions_by_event_boundaries() -> None:
         event_id="evt-1",
         session_id="job-1",
         timestamp=base_time,
-        kind=CPEventKind.session_resumed,
+        kind=EventKind.session_resumed,
         payload={"session_number": 2},
     )
     event_repo = SimpleNamespace(list_by_job=AsyncMock(return_value=[resumed_event]))
@@ -752,7 +752,7 @@ async def test_multi_session_direction_change_detection() -> None:
         event_id="evt-1",
         session_id="job-1",
         timestamp=base_time,
-        kind=CPEventKind.session_resumed,
+        kind=EventKind.session_resumed,
         payload={"session_number": 2},
     )
     event_repo = SimpleNamespace(list_by_job=AsyncMock(return_value=[resumed_event]))

--- a/backend/tests/unit/test_structural_endpoints.py
+++ b/backend/tests/unit/test_structural_endpoints.py
@@ -33,7 +33,7 @@ from backend.models.api_schemas import (
     StructuralDiffResponse,
 )
 from backend.models.domain import Job, JobState
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, new_event
 
 # -- Fixtures ------------------------------------------------------------------
 
@@ -691,9 +691,9 @@ async def test_multi_session_partitions_by_event_boundaries() -> None:
     step_repo = SimpleNamespace(get_by_job=AsyncMock(return_value=[step1, step2]))
 
     # Session boundary: session_resumed event at base_time
-    resumed_event = DomainEvent(
+    resumed_event = new_event(
         event_id="evt-1",
-        job_id="job-1",
+        session_id="job-1",
         timestamp=base_time,
         kind=DomainEventKind.session_resumed,
         payload={"session_number": 2},
@@ -748,9 +748,9 @@ async def test_multi_session_direction_change_detection() -> None:
     )
     step_repo = SimpleNamespace(get_by_job=AsyncMock(return_value=[step1, step2]))
 
-    resumed_event = DomainEvent(
+    resumed_event = new_event(
         event_id="evt-1",
-        job_id="job-1",
+        session_id="job-1",
         timestamp=base_time,
         kind=DomainEventKind.session_resumed,
         payload={"session_number": 2},

--- a/backend/tests/unit/test_summarization_helpers.py
+++ b/backend/tests/unit/test_summarization_helpers.py
@@ -24,12 +24,10 @@ from backend.services.completers.summarization_service import (
 
 def _make_event(role: str, content: str, *, kind: str = "transcript_entry") -> Any:
     """Build a minimal DomainEvent-like object."""
-    from backend.models.events import DomainEvent
+    from backend.models.events import new_event
 
-    return DomainEvent.for_job(
-        job_id="j1",
-        kind=kind,
-        payload={"role": role, "content": content, "timestamp": "2025-01-01T00:00:00Z"},
+    return new_event(
+        session_id="j1", kind=kind, payload={"role": role, "content": content, "timestamp": "2025-01-01T00:00:00Z"}
     )
 
 

--- a/backend/tests/unit/test_summarization_service.py
+++ b/backend/tests/unit/test_summarization_service.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, SessionEvent, new_event
 from backend.services.completers.summarization_service import (
     SummarizationService,
     _clean_transcript,
@@ -23,22 +23,22 @@ from backend.services.completers.summarization_service import (
 # ---------------------------------------------------------------------------
 
 
-def _transcript_event(role: str, content: str, timestamp: str = "2024-01-01T00:00:00Z") -> DomainEvent:
+def _transcript_event(role: str, content: str, timestamp: str = "2024-01-01T00:00:00Z") -> SessionEvent:
     """Create a transcript_updated DomainEvent for testing."""
-    return DomainEvent(
+    return new_event(
         event_id="evt-test",
-        job_id="job-1",
+        session_id="job-1",
         timestamp=datetime.now(UTC),
         kind=DomainEventKind.transcript_updated,
         payload={"role": role, "content": content, "timestamp": timestamp},
     )
 
 
-def _diff_event(changed_files: list[dict[str, object]]) -> DomainEvent:
+def _diff_event(changed_files: list[dict[str, object]]) -> SessionEvent:
     """Create a diff_updated DomainEvent for testing."""
-    return DomainEvent(
+    return new_event(
         event_id="evt-diff",
-        job_id="job-1",
+        session_id="job-1",
         timestamp=datetime.now(UTC),
         kind=DomainEventKind.diff_updated,
         payload={"changed_files": changed_files},
@@ -148,9 +148,9 @@ class TestCleanTranscript:
         assert result[0]["content"] == "spaced content"
 
     def test_none_content_treated_as_empty(self) -> None:
-        ev = DomainEvent(
+        ev = new_event(
             event_id="evt-test",
-            job_id="job-1",
+            session_id="job-1",
             timestamp=datetime.now(UTC),
             kind=DomainEventKind.transcript_updated,
             payload={"role": "agent", "content": None},
@@ -159,9 +159,9 @@ class TestCleanTranscript:
         assert result == []
 
     def test_missing_role_skipped(self) -> None:
-        ev = DomainEvent(
+        ev = new_event(
             event_id="evt-test",
-            job_id="job-1",
+            session_id="job-1",
             timestamp=datetime.now(UTC),
             kind=DomainEventKind.transcript_updated,
             payload={"content": "no role here"},

--- a/backend/tests/unit/test_summarization_service.py
+++ b/backend/tests/unit/test_summarization_service.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from backend.models.events import CPEventKind, SessionEvent, new_event, transcript_kind_for_role
+from backend.models.events import EventKind, SessionEvent, new_event, transcript_kind_for_role
 from backend.services.completers.summarization_service import (
     SummarizationService,
     _clean_transcript,
@@ -40,7 +40,7 @@ def _diff_event(changed_files: list[dict[str, object]]) -> SessionEvent:
         event_id="evt-diff",
         session_id="job-1",
         timestamp=datetime.now(UTC),
-        kind=CPEventKind.diff_updated,
+        kind=EventKind.diff_updated,
         payload={"changed_files": changed_files},
     )
 
@@ -152,7 +152,7 @@ class TestCleanTranscript:
             event_id="evt-test",
             session_id="job-1",
             timestamp=datetime.now(UTC),
-            kind=CPEventKind.message_assistant,
+            kind=EventKind.message_assistant,
             payload={"role": "agent", "content": None},
         )
         result = _clean_transcript([ev])
@@ -163,7 +163,7 @@ class TestCleanTranscript:
             event_id="evt-test",
             session_id="job-1",
             timestamp=datetime.now(UTC),
-            kind=CPEventKind.message_assistant,
+            kind=EventKind.message_assistant,
             payload={"content": "no role here"},
         )
         result = _clean_transcript([ev])

--- a/backend/tests/unit/test_summarization_service.py
+++ b/backend/tests/unit/test_summarization_service.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from backend.models.events import DomainEventKind, SessionEvent, new_event
+from backend.models.events import CPEventKind, SessionEvent, new_event, transcript_kind_for_role
 from backend.services.completers.summarization_service import (
     SummarizationService,
     _clean_transcript,
@@ -29,7 +29,7 @@ def _transcript_event(role: str, content: str, timestamp: str = "2024-01-01T00:0
         event_id="evt-test",
         session_id="job-1",
         timestamp=datetime.now(UTC),
-        kind=DomainEventKind.transcript_updated,
+        kind=transcript_kind_for_role(role),
         payload={"role": role, "content": content, "timestamp": timestamp},
     )
 
@@ -40,7 +40,7 @@ def _diff_event(changed_files: list[dict[str, object]]) -> SessionEvent:
         event_id="evt-diff",
         session_id="job-1",
         timestamp=datetime.now(UTC),
-        kind=DomainEventKind.diff_updated,
+        kind=CPEventKind.diff_updated,
         payload={"changed_files": changed_files},
     )
 
@@ -152,7 +152,7 @@ class TestCleanTranscript:
             event_id="evt-test",
             session_id="job-1",
             timestamp=datetime.now(UTC),
-            kind=DomainEventKind.transcript_updated,
+            kind=CPEventKind.message_assistant,
             payload={"role": "agent", "content": None},
         )
         result = _clean_transcript([ev])
@@ -163,7 +163,7 @@ class TestCleanTranscript:
             event_id="evt-test",
             session_id="job-1",
             timestamp=datetime.now(UTC),
-            kind=DomainEventKind.transcript_updated,
+            kind=CPEventKind.message_assistant,
             payload={"content": "no role here"},
         )
         result = _clean_transcript([ev])

--- a/backend/tests/unit/test_trail_enricher.py
+++ b/backend/tests/unit/test_trail_enricher.py
@@ -11,7 +11,7 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from backend.config import TrailConfig
 from backend.models.db import TrailNodeRow
-from backend.models.events import CPEventKind
+from backend.models.events import EventKind
 from backend.services.trail.enricher import TrailEnricher
 from backend.services.trail.models import TrailJobState
 
@@ -739,7 +739,7 @@ class TestDrainTitles:
         await enricher.drain_titles()
         enricher._event_bus.publish.assert_called_once()
         event = enricher._event_bus.publish.call_args[0][0]
-        assert event.kind == CPEventKind.turn_summary
+        assert event.kind == EventKind.turn_summary
         assert event.payload["activity_id"] == "act-123"
         assert event.payload["title"] == "Edited main.py"
         assert event.payload["is_new_activity"] is False

--- a/backend/tests/unit/test_trail_enricher.py
+++ b/backend/tests/unit/test_trail_enricher.py
@@ -11,7 +11,7 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from backend.config import TrailConfig
 from backend.models.db import TrailNodeRow
-from backend.models.events import DomainEventKind
+from backend.models.events import CPEventKind
 from backend.services.trail.enricher import TrailEnricher
 from backend.services.trail.models import TrailJobState
 
@@ -739,7 +739,7 @@ class TestDrainTitles:
         await enricher.drain_titles()
         enricher._event_bus.publish.assert_called_once()
         event = enricher._event_bus.publish.call_args[0][0]
-        assert event.kind == DomainEventKind.turn_summary
+        assert event.kind == CPEventKind.turn_summary
         assert event.payload["activity_id"] == "act-123"
         assert event.payload["title"] == "Edited main.py"
         assert event.payload["is_new_activity"] is False

--- a/backend/tests/unit/test_trail_service.py
+++ b/backend/tests/unit/test_trail_service.py
@@ -9,7 +9,7 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from backend.models.db import Base, JobTelemetrySpanRow, TrailNodeRow
-from backend.models.events import DomainEvent, DomainEventKind
+from backend.models.events import DomainEventKind, SessionEvent, new_event
 from backend.persistence.trail_repo import TrailNodeRepository
 from backend.services.events.event_bus import EventBus
 from backend.services.trail import TrailService
@@ -55,17 +55,11 @@ def _make_event(
     kind: DomainEventKind = DomainEventKind.job_state_changed,
     job_id: str = "job-1",
     payload: dict | None = None,
-) -> DomainEvent:
-    return DomainEvent(
-        event_id=DomainEvent.make_event_id(),
-        job_id=job_id,
-        timestamp=datetime.now(UTC),
-        kind=kind,
-        payload=payload or {},
-    )
+) -> SessionEvent:
+    return new_event(session_id=job_id, timestamp=datetime.now(UTC), kind=kind, payload=payload or {})
 
 
-def _job_started_event(job_id: str = "job-1") -> DomainEvent:
+def _job_started_event(job_id: str = "job-1") -> SessionEvent:
     """Create a job_state_changed event that triggers goal node creation."""
     return _make_event(
         DomainEventKind.job_state_changed,

--- a/backend/tests/unit/test_trail_service.py
+++ b/backend/tests/unit/test_trail_service.py
@@ -9,7 +9,7 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from backend.models.db import Base, JobTelemetrySpanRow, TrailNodeRow
-from backend.models.events import CPEventKind, SessionEvent, new_event
+from backend.models.events import EventKind, SessionEvent, new_event
 from backend.persistence.trail_repo import TrailNodeRepository
 from backend.services.events.event_bus import EventBus
 from backend.services.trail import TrailService
@@ -52,7 +52,7 @@ def trail_repo(session_factory):
 
 
 def _make_event(
-    kind: CPEventKind = CPEventKind.job_state_changed,
+    kind: EventKind = EventKind.job_state_changed,
     job_id: str = "job-1",
     payload: dict | None = None,
 ) -> SessionEvent:
@@ -62,7 +62,7 @@ def _make_event(
 def _job_started_event(job_id: str = "job-1") -> SessionEvent:
     """Create a job_state_changed event that triggers goal node creation."""
     return _make_event(
-        CPEventKind.job_state_changed,
+        EventKind.job_state_changed,
         job_id=job_id,
         payload={"previous_state": "queued", "new_state": "running"},
     )
@@ -149,7 +149,7 @@ class TestTrailServiceStepNodes:
         await trail_service.handle_event(_job_started_event())
 
         event = _make_event(
-            CPEventKind.step_completed,
+            EventKind.step_completed,
             payload={
                 "step_id": "step-1",
                 "files_written": ["auth.py", "config.py"],
@@ -177,7 +177,7 @@ class TestTrailServiceStepNodes:
         await trail_service.handle_event(_job_started_event())
 
         event = _make_event(
-            CPEventKind.step_completed,
+            EventKind.step_completed,
             payload={"step_id": "step-1", "files_read": ["main.py"]},
         )
         await trail_service.handle_event(event)
@@ -189,7 +189,7 @@ class TestTrailServiceStepNodes:
         await trail_service.handle_event(_job_started_event())
 
         event = _make_event(
-            CPEventKind.step_completed,
+            EventKind.step_completed,
             payload={"step_id": "step-1"},
         )
         await trail_service.handle_event(event)
@@ -200,7 +200,7 @@ class TestTrailServiceStepNodes:
     async def test_step_without_job_start_is_skipped(self, trail_service, trail_repo):
         """Steps for unknown jobs (started before trail service) are silently skipped."""
         event = _make_event(
-            CPEventKind.step_completed,
+            EventKind.step_completed,
             job_id="unknown-job",
             payload={"step_id": "step-1"},
         )
@@ -215,7 +215,7 @@ class TestTrailServicePhaseNodes:
         await trail_service.handle_event(_job_started_event())
 
         event = _make_event(
-            CPEventKind.execution_phase_changed,
+            EventKind.execution_phase_changed,
             payload={"phase": "agent_reasoning"},
         )
         await trail_service.handle_event(event)
@@ -232,7 +232,7 @@ class TestTrailServiceTerminalNodes:
     async def test_job_completed_creates_terminal_summarize(self, trail_service, trail_repo):
         await trail_service.handle_event(_job_started_event())
 
-        event = _make_event(CPEventKind.job_completed, payload={})
+        event = _make_event(EventKind.job_completed, payload={})
         await trail_service.handle_event(event)
 
         nodes = await trail_repo.get_by_job("job-1")
@@ -245,7 +245,7 @@ class TestTrailServiceTerminalNodes:
     async def test_job_failed_creates_terminal_summarize(self, trail_service, trail_repo):
         await trail_service.handle_event(_job_started_event())
 
-        event = _make_event(CPEventKind.job_failed, payload={"reason": "timeout"})
+        event = _make_event(EventKind.job_failed, payload={"reason": "timeout"})
         await trail_service.handle_event(event)
 
         nodes = await trail_repo.get_by_job("job-1")
@@ -256,7 +256,7 @@ class TestTrailServiceTerminalNodes:
         await trail_service.handle_event(_job_started_event())
         assert "job-1" in trail_service._job_state
 
-        await trail_service.handle_event(_make_event(CPEventKind.job_completed))
+        await trail_service.handle_event(_make_event(EventKind.job_completed))
         assert "job-1" not in trail_service._job_state
 
 
@@ -267,14 +267,14 @@ class TestTrailServiceApprovalNodes:
         # Start a step
         await trail_service.handle_event(
             _make_event(
-                CPEventKind.step_started,
+                EventKind.step_started,
                 payload={"step_id": "step-1", "step_number": 1},
             )
         )
         # Approval arrives mid-step
         await trail_service.handle_event(
             _make_event(
-                CPEventKind.approval_requested,
+                EventKind.approval_requested,
                 payload={"description": "Need approval for deploy"},
             )
         )
@@ -286,7 +286,7 @@ class TestTrailServiceApprovalNodes:
         # Step completes — should flush the deferred approval
         await trail_service.handle_event(
             _make_event(
-                CPEventKind.step_completed,
+                EventKind.step_completed,
                 payload={"step_id": "step-1", "files_read": ["a.py"]},
             )
         )
@@ -305,7 +305,7 @@ class TestTrailServiceSequencing:
         for i in range(5):
             await trail_service.handle_event(
                 _make_event(
-                    CPEventKind.step_completed,
+                    EventKind.step_completed,
                     payload={"step_id": f"step-{i}", "files_read": [f"f{i}.py"]},
                 )
             )
@@ -499,7 +499,7 @@ class TestTrailServiceQueries:
         await trail_service.handle_event(_job_started_event())
         await trail_service.handle_event(
             _make_event(
-                CPEventKind.step_completed,
+                EventKind.step_completed,
                 payload={"step_id": "step-1", "files_read": ["a.py"]},
             )
         )
@@ -515,7 +515,7 @@ class TestTrailServiceQueries:
         await trail_service.handle_event(_job_started_event())
         await trail_service.handle_event(
             _make_event(
-                CPEventKind.step_completed,
+                EventKind.step_completed,
                 payload={"step_id": "step-1", "files_read": ["a.py"]},
             )
         )
@@ -530,11 +530,11 @@ class TestTrailServiceQueries:
         for i in range(3):
             await trail_service.handle_event(
                 _make_event(
-                    CPEventKind.step_completed,
+                    EventKind.step_completed,
                     payload={"step_id": f"step-{i}", "files_read": [f"f{i}.py"]},
                 )
             )
-        await trail_service.handle_event(_make_event(CPEventKind.job_completed))
+        await trail_service.handle_event(_make_event(EventKind.job_completed))
 
         summary = await trail_service.get_summary("job-1")
         assert summary["job_id"] == "job-1"
@@ -558,7 +558,7 @@ class TestTrailFullLifecycle:
         # Phase change
         await trail_service.handle_event(
             _make_event(
-                CPEventKind.execution_phase_changed,
+                EventKind.execution_phase_changed,
                 job_id=job_id,
                 payload={"phase": "agent_reasoning"},
             )
@@ -567,14 +567,14 @@ class TestTrailFullLifecycle:
         # Step 1: explore
         await trail_service.handle_event(
             _make_event(
-                CPEventKind.step_started,
+                EventKind.step_started,
                 job_id=job_id,
                 payload={"step_id": "step-1", "step_number": 1},
             )
         )
         await trail_service.handle_event(
             _make_event(
-                CPEventKind.step_completed,
+                EventKind.step_completed,
                 job_id=job_id,
                 payload={"step_id": "step-1", "files_read": ["auth.py", "config.py"]},
             )
@@ -583,14 +583,14 @@ class TestTrailFullLifecycle:
         # Step 2: modify
         await trail_service.handle_event(
             _make_event(
-                CPEventKind.step_started,
+                EventKind.step_started,
                 job_id=job_id,
                 payload={"step_id": "step-2", "step_number": 2},
             )
         )
         await trail_service.handle_event(
             _make_event(
-                CPEventKind.step_completed,
+                EventKind.step_completed,
                 job_id=job_id,
                 payload={
                     "step_id": "step-2",
@@ -604,14 +604,14 @@ class TestTrailFullLifecycle:
         # Step 3: shell (no file tools)
         await trail_service.handle_event(
             _make_event(
-                CPEventKind.step_started,
+                EventKind.step_started,
                 job_id=job_id,
                 payload={"step_id": "step-3", "step_number": 3},
             )
         )
         await trail_service.handle_event(
             _make_event(
-                CPEventKind.step_completed,
+                EventKind.step_completed,
                 job_id=job_id,
                 payload={"step_id": "step-3"},
             )
@@ -620,7 +620,7 @@ class TestTrailFullLifecycle:
         # Job completes
         await trail_service.handle_event(
             _make_event(
-                CPEventKind.job_completed,
+                EventKind.job_completed,
                 job_id=job_id,
             )
         )
@@ -771,7 +771,7 @@ class TestWriteSubNodes:
         # Fire step_completed with files_written
         await trail_service.handle_event(
             _make_event(
-                CPEventKind.step_completed,
+                EventKind.step_completed,
                 payload={
                     "step_id": "step-1",
                     "turn_id": "turn-1",
@@ -821,7 +821,7 @@ class TestWriteSubNodes:
 
         await trail_service.handle_event(
             _make_event(
-                CPEventKind.step_completed,
+                EventKind.step_completed,
                 payload={
                     "step_id": "step-1",
                     "turn_id": "turn-1",
@@ -845,7 +845,7 @@ class TestWriteSubNodes:
 
         await trail_service.handle_event(
             _make_event(
-                CPEventKind.step_completed,
+                EventKind.step_completed,
                 payload={
                     "step_id": "step-1",
                     "turn_id": "turn-1",
@@ -879,7 +879,7 @@ class TestWriteSubNodes:
 
         await trail_service.handle_event(
             _make_event(
-                CPEventKind.step_completed,
+                EventKind.step_completed,
                 payload={
                     "step_id": "step-1",
                     "turn_id": "turn-1",
@@ -906,7 +906,7 @@ class TestWriteSubNodes:
 
         await trail_service.handle_event(
             _make_event(
-                CPEventKind.step_completed,
+                EventKind.step_completed,
                 payload={
                     "step_id": "step-1",
                     # no turn_id
@@ -946,7 +946,7 @@ class TestWriteSubNodes:
 
         await trail_service.handle_event(
             _make_event(
-                CPEventKind.step_completed,
+                EventKind.step_completed,
                 payload={
                     "step_id": "step-1",
                     "turn_id": "turn-1",
@@ -958,7 +958,7 @@ class TestWriteSubNodes:
         # Another step
         await trail_service.handle_event(
             _make_event(
-                CPEventKind.step_completed,
+                EventKind.step_completed,
                 payload={
                     "step_id": "step-2",
                     "turn_id": "turn-2",
@@ -1329,7 +1329,7 @@ class TestNodeBuilderToolCall:
         # Set up: start a job and create a write sub-node
         await trail_service.handle_event(
             _make_event(
-                CPEventKind.job_state_changed,
+                EventKind.job_state_changed,
                 payload={"new_state": "running"},
             )
         )
@@ -1353,7 +1353,7 @@ class TestNodeBuilderToolCall:
         # Fire tool_call transcript event
         await trail_service.handle_event(
             _make_event(
-                CPEventKind.tool_call_completed,
+                EventKind.tool_call_completed,
                 payload={
                     "role": "tool_call",
                     "content": "str_replace_editor",
@@ -1378,7 +1378,7 @@ class TestNodeBuilderToolCall:
         """tool_call with tool_name='report_intent' is silently skipped."""
         await trail_service.handle_event(
             _make_event(
-                CPEventKind.job_state_changed,
+                EventKind.job_state_changed,
                 payload={"new_state": "running"},
             )
         )
@@ -1386,7 +1386,7 @@ class TestNodeBuilderToolCall:
         # Fire report_intent — should be ignored
         await trail_service.handle_event(
             _make_event(
-                CPEventKind.tool_call_completed,
+                EventKind.tool_call_completed,
                 payload={
                     "role": "tool_call",
                     "content": "report_intent",
@@ -1407,14 +1407,14 @@ class TestNodeBuilderToolCall:
         """assistant transcript events update the recent_messages buffer."""
         await trail_service.handle_event(
             _make_event(
-                CPEventKind.job_state_changed,
+                EventKind.job_state_changed,
                 payload={"new_state": "running"},
             )
         )
 
         await trail_service.handle_event(
             _make_event(
-                CPEventKind.message_assistant,
+                EventKind.message_assistant,
                 payload={
                     "role": "assistant",
                     "content": "I will now refactor the module.",

--- a/backend/tests/unit/test_trail_service.py
+++ b/backend/tests/unit/test_trail_service.py
@@ -9,7 +9,7 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from backend.models.db import Base, JobTelemetrySpanRow, TrailNodeRow
-from backend.models.events import DomainEventKind, SessionEvent, new_event
+from backend.models.events import CPEventKind, SessionEvent, new_event
 from backend.persistence.trail_repo import TrailNodeRepository
 from backend.services.events.event_bus import EventBus
 from backend.services.trail import TrailService
@@ -52,7 +52,7 @@ def trail_repo(session_factory):
 
 
 def _make_event(
-    kind: DomainEventKind = DomainEventKind.job_state_changed,
+    kind: CPEventKind = CPEventKind.job_state_changed,
     job_id: str = "job-1",
     payload: dict | None = None,
 ) -> SessionEvent:
@@ -62,7 +62,7 @@ def _make_event(
 def _job_started_event(job_id: str = "job-1") -> SessionEvent:
     """Create a job_state_changed event that triggers goal node creation."""
     return _make_event(
-        DomainEventKind.job_state_changed,
+        CPEventKind.job_state_changed,
         job_id=job_id,
         payload={"previous_state": "queued", "new_state": "running"},
     )
@@ -149,7 +149,7 @@ class TestTrailServiceStepNodes:
         await trail_service.handle_event(_job_started_event())
 
         event = _make_event(
-            DomainEventKind.step_completed,
+            CPEventKind.step_completed,
             payload={
                 "step_id": "step-1",
                 "files_written": ["auth.py", "config.py"],
@@ -177,7 +177,7 @@ class TestTrailServiceStepNodes:
         await trail_service.handle_event(_job_started_event())
 
         event = _make_event(
-            DomainEventKind.step_completed,
+            CPEventKind.step_completed,
             payload={"step_id": "step-1", "files_read": ["main.py"]},
         )
         await trail_service.handle_event(event)
@@ -189,7 +189,7 @@ class TestTrailServiceStepNodes:
         await trail_service.handle_event(_job_started_event())
 
         event = _make_event(
-            DomainEventKind.step_completed,
+            CPEventKind.step_completed,
             payload={"step_id": "step-1"},
         )
         await trail_service.handle_event(event)
@@ -200,7 +200,7 @@ class TestTrailServiceStepNodes:
     async def test_step_without_job_start_is_skipped(self, trail_service, trail_repo):
         """Steps for unknown jobs (started before trail service) are silently skipped."""
         event = _make_event(
-            DomainEventKind.step_completed,
+            CPEventKind.step_completed,
             job_id="unknown-job",
             payload={"step_id": "step-1"},
         )
@@ -215,7 +215,7 @@ class TestTrailServicePhaseNodes:
         await trail_service.handle_event(_job_started_event())
 
         event = _make_event(
-            DomainEventKind.execution_phase_changed,
+            CPEventKind.execution_phase_changed,
             payload={"phase": "agent_reasoning"},
         )
         await trail_service.handle_event(event)
@@ -232,7 +232,7 @@ class TestTrailServiceTerminalNodes:
     async def test_job_completed_creates_terminal_summarize(self, trail_service, trail_repo):
         await trail_service.handle_event(_job_started_event())
 
-        event = _make_event(DomainEventKind.job_completed, payload={})
+        event = _make_event(CPEventKind.job_completed, payload={})
         await trail_service.handle_event(event)
 
         nodes = await trail_repo.get_by_job("job-1")
@@ -245,7 +245,7 @@ class TestTrailServiceTerminalNodes:
     async def test_job_failed_creates_terminal_summarize(self, trail_service, trail_repo):
         await trail_service.handle_event(_job_started_event())
 
-        event = _make_event(DomainEventKind.job_failed, payload={"reason": "timeout"})
+        event = _make_event(CPEventKind.job_failed, payload={"reason": "timeout"})
         await trail_service.handle_event(event)
 
         nodes = await trail_repo.get_by_job("job-1")
@@ -256,7 +256,7 @@ class TestTrailServiceTerminalNodes:
         await trail_service.handle_event(_job_started_event())
         assert "job-1" in trail_service._job_state
 
-        await trail_service.handle_event(_make_event(DomainEventKind.job_completed))
+        await trail_service.handle_event(_make_event(CPEventKind.job_completed))
         assert "job-1" not in trail_service._job_state
 
 
@@ -267,14 +267,14 @@ class TestTrailServiceApprovalNodes:
         # Start a step
         await trail_service.handle_event(
             _make_event(
-                DomainEventKind.step_started,
+                CPEventKind.step_started,
                 payload={"step_id": "step-1", "step_number": 1},
             )
         )
         # Approval arrives mid-step
         await trail_service.handle_event(
             _make_event(
-                DomainEventKind.approval_requested,
+                CPEventKind.approval_requested,
                 payload={"description": "Need approval for deploy"},
             )
         )
@@ -286,7 +286,7 @@ class TestTrailServiceApprovalNodes:
         # Step completes — should flush the deferred approval
         await trail_service.handle_event(
             _make_event(
-                DomainEventKind.step_completed,
+                CPEventKind.step_completed,
                 payload={"step_id": "step-1", "files_read": ["a.py"]},
             )
         )
@@ -305,7 +305,7 @@ class TestTrailServiceSequencing:
         for i in range(5):
             await trail_service.handle_event(
                 _make_event(
-                    DomainEventKind.step_completed,
+                    CPEventKind.step_completed,
                     payload={"step_id": f"step-{i}", "files_read": [f"f{i}.py"]},
                 )
             )
@@ -499,7 +499,7 @@ class TestTrailServiceQueries:
         await trail_service.handle_event(_job_started_event())
         await trail_service.handle_event(
             _make_event(
-                DomainEventKind.step_completed,
+                CPEventKind.step_completed,
                 payload={"step_id": "step-1", "files_read": ["a.py"]},
             )
         )
@@ -515,7 +515,7 @@ class TestTrailServiceQueries:
         await trail_service.handle_event(_job_started_event())
         await trail_service.handle_event(
             _make_event(
-                DomainEventKind.step_completed,
+                CPEventKind.step_completed,
                 payload={"step_id": "step-1", "files_read": ["a.py"]},
             )
         )
@@ -530,11 +530,11 @@ class TestTrailServiceQueries:
         for i in range(3):
             await trail_service.handle_event(
                 _make_event(
-                    DomainEventKind.step_completed,
+                    CPEventKind.step_completed,
                     payload={"step_id": f"step-{i}", "files_read": [f"f{i}.py"]},
                 )
             )
-        await trail_service.handle_event(_make_event(DomainEventKind.job_completed))
+        await trail_service.handle_event(_make_event(CPEventKind.job_completed))
 
         summary = await trail_service.get_summary("job-1")
         assert summary["job_id"] == "job-1"
@@ -558,7 +558,7 @@ class TestTrailFullLifecycle:
         # Phase change
         await trail_service.handle_event(
             _make_event(
-                DomainEventKind.execution_phase_changed,
+                CPEventKind.execution_phase_changed,
                 job_id=job_id,
                 payload={"phase": "agent_reasoning"},
             )
@@ -567,14 +567,14 @@ class TestTrailFullLifecycle:
         # Step 1: explore
         await trail_service.handle_event(
             _make_event(
-                DomainEventKind.step_started,
+                CPEventKind.step_started,
                 job_id=job_id,
                 payload={"step_id": "step-1", "step_number": 1},
             )
         )
         await trail_service.handle_event(
             _make_event(
-                DomainEventKind.step_completed,
+                CPEventKind.step_completed,
                 job_id=job_id,
                 payload={"step_id": "step-1", "files_read": ["auth.py", "config.py"]},
             )
@@ -583,14 +583,14 @@ class TestTrailFullLifecycle:
         # Step 2: modify
         await trail_service.handle_event(
             _make_event(
-                DomainEventKind.step_started,
+                CPEventKind.step_started,
                 job_id=job_id,
                 payload={"step_id": "step-2", "step_number": 2},
             )
         )
         await trail_service.handle_event(
             _make_event(
-                DomainEventKind.step_completed,
+                CPEventKind.step_completed,
                 job_id=job_id,
                 payload={
                     "step_id": "step-2",
@@ -604,14 +604,14 @@ class TestTrailFullLifecycle:
         # Step 3: shell (no file tools)
         await trail_service.handle_event(
             _make_event(
-                DomainEventKind.step_started,
+                CPEventKind.step_started,
                 job_id=job_id,
                 payload={"step_id": "step-3", "step_number": 3},
             )
         )
         await trail_service.handle_event(
             _make_event(
-                DomainEventKind.step_completed,
+                CPEventKind.step_completed,
                 job_id=job_id,
                 payload={"step_id": "step-3"},
             )
@@ -620,7 +620,7 @@ class TestTrailFullLifecycle:
         # Job completes
         await trail_service.handle_event(
             _make_event(
-                DomainEventKind.job_completed,
+                CPEventKind.job_completed,
                 job_id=job_id,
             )
         )
@@ -771,7 +771,7 @@ class TestWriteSubNodes:
         # Fire step_completed with files_written
         await trail_service.handle_event(
             _make_event(
-                DomainEventKind.step_completed,
+                CPEventKind.step_completed,
                 payload={
                     "step_id": "step-1",
                     "turn_id": "turn-1",
@@ -821,7 +821,7 @@ class TestWriteSubNodes:
 
         await trail_service.handle_event(
             _make_event(
-                DomainEventKind.step_completed,
+                CPEventKind.step_completed,
                 payload={
                     "step_id": "step-1",
                     "turn_id": "turn-1",
@@ -845,7 +845,7 @@ class TestWriteSubNodes:
 
         await trail_service.handle_event(
             _make_event(
-                DomainEventKind.step_completed,
+                CPEventKind.step_completed,
                 payload={
                     "step_id": "step-1",
                     "turn_id": "turn-1",
@@ -879,7 +879,7 @@ class TestWriteSubNodes:
 
         await trail_service.handle_event(
             _make_event(
-                DomainEventKind.step_completed,
+                CPEventKind.step_completed,
                 payload={
                     "step_id": "step-1",
                     "turn_id": "turn-1",
@@ -906,7 +906,7 @@ class TestWriteSubNodes:
 
         await trail_service.handle_event(
             _make_event(
-                DomainEventKind.step_completed,
+                CPEventKind.step_completed,
                 payload={
                     "step_id": "step-1",
                     # no turn_id
@@ -946,7 +946,7 @@ class TestWriteSubNodes:
 
         await trail_service.handle_event(
             _make_event(
-                DomainEventKind.step_completed,
+                CPEventKind.step_completed,
                 payload={
                     "step_id": "step-1",
                     "turn_id": "turn-1",
@@ -958,7 +958,7 @@ class TestWriteSubNodes:
         # Another step
         await trail_service.handle_event(
             _make_event(
-                DomainEventKind.step_completed,
+                CPEventKind.step_completed,
                 payload={
                     "step_id": "step-2",
                     "turn_id": "turn-2",
@@ -1329,7 +1329,7 @@ class TestNodeBuilderToolCall:
         # Set up: start a job and create a write sub-node
         await trail_service.handle_event(
             _make_event(
-                DomainEventKind.job_state_changed,
+                CPEventKind.job_state_changed,
                 payload={"new_state": "running"},
             )
         )
@@ -1353,7 +1353,7 @@ class TestNodeBuilderToolCall:
         # Fire tool_call transcript event
         await trail_service.handle_event(
             _make_event(
-                DomainEventKind.transcript_updated,
+                CPEventKind.tool_call_completed,
                 payload={
                     "role": "tool_call",
                     "content": "str_replace_editor",
@@ -1378,7 +1378,7 @@ class TestNodeBuilderToolCall:
         """tool_call with tool_name='report_intent' is silently skipped."""
         await trail_service.handle_event(
             _make_event(
-                DomainEventKind.job_state_changed,
+                CPEventKind.job_state_changed,
                 payload={"new_state": "running"},
             )
         )
@@ -1386,7 +1386,7 @@ class TestNodeBuilderToolCall:
         # Fire report_intent — should be ignored
         await trail_service.handle_event(
             _make_event(
-                DomainEventKind.transcript_updated,
+                CPEventKind.tool_call_completed,
                 payload={
                     "role": "tool_call",
                     "content": "report_intent",
@@ -1407,14 +1407,14 @@ class TestNodeBuilderToolCall:
         """assistant transcript events update the recent_messages buffer."""
         await trail_service.handle_event(
             _make_event(
-                DomainEventKind.job_state_changed,
+                CPEventKind.job_state_changed,
                 payload={"new_state": "running"},
             )
         )
 
         await trail_service.handle_event(
             _make_event(
-                DomainEventKind.transcript_updated,
+                CPEventKind.message_assistant,
                 payload={
                     "role": "assistant",
                     "content": "I will now refactor the module.",

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -24,7 +24,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/sister-sessions/metrics": {
+    "/api/sidecar-sessions/metrics": {
         parameters: {
             query?: never;
             header?: never;
@@ -32,10 +32,10 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Sister Session Metrics
-         * @description Return sister session metrics (global + per-job).
+         * Sidecar Session Metrics
+         * @description Return sidecar session metrics (global + per-job).
          */
-        get: operations["sister_session_metrics_api_sister_sessions_metrics_get"];
+        get: operations["sidecar_session_metrics_api_sidecar_sessions_metrics_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -201,6 +201,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/jobs/{job_id}/gate/resolve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Resolve Gate
+         * @description Resolve a sidecar gate — approve (resume) or keep blocked.
+         */
+        post: operations["resolve_gate_api_jobs__job_id__gate_resolve_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/jobs/{job_id}/continue": {
         parameters: {
             query?: never;
@@ -309,6 +329,28 @@ export interface paths {
          *     For completed/archived jobs, returns the last stored diff snapshot.
          */
         get: operations["get_job_diff_api_jobs__job_id__diff_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/jobs/{job_id}/diff-file": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Job Diff File
+         * @description Return the full (non-truncated) diff for a single file.
+         *
+         *     Used by the frontend to lazily load large file diffs on demand.
+         */
+        get: operations["get_job_diff_file_api_jobs__job_id__diff_file_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -544,14 +586,232 @@ export interface paths {
         };
         /**
          * Get Job Story
-         * @description Return a structured code-review story with validated change references.
+         * @description Return a cached code-review story for a job.
          *
-         *     Generated on demand using a cheap LLM for connective prose, with change
-         *     references built directly from telemetry spans.  Cached on the jobs table.
-         *     Pass ?regenerate=true to force a fresh generation.
-         *     Verbosity: summary (one-sentence per file), standard (default), detailed (full rationale).
+         *     Stories are pre-generated in the background as soon as a job enters
+         *     review state.  This endpoint reads from the DB cache only — it never
+         *     blocks on LLM generation.
+         *
+         *     Pass ?regenerate=true to force a fresh generation (fire-and-forget;
+         *     returns empty immediately and the background loop will populate it).
          */
         get: operations["get_job_story_api_jobs__job_id__story_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/jobs/{job_id}/structural-diff": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Job Structural Diff
+         * @description Return structural diff analysis for a job's changes.
+         *
+         *     Uses CodeRecon's semantic_diff to classify changes by structural impact
+         *     (added/removed/modified/moved symbols) rather than raw text diff.
+         *     Computes risk scores and merge confidence per design §9.4 and §7.4.
+         */
+        get: operations["get_job_structural_diff_api_jobs__job_id__structural_diff_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/jobs/{job_id}/multi-session": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Job Multi Session
+         * @description Multi-session structural intelligence.
+         *
+         *     Returns per-session structural analysis with direction change detection
+         *     and messy-session warnings (§10).
+         */
+        get: operations["get_job_multi_session_api_jobs__job_id__multi_session_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/jobs/{job_id}/impact-graph/{symbol}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Impact Graph
+         * @description Return reference/caller graph for a symbol in the job's worktree.
+         *
+         *     Uses ReviewKit.impact() when available; returns available=False otherwise.
+         */
+        get: operations["get_impact_graph_api_jobs__job_id__impact_graph__symbol__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/jobs/{job_id}/impact-graph-batch": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Get Impact Graph Batch
+         * @description Return impact graphs for multiple symbols in a single request.
+         */
+        post: operations["get_impact_graph_batch_api_jobs__job_id__impact_graph_batch_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/jobs/{job_id}/communities": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Job Communities
+         * @description Return community-grouped structural changes for a job.
+         *
+         *     Groups changes by module community so reviewers can see which logical
+         *     areas of the codebase are affected.
+         */
+        get: operations["get_job_communities_api_jobs__job_id__communities_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/jobs/{job_id}/review-story": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Review Story
+         * @description Generate a structured review story artifact (§11).
+         *
+         *     Returns a structured document with sections: attention_required,
+         *     structural_concerns, what_changed, what_added, session_history, verdict.
+         *     Each section is populated from structural diff data.
+         */
+        get: operations["get_review_story_api_jobs__job_id__review_story_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/jobs/{job_id}/motivations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Job Motivations
+         * @description Return all motivation annotations for a job's changed files.
+         */
+        get: operations["get_job_motivations_api_jobs__job_id__motivations_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/jobs/{job_id}/covering-tests": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Job Covering Tests
+         * @description Return tests that cover definitions in the given file for a job's repo.
+         */
+        get: operations["get_job_covering_tests_api_jobs__job_id__covering_tests_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/jobs/{job_id}/line-coverage": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Job Line Coverage
+         * @description Return per-line coverage data for gutter dot rendering in the layered diff view.
+         */
+        get: operations["get_job_line_coverage_api_jobs__job_id__line_coverage_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/jobs/{job_id}/blast-radius": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Job Blast Radius
+         * @description Return blast radius analysis for a job's changed files.
+         */
+        get: operations["get_job_blast_radius_api_jobs__job_id__blast_radius_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -749,6 +1009,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/hooks/claude": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Claude Stop Hook
+         * @description Receive Claude CLI Stop hook. Returns pending operator messages.
+         *
+         *     Claude CLI calls this synchronously on every Stop event. If there are
+         *     queued operator messages, they are returned in the response body which
+         *     Claude displays to the agent.
+         */
+        post: operations["claude_stop_hook_api_hooks_claude_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/jobs/{job_id}/artifacts": {
         parameters: {
             query?: never;
@@ -829,6 +1113,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/jobs/{job_id}/workspace/file/raw": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Workspace File Raw
+         * @description Serve a workspace file with its native content type (for images, PDFs, videos, etc.).
+         */
+        get: operations["get_workspace_file_raw_api_jobs__job_id__workspace_file_raw_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/voice/transcribe": {
         parameters: {
             query?: never;
@@ -891,6 +1195,46 @@ export interface paths {
          * @description Register a repository (local path or remote URL).
          */
         post: operations["register_repo_endpoint_api_settings_repos_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/settings/repos/{repo_path}/health": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Repo Health
+         * @description Structural health status for a repository (§6.2).
+         */
+        get: operations["get_repo_health_api_settings_repos__repo_path__health_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/settings/repos/{repo_path}/summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Repo Summary
+         * @description Aggregated dashboard overview for a single repository.
+         */
+        get: operations["get_repo_summary_api_settings_repos__repo_path__summary_get"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -1072,7 +1416,7 @@ export interface paths {
         };
         /**
          * Analytics Tools
-         * @description Tool performance stats (call counts, failure rates, latency).
+         * @description Tool performance stats (call counts, failure rates, latency) + category mix.
          */
         get: operations["analytics_tools_api_analytics_tools_get"];
         put?: never;
@@ -1186,6 +1530,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/analytics/latency-drivers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Fleet Latency Drivers
+         * @description Fleet-wide latency attribution: time breakdown across all jobs.
+         */
+        get: operations["fleet_latency_drivers_api_analytics_latency_drivers_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/analytics/file-access/{job_id}": {
         parameters: {
             query?: never;
@@ -1235,7 +1599,7 @@ export interface paths {
         };
         /**
          * Turn Economics For Job
-         * @description Per-turn cost curve for a specific job.
+         * @description Per-turn cost curve for a specific job, enriched with activity tags.
          */
         get: operations["turn_economics_for_job_api_analytics_turn_economics__job_id__get"];
         put?: never;
@@ -1430,6 +1794,209 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/analytics/yield": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Analytics Yield
+         * @description Cost yield breakdown by outcome category.
+         */
+        get: operations["analytics_yield_api_analytics_yield_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/analytics/model-efficiency": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Analytics Model Efficiency
+         * @description Per-model one-shot rate and retry statistics.
+         */
+        get: operations["analytics_model_efficiency_api_analytics_model_efficiency_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/analytics/cache-efficiency": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Analytics Cache Efficiency
+         * @description Cache token hit rate by execution phase or activity bucket.
+         */
+        get: operations["analytics_cache_efficiency_api_analytics_cache_efficiency_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/analytics/file-cost": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Analytics File Cost
+         * @description Most expensive files across the fleet.
+         */
+        get: operations["analytics_file_cost_api_analytics_file_cost_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/analytics/outcome-matrix": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Analytics Outcome Matrix
+         * @description Cost breakdown by activity × job resolution.
+         */
+        get: operations["analytics_outcome_matrix_api_analytics_outcome_matrix_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/analytics/activity-phase-matrix": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Analytics Activity Phase Matrix
+         * @description Phase × activity cost heatmap across the fleet.
+         */
+        get: operations["analytics_activity_phase_matrix_api_analytics_activity_phase_matrix_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/analytics/action-purpose-matrix": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Analytics Action Purpose Matrix
+         * @description Action × purpose cost heatmap across the fleet.
+         */
+        get: operations["analytics_action_purpose_matrix_api_analytics_action_purpose_matrix_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/analytics/executive-summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Analytics Executive Summary
+         * @description Simplified 3-bucket executive view: building / thinking / wasted.
+         */
+        get: operations["analytics_executive_summary_api_analytics_executive_summary_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/analytics/export": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Analytics Export
+         * @description Export analytics data as CSV or JSON for external analysis.
+         *
+         *     ``sections`` is a comma-separated list of data sections to include.
+         *     Supported: overview, models, cost-drivers, yield, observations.
+         */
+        get: operations["analytics_export_api_analytics_export_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/analytics/sidecar-costs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Analytics Sidecar Costs
+         * @description Cost breakdown by session kind for sidecar sessions (preflight, memory, etc).
+         */
+        get: operations["analytics_sidecar_costs_api_analytics_sidecar_costs_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/notifications/vapid-key": {
         parameters: {
             query?: never;
@@ -1534,26 +2101,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/terminal/observer/{job_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Observer Terminal
-         * @description Return the observer terminal session for a running job, if one exists.
-         */
-        get: operations["get_observer_terminal_api_terminal_observer__job_id__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/api/terminal/ask": {
         parameters: {
             query?: never;
@@ -1585,33 +2132,33 @@ export interface paths {
          * Preview Proxy
          * @description Reverse-proxy a request to a local development server.
          */
-        get: operations["preview_proxy_api_preview__port___path__patch"];
+        get: operations["preview_proxy_api_preview__port___path__delete"];
         /**
          * Preview Proxy
          * @description Reverse-proxy a request to a local development server.
          */
-        put: operations["preview_proxy_api_preview__port___path__patch"];
+        put: operations["preview_proxy_api_preview__port___path__delete"];
         /**
          * Preview Proxy
          * @description Reverse-proxy a request to a local development server.
          */
-        post: operations["preview_proxy_api_preview__port___path__patch"];
+        post: operations["preview_proxy_api_preview__port___path__delete"];
         /**
          * Preview Proxy
          * @description Reverse-proxy a request to a local development server.
          */
-        delete: operations["preview_proxy_api_preview__port___path__patch"];
+        delete: operations["preview_proxy_api_preview__port___path__delete"];
         options?: never;
         /**
          * Preview Proxy
          * @description Reverse-proxy a request to a local development server.
          */
-        head: operations["preview_proxy_api_preview__port___path__patch"];
+        head: operations["preview_proxy_api_preview__port___path__delete"];
         /**
          * Preview Proxy
          * @description Reverse-proxy a request to a local development server.
          */
-        patch: operations["preview_proxy_api_preview__port___path__patch"];
+        patch: operations["preview_proxy_api_preview__port___path__delete"];
         trace?: never;
     };
     "/api/jobs/{job_id}/share": {
@@ -2018,10 +2565,240 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/metrics/chat": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Chat Ask
+         * @description Send a natural language question about telemetry data.
+         */
+        post: operations["chat_ask_api_metrics_chat_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/metrics/chat/conversations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Conversations
+         * @description List recent chat conversations.
+         */
+        get: operations["list_conversations_api_metrics_chat_conversations_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/metrics/chat/conversations/{conversation_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete Conversation
+         * @description Clear an in-memory conversation session.
+         */
+        delete: operations["delete_conversation_api_metrics_chat_conversations__conversation_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/metrics": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Custom Metrics
+         * @description List all pinned custom metrics with their current data.
+         */
+        get: operations["list_custom_metrics_api_metrics_get"];
+        put?: never;
+        /**
+         * Pin Metric
+         * @description Pin a metric as a dashboard tile.
+         */
+        post: operations["pin_metric_api_metrics_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/metrics/{metric_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete Metric
+         * @description Delete a pinned metric.
+         */
+        delete: operations["delete_metric_api_metrics__metric_id__delete"];
+        options?: never;
+        head?: never;
+        /**
+         * Update Metric
+         * @description Update a pinned metric's configuration.
+         */
+        patch: operations["update_metric_api_metrics__metric_id__patch"];
+        trace?: never;
+    };
+    "/api/sidecar-templates": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Sidecar Templates
+         * @description List all saved sidecar templates.
+         */
+        get: operations["list_sidecar_templates_api_sidecar_templates_get"];
+        put?: never;
+        /**
+         * Create Sidecar Template
+         * @description Create a new sidecar template.
+         */
+        post: operations["create_sidecar_template_api_sidecar_templates_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/sidecar-templates/{template_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Sidecar Template
+         * @description Get a single sidecar template by ID.
+         */
+        get: operations["get_sidecar_template_api_sidecar_templates__template_id__get"];
+        /**
+         * Update Sidecar Template
+         * @description Update an existing sidecar template.
+         */
+        put: operations["update_sidecar_template_api_sidecar_templates__template_id__put"];
+        post?: never;
+        /**
+         * Delete Sidecar Template
+         * @description Delete a sidecar template.
+         */
+        delete: operations["delete_sidecar_template_api_sidecar_templates__template_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/sidecar-templates/generate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Generate Sidecar Definition
+         * @description Generate a sidecar definition from a natural language description.
+         */
+        post: operations["generate_sidecar_definition_api_sidecar_templates_generate_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/jobs/{job_id}/sidecars/{sidecar_name}/fire": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Fire Sidecar
+         * @description Manually fire a sidecar's ManualCondition pipelines.
+         */
+        post: operations["fire_sidecar_api_jobs__job_id__sidecars__sidecar_name__fire_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        /** ActionPurposeCell */
+        ActionPurposeCell: {
+            /** Action */
+            action: string;
+            /** Purpose */
+            purpose: string;
+            /**
+             * Costusd
+             * @default 0
+             */
+            costUsd: number;
+            /**
+             * Callcount
+             * @default 0
+             */
+            callCount: number;
+        };
+        /** ActionPurposeMatrixResponse */
+        ActionPurposeMatrixResponse: {
+            /**
+             * Cells
+             * @default []
+             */
+            cells: components["schemas"]["ActionPurposeCell"][];
+            /**
+             * Perioddays
+             * @default 30
+             */
+            periodDays: number;
+        };
         /** ActionRuleRequest */
         ActionRuleRequest: {
             /** Matchpattern */
@@ -2043,6 +2820,57 @@ export interface components {
             reason: string;
             /** Createdat */
             createdAt: string;
+        };
+        /** ActivityPhaseCell */
+        ActivityPhaseCell: {
+            /**
+             * Activity
+             * @default
+             */
+            activity: string;
+            /**
+             * Phase
+             * @default
+             */
+            phase: string;
+            /**
+             * Costusd
+             * @default 0
+             */
+            costUsd: number;
+            /**
+             * Inputtokens
+             * @default 0
+             */
+            inputTokens: number;
+            /**
+             * Outputtokens
+             * @default 0
+             */
+            outputTokens: number;
+            /**
+             * Callcount
+             * @default 0
+             */
+            callCount: number;
+            /**
+             * Jobcount
+             * @default 0
+             */
+            jobCount: number;
+        };
+        /** ActivityPhaseMatrixResponse */
+        ActivityPhaseMatrixResponse: {
+            /**
+             * Cells
+             * @default []
+             */
+            cells: components["schemas"]["ActivityPhaseCell"][];
+            /**
+             * Perioddays
+             * @default 30
+             */
+            periodDays: number;
         };
         /** AnalyticsJobsResponse */
         AnalyticsJobsResponse: {
@@ -2240,6 +3068,8 @@ export interface components {
              * @default false
              */
             requiresExplicitApproval: boolean;
+            /** Notes */
+            notes?: string | null;
         };
         /** ArtifactListResponse */
         ArtifactListResponse: {
@@ -2271,6 +3101,53 @@ export interface components {
          * @enum {string}
          */
         ArtifactType: "diff_snapshot" | "agent_summary" | "session_snapshot" | "session_log" | "agent_plan" | "telemetry_report" | "approval_history" | "agent_log" | "document" | "custom";
+        /**
+         * BlastRadiusCandidate
+         * @description A test candidate from blast radius analysis.
+         */
+        BlastRadiusCandidate: {
+            /** Testid */
+            testId: string;
+            /** Source */
+            source: string;
+            /**
+             * Distance
+             * @default 0
+             */
+            distance: number;
+            /**
+             * Confidence
+             * @default 0
+             */
+            confidence: number;
+            /**
+             * Reason
+             * @default
+             */
+            reason: string;
+        };
+        /**
+         * BlastRadiusResponse
+         * @description Blast radius result for a job's changed files.
+         */
+        BlastRadiusResponse: {
+            /** Jobid */
+            jobId: string;
+            /**
+             * Available
+             * @default true
+             */
+            available: boolean;
+            /**
+             * Hascoveragedata
+             * @default false
+             */
+            hasCoverageData: boolean;
+            /** Candidates */
+            candidates?: components["schemas"]["BlastRadiusCandidate"][];
+            /** Coveragegaps */
+            coverageGaps?: string[];
+        };
         /** Body_transcribe_api_voice_transcribe_post */
         Body_transcribe_api_voice_transcribe_post: {
             /** Audio */
@@ -2297,15 +3174,161 @@ export interface components {
              */
             isGitRepo: boolean;
         };
+        /** CacheEfficiencyResponse */
+        CacheEfficiencyResponse: {
+            /** Period */
+            period: number;
+            /** Dimension */
+            dimension: string;
+            /**
+             * Buckets
+             * @default []
+             */
+            buckets: components["schemas"]["CacheEfficiencyRow"][];
+        };
+        /** CacheEfficiencyRow */
+        CacheEfficiencyRow: {
+            /** Bucket */
+            bucket: string;
+            /**
+             * Totalinputtokens
+             * @default 0
+             */
+            totalInputTokens: number;
+            /**
+             * Totalcachereadtokens
+             * @default 0
+             */
+            totalCacheReadTokens: number;
+            /**
+             * Totalcachewritetokens
+             * @default 0
+             */
+            totalCacheWriteTokens: number;
+            /**
+             * Cachehitrate
+             * @default 0
+             */
+            cacheHitRate: number;
+            /**
+             * Jobcount
+             * @default 0
+             */
+            jobCount: number;
+        };
         /** CleanupWorktreesResponse */
         CleanupWorktreesResponse: {
             /** Removed */
             removed: number;
         };
+        /**
+         * CommunitiesResponse
+         * @description Community-grouped structural changes for a job.
+         */
+        CommunitiesResponse: {
+            /** Jobid */
+            jobId: string;
+            /**
+             * Available
+             * @default true
+             */
+            available: boolean;
+            /** Communities */
+            communities?: components["schemas"]["CommunityGroup"][];
+            /** Unclustered */
+            unclustered?: {
+                [key: string]: unknown;
+            }[];
+        };
+        /**
+         * CommunityGroup
+         * @description A module community with its grouped changes.
+         */
+        CommunityGroup: {
+            /** Name */
+            name: string;
+            /** Changes */
+            changes?: {
+                [key: string]: unknown;
+            }[];
+            /**
+             * Totalrisk
+             * @default 0
+             */
+            totalRisk: number;
+        };
+        /**
+         * CommunityRollupSchema
+         * @description Community-level aggregation when body changes exceed cognitive cap.
+         */
+        CommunityRollupSchema: {
+            /**
+             * Name
+             * @default
+             */
+            name: string;
+            /**
+             * Changecount
+             * @default 0
+             */
+            changeCount: number;
+            /**
+             * Avgrisk
+             * @default 0
+             */
+            avgRisk: number;
+            /** Highestrisksymbol */
+            highestRiskSymbol?: string | null;
+            /**
+             * Highestrisk
+             * @default 0
+             */
+            highestRisk: number;
+            /**
+             * Summary
+             * @default
+             */
+            summary: string;
+        };
+        /** ContextHandoffPayload */
+        ContextHandoffPayload: {
+            /**
+             * Jobid
+             * @default
+             */
+            jobId: string;
+            /**
+             * Source
+             * @default
+             */
+            source: string;
+            /** Sourcesessionid */
+            sourceSessionId?: string | null;
+            /**
+             * Summary
+             * @default
+             */
+            summary: string;
+            /** Content */
+            content?: string | null;
+            /**
+             * Timestamp
+             * Format: date-time
+             * @default 0001-01-01T00:00:00
+             */
+            timestamp: string;
+        };
         /** ContinueJobRequest */
         ContinueJobRequest: {
             /** Instruction */
             instruction: string;
+        };
+        /** ConversationListResponse */
+        ConversationListResponse: {
+            /** Conversations */
+            conversations: {
+                [key: string]: unknown;
+            }[];
         };
         /** CostDriverEntry */
         CostDriverEntry: {
@@ -2395,6 +3418,50 @@ export interface components {
              */
             jobs: number;
         };
+        /**
+         * CoveringTestCandidate
+         * @description A test that covers a specific symbol.
+         */
+        CoveringTestCandidate: {
+            /** Testid */
+            testId: string;
+            /** Source */
+            source: string;
+            /**
+             * Distance
+             * @default 0
+             */
+            distance: number;
+            /**
+             * Confidence
+             * @default 0
+             */
+            confidence: number;
+            /**
+             * Reason
+             * @default
+             */
+            reason: string;
+        };
+        /**
+         * CoveringTestsResponse
+         * @description Tests covering definitions in a file.
+         */
+        CoveringTestsResponse: {
+            /** Jobid */
+            jobId: string;
+            /** Filepath */
+            filePath: string;
+            /**
+             * Available
+             * @default true
+             */
+            available: boolean;
+            /** Symbols */
+            symbols?: {
+                [key: string]: components["schemas"]["CoveringTestCandidate"][];
+            };
+        };
         /** CreateJobRequest */
         CreateJobRequest: {
             /** Repo */
@@ -2470,6 +3537,15 @@ export interface components {
             /** Name */
             name: string;
         };
+        /** CreateSidecarTemplateRequest */
+        CreateSidecarTemplateRequest: {
+            /** Name */
+            name: string;
+            /** Description */
+            description: string;
+            /** Definitionjson */
+            definitionJson: string;
+        };
         /** CreateTerminalSessionRequest */
         CreateTerminalSessionRequest: {
             /** Shell */
@@ -2494,6 +3570,83 @@ export interface components {
             /** Pid */
             pid: number;
         };
+        /** CustomMetricResponse */
+        CustomMetricResponse: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Sql */
+            sql: string;
+            /** Viz */
+            viz: string;
+            /** Vizconfig */
+            vizConfig?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Periodrelative
+             * @default true
+             */
+            periodRelative: boolean;
+            /**
+             * Pindashboard
+             * @default true
+             */
+            pinDashboard: boolean;
+            /**
+             * Pinjobpanel
+             * @default false
+             */
+            pinJobPanel: boolean;
+            /**
+             * Alertenabled
+             * @default false
+             */
+            alertEnabled: boolean;
+            /** Alertop */
+            alertOp?: string | null;
+            /** Alertvalue */
+            alertValue?: number | null;
+            /** Alertseverity */
+            alertSeverity?: string | null;
+            /** Alertcooldownhours */
+            alertCooldownHours?: number | null;
+            /**
+             * Tilesize
+             * @default 1x1
+             */
+            tileSize: string;
+            /**
+             * Position
+             * @default 0
+             */
+            position: number;
+            /** Originalquestion */
+            originalQuestion?: string | null;
+            /** Explanation */
+            explanation?: string | null;
+            /** Createdat */
+            createdAt: string;
+            /** Updatedat */
+            updatedAt: string;
+        };
+        /** CustomMetricWithDataResponse */
+        CustomMetricWithDataResponse: {
+            metric: components["schemas"]["CustomMetricResponse"];
+            /**
+             * Data
+             * @default []
+             */
+            data: unknown[];
+            /** Error */
+            error?: string | null;
+        };
+        /** CustomMetricsListResponse */
+        CustomMetricsListResponse: {
+            /** Metrics */
+            metrics: components["schemas"]["CustomMetricWithDataResponse"][];
+        };
         /** DiffFileModel */
         DiffFileModel: {
             /** Path */
@@ -2505,16 +3658,53 @@ export interface components {
             deletions: number;
             /** Hunks */
             hunks: components["schemas"]["DiffHunkModel"][];
+            /**
+             * Truncated
+             * @default false
+             */
+            truncated: boolean;
+            /** Rawsize */
+            rawSize?: number | null;
             /** Writecount */
             writeCount?: number | null;
             /** Retrycount */
             retryCount?: number | null;
+            /** Symbols */
+            symbols?: components["schemas"]["DiffFileSymbolImpact"][];
         };
         /**
          * DiffFileStatus
          * @enum {string}
          */
         DiffFileStatus: "added" | "modified" | "deleted" | "renamed";
+        /**
+         * DiffFileSymbolImpact
+         * @description A symbol in a diff file with its impact data from CodeRecon semantic_diff.
+         */
+        DiffFileSymbolImpact: {
+            /** Symbol */
+            symbol: string;
+            /** Kind */
+            kind: string;
+            /**
+             * Category
+             * @default non-structural
+             */
+            category: string;
+            /** Linerange */
+            lineRange?: number[] | null;
+            /**
+             * Refcount
+             * @default 0
+             */
+            refCount: number;
+            /** Reftiers */
+            refTiers?: {
+                [key: string]: number;
+            };
+            /** Testfiles */
+            testFiles?: string[];
+        };
         /** DiffHunkModel */
         DiffHunkModel: {
             /** Oldstart */
@@ -2548,6 +3738,34 @@ export interface components {
         DismissResponse: {
             /** Status */
             status: string;
+        };
+        /**
+         * EdgeCaseBlockSchema
+         * @description A metadata block for non-narrative content (docs, generated, vendor, etc.).
+         */
+        EdgeCaseBlockSchema: {
+            /**
+             * Kind
+             * @default
+             */
+            kind: string;
+            /**
+             * Icon
+             * @default
+             */
+            icon: string;
+            /**
+             * Title
+             * @default
+             */
+            title: string;
+            /** Files */
+            files?: string[];
+            /**
+             * Detail
+             * @default
+             */
+            detail: string;
         };
         /** EditEfficiencyCategory */
         EditEfficiencyCategory: {
@@ -2597,6 +3815,58 @@ export interface components {
          * @enum {string}
          */
         ExecutionPhase: "environment_setup" | "agent_reasoning" | "verification" | "finalization" | "post_completion";
+        /** ExecutiveSummaryResponse */
+        ExecutiveSummaryResponse: {
+            /**
+             * Buildingusd
+             * @default 0
+             */
+            buildingUsd: number;
+            /**
+             * Thinkingusd
+             * @default 0
+             */
+            thinkingUsd: number;
+            /**
+             * Wastedusd
+             * @default 0
+             */
+            wastedUsd: number;
+            /**
+             * Totalusd
+             * @default 0
+             */
+            totalUsd: number;
+            /**
+             * Buildingpct
+             * @default 0
+             */
+            buildingPct: number;
+            /**
+             * Thinkingpct
+             * @default 0
+             */
+            thinkingPct: number;
+            /**
+             * Wastedpct
+             * @default 0
+             */
+            wastedPct: number;
+            /**
+             * @default {
+             *       "retryUsd": 0,
+             *       "failedJobsUsd": 0,
+             *       "compactionUsd": 0,
+             *       "rereadsUsd": 0
+             *     }
+             */
+            wasteBreakdown: components["schemas"]["WasteBreakdown"];
+            /**
+             * Perioddays
+             * @default 30
+             */
+            periodDays: number;
+        };
         /** FileAccessEntry */
         FileAccessEntry: {
             /**
@@ -2678,6 +3948,52 @@ export interface components {
              */
             rereadCount: number;
         };
+        /** FileCostEntry */
+        FileCostEntry: {
+            /**
+             * Filepath
+             * @default
+             */
+            filePath: string;
+            /**
+             * Totalcostusd
+             * @default 0
+             */
+            totalCostUsd: number;
+            /**
+             * Totalreadcost
+             * @default 0
+             */
+            totalReadCost: number;
+            /**
+             * Totalwritecost
+             * @default 0
+             */
+            totalWriteCost: number;
+            /**
+             * Totalturns
+             * @default 0
+             */
+            totalTurns: number;
+            /**
+             * Jobcount
+             * @default 0
+             */
+            jobCount: number;
+        };
+        /** FileCostResponse */
+        FileCostResponse: {
+            /**
+             * Files
+             * @default []
+             */
+            files: components["schemas"]["FileCostEntry"][];
+            /**
+             * Perioddays
+             * @default 30
+             */
+            periodDays: number;
+        };
         /**
          * FileMotivation
          * @description Per-file motivation annotation.
@@ -2693,19 +4009,61 @@ export interface components {
              */
             unmatchedEdits: components["schemas"]["HunkMotivation"][];
         };
-        /** FleetCostDriversResponse */
-        FleetCostDriversResponse: {
+        /**
+         * FireSidecarRequest
+         * @description Optional context to pass to the sidecar's manual trigger.
+         */
+        FireSidecarRequest: {
+            /** Context */
+            context?: {
+                [key: string]: unknown;
+            } | null;
+        };
+        /** FleetFileAccessResponse */
+        FleetFileAccessResponse: {
+            /** Period */
+            period: number;
+            /**
+             * Topfiles
+             * @default []
+             */
+            topFiles: components["schemas"]["FileAccessEntry"][];
+        };
+        /**
+         * FleetLatencyDriversResponse
+         * @description Fleet-wide latency attribution response.
+         */
+        FleetLatencyDriversResponse: {
             /** Period */
             period: number;
             /** Dimension */
             dimension?: string | null;
-            /** Buckets */
-            buckets?: components["schemas"]["CostDriverEntry"][] | null;
-            /** Summary */
-            summary?: components["schemas"]["FleetCostEntry"][] | null;
+            /**
+             * Summary
+             * @default []
+             */
+            summary: components["schemas"]["FleetLatencyEntry"][];
+            /**
+             * Avgjobdurationms
+             * @default 0
+             */
+            avgJobDurationMs: number;
+            /**
+             * P50Jobdurationms
+             * @default 0
+             */
+            p50JobDurationMs: number;
+            /**
+             * P95Jobdurationms
+             * @default 0
+             */
+            p95JobDurationMs: number;
         };
-        /** FleetCostEntry */
-        FleetCostEntry: {
+        /**
+         * FleetLatencyEntry
+         * @description A single row in fleet latency breakdown.
+         */
+        FleetLatencyEntry: {
             /**
              * Dimension
              * @default
@@ -2717,52 +4075,30 @@ export interface components {
              */
             bucket: string;
             /**
-             * Costusd
+             * Avgwallclockms
              * @default 0
              */
-            costUsd: number;
+            avgWallClockMs: number;
             /**
-             * Inputtokens
+             * Avgsumdurationms
              * @default 0
              */
-            inputTokens: number;
+            avgSumDurationMs: number;
             /**
-             * Outputtokens
+             * Totalspancount
              * @default 0
              */
-            outputTokens: number;
-            /**
-             * Callcount
-             * @default 0
-             */
-            callCount: number;
+            totalSpanCount: number;
             /**
              * Jobcount
              * @default 0
              */
             jobCount: number;
             /**
-             * Avgcostperjob
+             * Avgpctoftotal
              * @default 0
              */
-            avgCostPerJob: number;
-            /**
-             * Confidence
-             * @default
-             */
-            confidence: string;
-        } & {
-            [key: string]: unknown;
-        };
-        /** FleetFileAccessResponse */
-        FleetFileAccessResponse: {
-            /** Period */
-            period: number;
-            /**
-             * Topfiles
-             * @default []
-             */
-            topFiles: components["schemas"]["FileAccessEntry"][];
+            avgPctOfTotal: number;
         };
         /** FullPolicyResponse */
         FullPolicyResponse: {
@@ -2777,6 +4113,18 @@ export interface components {
             mcpServers?: components["schemas"]["MCPServerResponse"][];
             /** Trustgrants */
             trustGrants?: components["schemas"]["TrustGrantResponse"][];
+        };
+        /** GenerateSidecarRequest */
+        GenerateSidecarRequest: {
+            /** Description */
+            description: string;
+        };
+        /** GenerateSidecarResponse */
+        GenerateSidecarResponse: {
+            /** Definition */
+            definition: {
+                [key: string]: unknown;
+            };
         };
         /**
          * GitMergeOutcome
@@ -2820,6 +4168,109 @@ export interface components {
             title: string;
             /** Why */
             why: string;
+        };
+        /**
+         * ImpactGraphBatchRequest
+         * @description Request body for batch impact graph queries.
+         */
+        ImpactGraphBatchRequest: {
+            /** Symbols */
+            symbols: string[];
+        };
+        /**
+         * ImpactGraphBatchResponse
+         * @description Batch impact graph results keyed by symbol name.
+         */
+        ImpactGraphBatchResponse: {
+            /** Jobid */
+            jobId: string;
+            /** Results */
+            results?: {
+                [key: string]: components["schemas"]["ImpactGraphResponse"];
+            };
+        };
+        /**
+         * ImpactGraphResponse
+         * @description Impact graph for a symbol — callers with tier classification.
+         */
+        ImpactGraphResponse: {
+            /** Jobid */
+            jobId: string;
+            /** Target */
+            target: string;
+            /**
+             * Available
+             * @default true
+             */
+            available: boolean;
+            /**
+             * Totalreferences
+             * @default 0
+             */
+            totalReferences: number;
+            /**
+             * Filesaffected
+             * @default 0
+             */
+            filesAffected: number;
+            /**
+             * Summary
+             * @default
+             */
+            summary: string;
+            /** References */
+            references?: components["schemas"]["ImpactReference"][];
+            /**
+             * Failcount
+             * @default 0
+             */
+            failCount: number;
+            /**
+             * Uncoveredcount
+             * @default 0
+             */
+            uncoveredCount: number;
+        };
+        /**
+         * ImpactReference
+         * @description A single reference/caller in an impact graph.
+         */
+        ImpactReference: {
+            /**
+             * Symbol
+             * @default
+             */
+            symbol: string;
+            /**
+             * File
+             * @default
+             */
+            file: string;
+            /** Line */
+            line?: number | null;
+            /**
+             * Tier
+             * @default unverified
+             */
+            tier: string;
+            /**
+             * Istest
+             * @default false
+             */
+            isTest: boolean;
+            /**
+             * Rawtier
+             * @default UNKNOWN
+             */
+            rawTier: string;
+            /** Covered */
+            covered?: boolean | null;
+            /** Testpassed */
+            testPassed?: boolean | null;
+            /** Coveringtestids */
+            coveringTestIds?: string[];
+            /** Stale */
+            stale?: boolean | null;
         };
         /** JobContextFlag */
         JobContextFlag: {
@@ -2928,6 +4379,42 @@ export interface components {
             /** Hasmore */
             hasMore: boolean;
         };
+        /**
+         * JobMode
+         * @description Execution mode for a job.
+         *
+         *     standard          — Normal execution: agent receives task and runs freely.
+         *     plan              — Plan-first: a planning session produces a structured plan,
+         *                         the operator reviews it, then a fresh implementation session
+         *                         executes the approved plan.
+         *     plan_implementing — The planning phase is done and the implementation session
+         *                         is running.  Persisted so crash recovery knows which phase
+         *                         the job is in.
+         * @enum {string}
+         */
+        JobMode: "standard" | "plan" | "plan_implementing";
+        /**
+         * JobMotivationsResponse
+         * @description All motivation annotations for a job, keyed by file path.
+         */
+        JobMotivationsResponse: {
+            /** Jobid */
+            jobId: string;
+            /**
+             * Filemotivations
+             * @default {}
+             */
+            fileMotivations: {
+                [key: string]: components["schemas"]["FileMotivation"];
+            };
+            /**
+             * Hunkmotivations
+             * @default {}
+             */
+            hunkMotivations: {
+                [key: string]: components["schemas"]["HunkMotivation"];
+            };
+        };
         /** JobResponse */
         JobResponse: {
             /** Id */
@@ -2997,6 +4484,23 @@ export interface components {
             enablePlanTracking?: boolean | null;
             /** Parentjobid */
             parentJobId?: string | null;
+            /**
+             * Source
+             * @default managed
+             */
+            source: string;
+            /** Externalsessionid */
+            externalSessionId?: string | null;
+            /** @default standard */
+            mode: components["schemas"]["JobMode"];
+            /** Totalcostusd */
+            totalCostUsd?: number | null;
+            /** Totaltokens */
+            totalTokens?: number | null;
+            /** Inputtokens */
+            inputTokens?: number | null;
+            /** Outputtokens */
+            outputTokens?: number | null;
         };
         /**
          * JobSnapshotResponse
@@ -3024,6 +4528,16 @@ export interface components {
              * @default []
              */
             turnSummaries: components["schemas"]["TurnSummaryPayload"][];
+            /**
+             * Secondarysessions
+             * @default []
+             */
+            secondarySessions: components["schemas"]["SecondarySessionResponse"][];
+            /**
+             * Contexthandoffs
+             * @default []
+             */
+            contextHandoffs: components["schemas"]["ContextHandoffPayload"][];
         };
         /**
          * JobState
@@ -3194,6 +4708,36 @@ export interface components {
             turnEconomics: components["schemas"]["TelemetryTurnEconomics"];
             /**
              * @default {
+             *       "category": [],
+             *       "activity": [],
+             *       "phase": [],
+             *       "toolType": []
+             *     }
+             */
+            latencyDrivers: components["schemas"]["TelemetryLatencyDrivers"];
+            /**
+             * @default {
+             *       "totalTurns": 0,
+             *       "peakTurnMs": 0,
+             *       "avgTurnMs": 0,
+             *       "firstHalfMs": 0,
+             *       "secondHalfMs": 0,
+             *       "turnCurve": []
+             *     }
+             */
+            turnLatency: components["schemas"]["TelemetryTurnLatency"];
+            /**
+             * Parallelismratio
+             * @default 0
+             */
+            parallelismRatio: number;
+            /**
+             * Idlems
+             * @default 0
+             */
+            idleMs: number;
+            /**
+             * @default {
              *       "stats": {
              *         "rereadCount": 0,
              *         "totalAccesses": 0,
@@ -3223,6 +4767,64 @@ export interface components {
              *     }
              */
             reviewComplexity: components["schemas"]["TelemetryReviewComplexity"];
+            /**
+             * Sidecarsessions
+             * @default []
+             */
+            sidecarSessions: components["schemas"]["SidecarSessionSummary"][];
+        };
+        /**
+         * LineCoverageResponse
+         * @description Per-line coverage for gutter rendering in the layered diff view.
+         */
+        LineCoverageResponse: {
+            /** Jobid */
+            jobId: string;
+            /** Filepath */
+            filePath: string;
+            /**
+             * Available
+             * @default true
+             */
+            available: boolean;
+            /** Coveredlines */
+            coveredLines?: number[];
+            /** Uncoveredlines */
+            uncoveredLines?: number[];
+            /**
+             * Totalinstrumented
+             * @default 0
+             */
+            totalInstrumented: number;
+            /**
+             * Linerate
+             * @default 0
+             */
+            lineRate: number;
+            /** Testsbyline */
+            testsByLine?: {
+                [key: string]: components["schemas"]["LineCoverageTestInfo"][];
+            };
+        };
+        /**
+         * LineCoverageTestInfo
+         * @description A test that covers a specific line.
+         */
+        LineCoverageTestInfo: {
+            /** Name */
+            name: string;
+            /** File */
+            file: string;
+            /**
+             * Line
+             * @default 0
+             */
+            line: number;
+            /**
+             * Status
+             * @default notrun
+             */
+            status: string;
         };
         /**
          * LogLevel
@@ -3322,6 +4924,47 @@ export interface components {
             };
             /** Createdat */
             createdAt: string;
+        };
+        /** MetricsChatMessageResponse */
+        MetricsChatMessageResponse: {
+            /** Messageid */
+            messageId: string;
+            /** Narrative */
+            narrative: string;
+            /**
+             * Error
+             * @default false
+             */
+            error: boolean;
+            /** Title */
+            title?: string | null;
+            /** Viz */
+            viz?: string | null;
+            /** Vizconfig */
+            vizConfig?: {
+                [key: string]: unknown;
+            } | null;
+            /** Vizdata */
+            vizData?: unknown[] | null;
+            /** Sqlqueries */
+            sqlQueries?: string[] | null;
+            /** Suggestion */
+            suggestion?: string | null;
+        };
+        /** MetricsChatRequest */
+        MetricsChatRequest: {
+            /** Question */
+            question: string;
+            /** Conversationid */
+            conversationId?: string | null;
+            /** Perioddays */
+            periodDays?: number | null;
+        };
+        /** MetricsChatResponse */
+        MetricsChatResponse: {
+            /** Conversationid */
+            conversationId: string;
+            message: components["schemas"]["MetricsChatMessageResponse"];
         };
         /** ModelComparisonResponse */
         ModelComparisonResponse: {
@@ -3423,6 +5066,81 @@ export interface components {
              * @default 0
              */
             costPerToolCall: number;
+            /**
+             * Costperdiffline
+             * @default 0
+             */
+            costPerDiffLine: number;
+        };
+        /** ModelCostMixEntry */
+        ModelCostMixEntry: {
+            /** Model */
+            model: string;
+            /**
+             * Costpermtok
+             * @default 0
+             */
+            costPerMtok: number;
+            /**
+             * Totaltokens
+             * @default 0
+             */
+            totalTokens: number;
+            /**
+             * Totalcostusd
+             * @default 0
+             */
+            totalCostUsd: number;
+            /**
+             * Pctoftokens
+             * @default 0
+             */
+            pctOfTokens: number;
+        };
+        /** ModelEfficiencyResponse */
+        ModelEfficiencyResponse: {
+            /** Period */
+            period: number;
+            /**
+             * Models
+             * @default []
+             */
+            models: components["schemas"]["ModelEfficiencyRow"][];
+        };
+        /** ModelEfficiencyRow */
+        ModelEfficiencyRow: {
+            /** Model */
+            model: string;
+            /**
+             * Editturns
+             * @default 0
+             */
+            editTurns: number;
+            /**
+             * Oneshotturns
+             * @default 0
+             */
+            oneShotTurns: number;
+            /**
+             * Retries
+             * @default 0
+             */
+            retries: number;
+            /**
+             * Oneshotrate
+             * @default 0
+             */
+            oneShotRate: number;
+            /**
+             * Retryrate
+             * @default 0
+             */
+            retryRate: number;
+            /**
+             * Jobcount
+             * @default 0
+             */
+            jobCount: number;
         };
         /**
          * ModelInfoResponse
@@ -3524,6 +5242,28 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /**
+         * MultiSessionResponse
+         * @description Multi-session structural intelligence for a job (§10).
+         */
+        MultiSessionResponse: {
+            /** Jobid */
+            jobId: string;
+            /**
+             * Available
+             * @default true
+             */
+            available: boolean;
+            /**
+             * Sessions
+             * @default []
+             */
+            sessions: components["schemas"]["SessionSegment"][];
+            /** Directionchanges */
+            directionChanges?: {
+                [key: string]: unknown;
+            }[];
+        };
         /** ObservationEntry */
         ObservationEntry: {
             /**
@@ -3551,6 +5291,27 @@ export interface components {
              * @default
              */
             detail: string;
+            /**
+             * Evidence
+             * @default {}
+             */
+            evidence: {
+                [key: string]: unknown;
+            };
+            /**
+             * Jobcount
+             * @default 0
+             */
+            jobCount: number;
+            /**
+             * Totalwasteusd
+             * @default 0
+             */
+            totalWasteUsd: number;
+            /** Firstseenat */
+            firstSeenAt?: string | null;
+            /** Lastseenat */
+            lastSeenAt?: string | null;
         } & {
             [key: string]: unknown;
         };
@@ -3561,6 +5322,57 @@ export interface components {
              * @default []
              */
             observations: components["schemas"]["ObservationEntry"][];
+        };
+        /** OutcomeMatrixCell */
+        OutcomeMatrixCell: {
+            /**
+             * Activity
+             * @default
+             */
+            activity: string;
+            /**
+             * Resolution
+             * @default
+             */
+            resolution: string;
+            /**
+             * Costusd
+             * @default 0
+             */
+            costUsd: number;
+            /**
+             * Inputtokens
+             * @default 0
+             */
+            inputTokens: number;
+            /**
+             * Outputtokens
+             * @default 0
+             */
+            outputTokens: number;
+            /**
+             * Jobcount
+             * @default 0
+             */
+            jobCount: number;
+        };
+        /** OutcomeMatrixResponse */
+        OutcomeMatrixResponse: {
+            /**
+             * Cells
+             * @default []
+             */
+            cells: components["schemas"]["OutcomeMatrixCell"][];
+            /**
+             * Perioddays
+             * @default 30
+             */
+            periodDays: number;
+            /**
+             * Totalwasteusd
+             * @default 0
+             */
+            totalWasteUsd: number;
         };
         /** PathRuleRequest */
         PathRuleRequest: {
@@ -3583,6 +5395,66 @@ export interface components {
             reason: string;
             /** Createdat */
             createdAt: string;
+        };
+        /**
+         * PatternGroupSchema
+         * @description A group of changes sharing a common structural pattern.
+         */
+        PatternGroupSchema: {
+            /**
+             * Pattern
+             * @default
+             */
+            pattern: string;
+            /**
+             * Count
+             * @default 0
+             */
+            count: number;
+            /** Files */
+            files?: string[];
+            /**
+             * Summary
+             * @default
+             */
+            summary: string;
+        };
+        /** PinMetricRequest */
+        PinMetricRequest: {
+            /** Name */
+            name: string;
+            /** Sql */
+            sql: string;
+            /** Viz */
+            viz: string;
+            /** Vizconfig */
+            vizConfig?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Periodrelative
+             * @default true
+             */
+            periodRelative: boolean;
+            /**
+             * Pindashboard
+             * @default true
+             */
+            pinDashboard: boolean;
+            /**
+             * Pinjobpanel
+             * @default false
+             */
+            pinJobPanel: boolean;
+            /**
+             * Tilesize
+             * @default 1x1
+             */
+            tileSize: string;
+            /** Originalquestion */
+            originalQuestion?: string | null;
+            /** Explanation */
+            explanation?: string | null;
         };
         /**
          * PlanStepPayload
@@ -3687,20 +5559,14 @@ export interface components {
          * @description Action policy preset — controls how the policy router classifies agent actions.
          *
          *     autonomous — Contained actions auto-approved. Non-contained actions gated.
+         *                  Monitor handles gate-tier decisions.
          *     supervised — Reversible + contained auto-approved. Irreversible or
-         *                  non-contained actions gated.
+         *                  non-contained actions gated. Monitor handles gate-tier decisions.
          *     locked     — Reversible + contained get checkpointed. Everything else gated.
+         *                  Monitor disabled — all gates go directly to human.
          * @enum {string}
          */
         Preset: "autonomous" | "supervised" | "locked";
-        /**
-         * JobMode
-         * @description Execution mode for a job.
-         *     standard — Normal single-phase execution.
-         *     plan     — Plan-first: agent produces a plan, operator reviews, then implementation runs.
-         * @enum {string}
-         */
-        JobMode: "standard" | "plan";
         /** ProgressHeadlinePayload */
         ProgressHeadlinePayload: {
             /** Jobid */
@@ -3738,6 +5604,27 @@ export interface components {
             /** Cloned */
             cloned: boolean;
         };
+        /**
+         * RepoCostSummary
+         * @description Aggregated cost for a repo over a time period.
+         */
+        RepoCostSummary: {
+            /**
+             * Totalcostusd
+             * @default 0
+             */
+            totalCostUsd: number;
+            /**
+             * Totaljobs
+             * @default 0
+             */
+            totalJobs: number;
+            /**
+             * Totaltokens
+             * @default 0
+             */
+            totalTokens: number;
+        };
         /** RepoDetailResponse */
         RepoDetailResponse: {
             /** Path */
@@ -3755,6 +5642,71 @@ export interface components {
             activeJobCount: number;
             /** Platform */
             platform?: string | null;
+        };
+        /**
+         * RepoHealthResponse
+         * @description Structural health status for a repository (§6.2).
+         */
+        RepoHealthResponse: {
+            /** Repo */
+            repo: string;
+            /**
+             * Available
+             * @default false
+             */
+            available: boolean;
+            /** Indexstatus */
+            indexStatus?: string | null;
+            /**
+             * Symbolcount
+             * @default 0
+             */
+            symbolCount: number;
+            /**
+             * Filecount
+             * @default 0
+             */
+            fileCount: number;
+            /** Lastindexedsha */
+            lastIndexedSha?: string | null;
+            /**
+             * Communitycount
+             * @default 0
+             */
+            communityCount: number;
+            /**
+             * Cyclecount
+             * @default 0
+             */
+            cycleCount: number;
+            /**
+             * Stale
+             * @default false
+             */
+            stale: boolean;
+        };
+        /**
+         * RepoJobSummary
+         * @description Minimal job info for repo dashboard.
+         */
+        RepoJobSummary: {
+            /** Id */
+            id: string;
+            /** Title */
+            title?: string | null;
+            /** State */
+            state: string;
+            /**
+             * Createdat
+             * Format: date-time
+             */
+            createdAt: string;
+            /** Completedat */
+            completedAt?: string | null;
+            /** Totalcostusd */
+            totalCostUsd?: number | null;
+            /** Model */
+            model?: string | null;
         };
         /** RepoListResponse */
         RepoListResponse: {
@@ -3812,6 +5764,41 @@ export interface components {
             [key: string]: unknown;
         };
         /**
+         * RepoSummaryResponse
+         * @description Aggregated overview for a single repo dashboard.
+         */
+        RepoSummaryResponse: {
+            /** Path */
+            path: string;
+            /** Originurl */
+            originUrl?: string | null;
+            /** Basebranch */
+            baseBranch?: string | null;
+            /** Currentbranch */
+            currentBranch?: string | null;
+            /** Platform */
+            platform?: string | null;
+            /**
+             * Recentjobs
+             * @default []
+             */
+            recentJobs: components["schemas"]["RepoJobSummary"][];
+            /**
+             * Activejobcount
+             * @default 0
+             */
+            activeJobCount: number;
+            /**
+             * @default {
+             *       "totalCostUsd": 0,
+             *       "totalJobs": 0,
+             *       "totalTokens": 0
+             *     }
+             */
+            cost: components["schemas"]["RepoCostSummary"];
+            health?: components["schemas"]["RepoHealthResponse"] | null;
+        };
+        /**
          * Resolution
          * @description User-facing disposition of a completed job.
          *
@@ -3829,6 +5816,8 @@ export interface components {
         /** ResolveApprovalRequest */
         ResolveApprovalRequest: {
             resolution: components["schemas"]["ApprovalResolution"];
+            /** Notes */
+            notes?: string | null;
         };
         /**
          * ResolveBatchRequest
@@ -3849,9 +5838,30 @@ export interface components {
             /** Resolved */
             resolved: boolean;
         };
+        /**
+         * ResolveGateRequest
+         * @description Operator resolution for a sidecar gate verdict.
+         */
+        ResolveGateRequest: {
+            /**
+             * Action
+             * @description 'approve' or 'reject'
+             */
+            action: string;
+            /**
+             * Message
+             * @description Optional follow-up message to the agent
+             */
+            message?: string | null;
+        };
         /** ResolveJobRequest */
         ResolveJobRequest: {
             action: components["schemas"]["ResolutionAction"];
+            /**
+             * Confirmlowconfidence
+             * @default false
+             */
+            confirmLowConfidence: boolean;
         };
         /** ResolveJobResponse */
         ResolveJobResponse: {
@@ -3910,6 +5920,94 @@ export interface components {
              * @default 0
              */
             retryPct: number;
+        };
+        /**
+         * ReviewStoryHeader
+         * @description Header block for the review story.
+         */
+        ReviewStoryHeader: {
+            /**
+             * Title
+             * @default
+             */
+            title: string;
+            /**
+             * Filecount
+             * @default 0
+             */
+            fileCount: number;
+            /**
+             * Breakingcount
+             * @default 0
+             */
+            breakingCount: number;
+            /** Mergeconfidence */
+            mergeConfidence?: string | null;
+        };
+        /**
+         * ReviewStoryResponse
+         * @description Structured review story artifact (§11).
+         */
+        ReviewStoryResponse: {
+            /** Jobid */
+            jobId: string;
+            /**
+             * Available
+             * @default true
+             */
+            available: boolean;
+            /**
+             * Collapsed
+             * @default false
+             */
+            collapsed: boolean;
+            header?: components["schemas"]["ReviewStoryHeader"] | null;
+            /** Attentionrequired */
+            attentionRequired?: {
+                [key: string]: unknown;
+            }[];
+            /** Structuralconcerns */
+            structuralConcerns?: {
+                [key: string]: unknown;
+            }[];
+            /** Whatchanged */
+            whatChanged?: {
+                [key: string]: unknown;
+            }[];
+            /** Whatadded */
+            whatAdded?: {
+                [key: string]: unknown;
+            }[];
+            /**
+             * Nonstructuralcount
+             * @default 0
+             */
+            nonStructuralCount: number;
+            /** Edgecases */
+            edgeCases?: components["schemas"]["EdgeCaseBlockSchema"][];
+            /** Communityrollups */
+            communityRollups?: components["schemas"]["CommunityRollupSchema"][];
+            /** Patterngroups */
+            patternGroups?: components["schemas"]["PatternGroupSchema"][];
+            verdict?: components["schemas"]["ReviewStoryVerdict"] | null;
+        };
+        /**
+         * ReviewStoryVerdict
+         * @description Verdict section of the review story.
+         */
+        ReviewStoryVerdict: {
+            /**
+             * Confidence
+             * @default MEDIUM
+             */
+            confidence: string;
+            /** Blockers */
+            blockers?: string[];
+            /**
+             * Summary
+             * @default
+             */
+            summary: string;
         };
         /** SDKInfoResponse */
         SDKInfoResponse: {
@@ -4014,12 +6112,27 @@ export interface components {
         };
         /** ScorecardResponse */
         ScorecardResponse: {
+            /**
+             * Period
+             * @default 0
+             */
+            period: number;
             activity: components["schemas"]["ScorecardActivity"];
             /**
              * Budget
              * @default []
              */
             budget: components["schemas"]["ScorecardBudget"][];
+            /**
+             * Avgcostpermtok
+             * @default 0
+             */
+            avgCostPerMtok: number;
+            /**
+             * Modelcostmix
+             * @default []
+             */
+            modelCostMix: components["schemas"]["ModelCostMixEntry"][];
             /** Quotajson */
             quotaJson?: string | null;
             /**
@@ -4032,6 +6145,130 @@ export interface components {
              * @default 0
              */
             dailySpendLimitUsd: number;
+            /**
+             * Monthlybudgetusd
+             * @default 0
+             */
+            monthlyBudgetUsd: number;
+            /**
+             * Monthspendusd
+             * @default 0
+             */
+            monthSpendUsd: number;
+            /**
+             * Projectedmonthendusd
+             * @default 0
+             */
+            projectedMonthEndUsd: number;
+            /**
+             * Dayselapsed
+             * @default 0
+             */
+            daysElapsed: number;
+            /**
+             * Daysinmonth
+             * @default 0
+             */
+            daysInMonth: number;
+            /**
+             * Dailyavgusd
+             * @default 0
+             */
+            dailyAvgUsd: number;
+            /**
+             * Pctmonthlybudgetused
+             * @default 0
+             */
+            pctMonthlyBudgetUsed: number;
+            /**
+             * Costperdiffline
+             * @default 0
+             */
+            costPerDiffLine: number;
+            /**
+             * Totaldifflines
+             * @default 0
+             */
+            totalDiffLines: number;
+            /**
+             * Compactioncostusd
+             * @default 0
+             */
+            compactionCostUsd: number;
+            /**
+             * Compactiontokens
+             * @default 0
+             */
+            compactionTokens: number;
+        };
+        /** SecondarySessionEntryResponse */
+        SecondarySessionEntryResponse: {
+            /** Seq */
+            seq: number;
+            /** Kind */
+            kind: string;
+            /** Content */
+            content: string;
+            /** Toolname */
+            toolName?: string | null;
+            /** Toolargs */
+            toolArgs?: string | null;
+            /** Durationms */
+            durationMs?: number | null;
+            /** Toolresult */
+            toolResult?: string | null;
+            /** Tooldisplay */
+            toolDisplay?: string | null;
+            /** Tooldisplayfull */
+            toolDisplayFull?: string | null;
+            /** Toolsuccess */
+            toolSuccess?: boolean | null;
+            /** Toolissue */
+            toolIssue?: string | null;
+            /** Toolvisibility */
+            toolVisibility?: string | null;
+        };
+        /** SecondarySessionResponse */
+        SecondarySessionResponse: {
+            /** Id */
+            id: string;
+            /** Kind */
+            kind: string;
+            /** Name */
+            name: string;
+            /** Icon */
+            icon: string;
+            /** Status */
+            status: string;
+            /**
+             * Startedat
+             * Format: date-time
+             */
+            startedAt: string;
+            /** Completedat */
+            completedAt?: string | null;
+            /** Output */
+            output?: string | null;
+            /**
+             * Inputtokens
+             * @default 0
+             */
+            inputTokens: number;
+            /**
+             * Outputtokens
+             * @default 0
+             */
+            outputTokens: number;
+            /**
+             * Costusd
+             * @default 0
+             */
+            costUsd: number;
+            /**
+             * Entries
+             * @default []
+             */
+            entries: components["schemas"]["SecondarySessionEntryResponse"][];
         };
         /** SendMessageRequest */
         SendMessageRequest: {
@@ -4047,6 +6284,32 @@ export interface components {
              * Format: date-time
              */
             timestamp: string;
+        };
+        /**
+         * SessionSegment
+         * @description Structural analysis of a single agent session.
+         */
+        SessionSegment: {
+            /** Sessionnumber */
+            sessionNumber: number;
+            /** Startsha */
+            startSha?: string | null;
+            /** Endsha */
+            endSha?: string | null;
+            /**
+             * Changes
+             * @default []
+             */
+            changes: components["schemas"]["StructuralChange"][];
+            /**
+             * Risk
+             * @default 0
+             */
+            risk: number;
+            /** Warnings */
+            warnings?: {
+                [key: string]: unknown;
+            }[];
         };
         /** SettingsResponse */
         SettingsResponse: {
@@ -4074,6 +6337,12 @@ export interface components {
             verifyPrompt: string;
             /** Selfreviewprompt */
             selfReviewPrompt: string;
+            /** Clisidecars */
+            cliSidecars: string[] | null;
+            /** Codereconsplade */
+            codereconSplade: boolean;
+            /** Codereconcrossencoder */
+            codereconCrossEncoder: boolean;
         };
         /** ShareTokenResponse */
         ShareTokenResponse: {
@@ -4124,8 +6393,49 @@ export interface components {
              */
             commands: components["schemas"]["ShellCommandEntry"][];
         };
-        /** SisterSessionGlobalMetrics */
-        SisterSessionGlobalMetrics: {
+        /**
+         * SidecarCostEntry
+         * @description Fleet-level cost breakdown for a single sidecar session kind.
+         */
+        SidecarCostEntry: {
+            /**
+             * Sessionkind
+             * @default
+             */
+            sessionKind: string;
+            /**
+             * Sessioncount
+             * @default 0
+             */
+            sessionCount: number;
+            /**
+             * Totalcostusd
+             * @default 0
+             */
+            totalCostUsd: number;
+            /**
+             * Inputtokens
+             * @default 0
+             */
+            inputTokens: number;
+            /**
+             * Outputtokens
+             * @default 0
+             */
+            outputTokens: number;
+            /**
+             * Llmcallcount
+             * @default 0
+             */
+            llmCallCount: number;
+            /**
+             * Toolcallcount
+             * @default 0
+             */
+            toolCallCount: number;
+        };
+        /** SidecarSessionGlobalMetrics */
+        SidecarSessionGlobalMetrics: {
             /** Totalcalls */
             totalCalls: number;
             /** Avglatencyms */
@@ -4137,8 +6447,8 @@ export interface components {
             /** Warmtokens */
             warmTokens: number;
         };
-        /** SisterSessionJobMetrics */
-        SisterSessionJobMetrics: {
+        /** SidecarSessionJobMetrics */
+        SidecarSessionJobMetrics: {
             /** Callcount */
             callCount: number;
             /** Avglatencyms */
@@ -4152,13 +6462,77 @@ export interface components {
             /** Costusd */
             costUsd: number;
         };
-        /** SisterSessionMetricsResponse */
-        SisterSessionMetricsResponse: {
-            global: components["schemas"]["SisterSessionGlobalMetrics"];
+        /** SidecarSessionMetricsResponse */
+        SidecarSessionMetricsResponse: {
+            global: components["schemas"]["SidecarSessionGlobalMetrics"];
             /** Jobs */
             jobs: {
-                [key: string]: components["schemas"]["SisterSessionJobMetrics"];
+                [key: string]: components["schemas"]["SidecarSessionJobMetrics"];
             };
+        };
+        /**
+         * SidecarSessionSummary
+         * @description Per-session-kind cost/token summary for sidecar sessions within a job.
+         */
+        SidecarSessionSummary: {
+            /**
+             * Sessionkind
+             * @default
+             */
+            sessionKind: string;
+            /**
+             * Inputtokens
+             * @default 0
+             */
+            inputTokens: number;
+            /**
+             * Outputtokens
+             * @default 0
+             */
+            outputTokens: number;
+            /**
+             * Totalcostusd
+             * @default 0
+             */
+            totalCostUsd: number;
+            /**
+             * Llmcallcount
+             * @default 0
+             */
+            llmCallCount: number;
+            /**
+             * Toolcallcount
+             * @default 0
+             */
+            toolCallCount: number;
+        };
+        /** SidecarTemplateListResponse */
+        SidecarTemplateListResponse: {
+            /** Items */
+            items: components["schemas"]["SidecarTemplateResponse"][];
+        };
+        /** SidecarTemplateResponse */
+        SidecarTemplateResponse: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Description */
+            description: string;
+            /** Definitionjson */
+            definitionJson: string;
+            /**
+             * Createdat
+             * Format: date-time
+             */
+            createdAt: string;
+            /** Lastusedat */
+            lastUsedAt: string | null;
+            /**
+             * Enabled
+             * @default true
+             */
+            enabled: boolean;
         };
         /**
          * StepDiffPayload
@@ -4201,14 +6575,22 @@ export interface components {
         /**
          * StoryBlock
          * @description A single block in a structured code-review story.
+         *
+         *     Block types:
+         *     - ``narrative``: prose text connecting references and beats
+         *     - ``reference``: validated code change with file/snippet data
+         *     - ``beat``: cognitive turning point (decision, backtrack, insight, verify)
+         *     - ``heading``: section title for story structure
          */
         StoryBlock: {
             /** Type */
             type: string;
             /** Text */
             text?: string | null;
+            /** Beatkind */
+            beatKind?: string | null;
             /** Spanid */
-            spanId?: number | null;
+            spanId?: string | null;
             /** Stepnumber */
             stepNumber?: number | null;
             /** Steptitle */
@@ -4221,10 +6603,15 @@ export interface components {
             turnId?: string | null;
             /** Editcount */
             editCount?: number | null;
+            /** Snippet */
+            snippet?: string | null;
+            /** Action */
+            action?: string | null;
         };
         /**
          * StoryResponse
-         * @description Structured code-review story with validated change references.
+         * @description Structured code-review story with validated change references
+         *     and agent cognitive beats.
          */
         StoryResponse: {
             /** Jobid */
@@ -4240,10 +6627,93 @@ export interface components {
              */
             cached: boolean;
             /**
-             * Verbosity
-             * @default standard
+             * Beatcount
+             * @default 0
              */
-            verbosity: string;
+            beatCount: number;
+            /**
+             * Hasdecisions
+             * @default false
+             */
+            hasDecisions: boolean;
+            /**
+             * Hasbacktracks
+             * @default false
+             */
+            hasBacktracks: boolean;
+            /**
+             * Pending
+             * @default false
+             */
+            pending: boolean;
+        };
+        /**
+         * StructuralChange
+         * @description A single structural change detected by semantic diff.
+         */
+        StructuralChange: {
+            /** Kind */
+            kind: string;
+            /** Symbol */
+            symbol?: string | null;
+            /** File */
+            file: string;
+            /** Summary */
+            summary?: string | null;
+            /**
+             * Category
+             * @default non-structural
+             */
+            category: string;
+            /**
+             * Refcount
+             * @default 0
+             */
+            refCount: number;
+            /** Reftiers */
+            refTiers?: {
+                [key: string]: number;
+            };
+            /** Testfiles */
+            testFiles?: string[];
+            /**
+             * Risk
+             * @default 0
+             */
+            risk: number;
+            /** Linerange */
+            lineRange?: number[] | null;
+            /** Coverageconfidence */
+            coverageConfidence?: string | null;
+        };
+        /**
+         * StructuralDiffResponse
+         * @description Structural diff result for a job's changes.
+         */
+        StructuralDiffResponse: {
+            /** Jobid */
+            jobId: string;
+            /**
+             * Summary
+             * @default
+             */
+            summary: string;
+            /**
+             * Changes
+             * @default []
+             */
+            changes: components["schemas"]["StructuralChange"][];
+            /**
+             * Available
+             * @default true
+             */
+            available: boolean;
+            /** Mergeconfidence */
+            mergeConfidence?: string | null;
+            /** Triage */
+            triage?: {
+                [key: string]: number;
+            };
         };
         /** SubscriptionRequest */
         SubscriptionRequest: {
@@ -4304,6 +6774,12 @@ export interface components {
              * @default 0
              */
             callCount: number;
+            /** Activity */
+            activity?: string | null;
+            /** Intent */
+            intent?: string | null;
+            /** Actions */
+            actions?: components["schemas"]["TurnAction"][] | null;
         };
         /** TelemetryCostDrivers */
         TelemetryCostDrivers: {
@@ -4396,6 +6872,83 @@ export interface components {
              * @default 0
              */
             rereadCount: number;
+        };
+        /**
+         * TelemetryLatencyBucket
+         * @description A single bucket within a latency attribution dimension.
+         */
+        TelemetryLatencyBucket: {
+            /**
+             * Dimension
+             * @default unknown
+             */
+            dimension: string;
+            /**
+             * Bucket
+             * @default unknown
+             */
+            bucket: string;
+            /**
+             * Wallclockms
+             * @default 0
+             */
+            wallClockMs: number;
+            /**
+             * Sumdurationms
+             * @default 0
+             */
+            sumDurationMs: number;
+            /**
+             * Spancount
+             * @default 0
+             */
+            spanCount: number;
+            /**
+             * P50Ms
+             * @default 0
+             */
+            p50Ms: number;
+            /**
+             * P95Ms
+             * @default 0
+             */
+            p95Ms: number;
+            /**
+             * Maxms
+             * @default 0
+             */
+            maxMs: number;
+            /**
+             * Pctoftotal
+             * @default 0
+             */
+            pctOfTotal: number;
+        };
+        /**
+         * TelemetryLatencyDrivers
+         * @description Latency breakdown by multiple dimensions.
+         */
+        TelemetryLatencyDrivers: {
+            /**
+             * Category
+             * @default []
+             */
+            category: components["schemas"]["TelemetryLatencyBucket"][];
+            /**
+             * Activity
+             * @default []
+             */
+            activity: components["schemas"]["TelemetryLatencyBucket"][];
+            /**
+             * Phase
+             * @default []
+             */
+            phase: components["schemas"]["TelemetryLatencyBucket"][];
+            /**
+             * Tooltype
+             * @default []
+             */
+            toolType: components["schemas"]["TelemetryLatencyBucket"][];
         };
         /** TelemetryLlmCall */
         TelemetryLlmCall: {
@@ -4519,6 +7072,18 @@ export interface components {
         TelemetryToolCall: {
             /** Name */
             name: string;
+            /** Displaylabel */
+            displayLabel?: string | null;
+            /**
+             * Activity
+             * @default overhead
+             */
+            activity: string;
+            /**
+             * Toolcategory
+             * @default other
+             */
+            toolCategory: string;
             /**
              * Durationms
              * @default 0
@@ -4571,6 +7136,42 @@ export interface components {
              * @default []
              */
             turnCurve: components["schemas"]["TelemetryCostBucket"][];
+        };
+        /**
+         * TelemetryTurnLatency
+         * @description Turn latency summary for a single job.
+         */
+        TelemetryTurnLatency: {
+            /**
+             * Totalturns
+             * @default 0
+             */
+            totalTurns: number;
+            /**
+             * Peakturnms
+             * @default 0
+             */
+            peakTurnMs: number;
+            /**
+             * Avgturnms
+             * @default 0
+             */
+            avgTurnMs: number;
+            /**
+             * Firsthalfms
+             * @default 0
+             */
+            firstHalfMs: number;
+            /**
+             * Secondhalfms
+             * @default 0
+             */
+            secondHalfMs: number;
+            /**
+             * Turncurve
+             * @default []
+             */
+            turnCurve: components["schemas"]["TelemetryLatencyBucket"][];
         };
         /** TerminalAskRequest */
         TerminalAskRequest: {
@@ -4888,12 +7489,20 @@ export interface components {
             stepId?: string | null;
             /** Stepnumber */
             stepNumber?: number | null;
+            /** Sidecarname */
+            sidecarName?: string | null;
+            /** Sidecaricon */
+            sidecarIcon?: string | null;
+            /** Sidecardescription */
+            sidecarDescription?: string | null;
+            /** Sidecartemplateid */
+            sidecarTemplateId?: string | null;
         };
         /**
          * TranscriptRole
          * @enum {string}
          */
-        TranscriptRole: "agent" | "agent_delta" | "operator" | "tool_call" | "tool_running" | "tool_output_delta" | "reasoning" | "reasoning_delta" | "divider";
+        TranscriptRole: "agent" | "agent_delta" | "operator" | "tool_call" | "tool_running" | "tool_output_delta" | "reasoning" | "reasoning_delta" | "divider" | "sidecar";
         /** TranscriptSearchListResponse */
         TranscriptSearchListResponse: {
             /** Items */
@@ -4980,6 +7589,16 @@ export interface components {
             /** Resolved */
             resolved: number;
         };
+        /**
+         * TurnAction
+         * @description A single concrete action within a turn, tagged with its activity.
+         */
+        TurnAction: {
+            /** Text */
+            text: string;
+            /** Activity */
+            activity: string;
+        };
         /** TurnEconomicsResponse */
         TurnEconomicsResponse: {
             /** Jobid */
@@ -5013,7 +7632,7 @@ export interface components {
              * Turncurve
              * @default []
              */
-            turnCurve: components["schemas"]["CostDriverEntry"][];
+            turnCurve: components["schemas"]["TelemetryCostBucket"][];
         };
         /**
          * TurnSummaryPayload
@@ -5042,6 +7661,8 @@ export interface components {
             isNewActivity: boolean;
             /** Planitemid */
             planItemId?: string | null;
+            /** Replacesturnid */
+            replacesTurnId?: string | null;
         };
         /** UnsubscribeRequest */
         UnsubscribeRequest: {
@@ -5054,6 +7675,29 @@ export interface components {
             preset?: string | null;
             /** Batchwindowseconds */
             batchWindowSeconds?: number | null;
+        };
+        /** UpdateMetricRequest */
+        UpdateMetricRequest: {
+            /** Name */
+            name?: string | null;
+            /** Tilesize */
+            tileSize?: string | null;
+            /** Position */
+            position?: number | null;
+            /** Pindashboard */
+            pinDashboard?: boolean | null;
+            /** Pinjobpanel */
+            pinJobPanel?: boolean | null;
+            /** Alertenabled */
+            alertEnabled?: boolean | null;
+            /** Alertop */
+            alertOp?: string | null;
+            /** Alertvalue */
+            alertValue?: number | null;
+            /** Alertseverity */
+            alertSeverity?: string | null;
+            /** Alertcooldownhours */
+            alertCooldownHours?: number | null;
         };
         /** UpdatePresetRequest */
         UpdatePresetRequest: {
@@ -5089,6 +7733,26 @@ export interface components {
             verifyPrompt?: string | null;
             /** Selfreviewprompt */
             selfReviewPrompt?: string | null;
+            /**
+             * Clisidecars
+             * @description Sidecar names for CLI sessions; null leaves current value unchanged
+             */
+            cliSidecars?: string[] | null;
+            /** Codereconsplade */
+            codereconSplade?: boolean | null;
+            /** Codereconcrossencoder */
+            codereconCrossEncoder?: boolean | null;
+        };
+        /** UpdateSidecarTemplateRequest */
+        UpdateSidecarTemplateRequest: {
+            /** Name */
+            name?: string | null;
+            /** Description */
+            description?: string | null;
+            /** Definitionjson */
+            definitionJson?: string | null;
+            /** Enabled */
+            enabled?: boolean | null;
         };
         /** ValidationError */
         ValidationError: {
@@ -5108,64 +7772,33 @@ export interface components {
             /** Publickey */
             publicKey: string;
         };
-        /** GenerateSidecarRequest */
-        GenerateSidecarRequest: {
-            /** Description */
-            description: string;
-        };
-        /** GenerateSidecarResponse */
-        GenerateSidecarResponse: {
-            /** Definition */
-            definition: Record<string, unknown>;
-        };
-        /** CreateSidecarTemplateRequest */
-        CreateSidecarTemplateRequest: {
-            /** Name */
-            name: string;
-            /** Description */
-            description: string;
-            /** Definitionjson */
-            definitionJson: string;
-        };
-        /** UpdateSidecarTemplateRequest */
-        UpdateSidecarTemplateRequest: {
-            /** Name */
-            name?: string | null;
-            /** Description */
-            description?: string | null;
-            /** Definitionjson */
-            definitionJson?: string | null;
-        };
-        /** SidecarTemplateResponse */
-        SidecarTemplateResponse: {
-            /** Id */
-            id: string;
-            /** Name */
-            name: string;
-            /** Description */
-            description: string;
-            /** Definitionjson */
-            definitionJson: string;
-            /**
-             * Createdat
-             * Format: date-time
-             */
-            createdAt: string;
-            /**
-             * Lastusedat
-             * Format: date-time
-             */
-            lastUsedAt?: string | null;
-        };
-        /** SidecarTemplateListResponse */
-        SidecarTemplateListResponse: {
-            /** Items */
-            items: components["schemas"]["SidecarTemplateResponse"][];
-        };
         /** WarmSessionResponse */
         WarmSessionResponse: {
             /** Sessiontoken */
             sessionToken: string;
+        };
+        /** WasteBreakdown */
+        WasteBreakdown: {
+            /**
+             * Retryusd
+             * @default 0
+             */
+            retryUsd: number;
+            /**
+             * Failedjobsusd
+             * @default 0
+             */
+            failedJobsUsd: number;
+            /**
+             * Compactionusd
+             * @default 0
+             */
+            compactionUsd: number;
+            /**
+             * Rereadsusd
+             * @default 0
+             */
+            rereadsUsd: number;
         };
         /** WorkspaceEntry */
         WorkspaceEntry: {
@@ -5196,6 +7829,56 @@ export interface components {
             /** Hasmore */
             hasMore: boolean;
         };
+        /** YieldCategoryRow */
+        YieldCategoryRow: {
+            /** Category */
+            category: string;
+            /**
+             * Jobcount
+             * @default 0
+             */
+            jobCount: number;
+            /**
+             * Totalcostusd
+             * @default 0
+             */
+            totalCostUsd: number;
+            /**
+             * Avgcostusd
+             * @default 0
+             */
+            avgCostUsd: number;
+            /**
+             * Pctoftotal
+             * @default 0
+             */
+            pctOfTotal: number;
+        };
+        /** YieldResponse */
+        YieldResponse: {
+            /** Period */
+            period: number;
+            /**
+             * Categories
+             * @default []
+             */
+            categories: components["schemas"]["YieldCategoryRow"][];
+            /**
+             * Costpermergeusd
+             * @default 0
+             */
+            costPerMergeUsd: number;
+            /**
+             * Totalcostusd
+             * @default 0
+             */
+            totalCostUsd: number;
+            /**
+             * Totaljobs
+             * @default 0
+             */
+            totalJobs: number;
+        };
     };
     responses: never;
     parameters: never;
@@ -5225,7 +7908,7 @@ export interface operations {
             };
         };
     };
-    sister_session_metrics_api_sister_sessions_metrics_get: {
+    sidecar_session_metrics_api_sidecar_sessions_metrics_get: {
         parameters: {
             query?: never;
             header?: never;
@@ -5240,7 +7923,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["SisterSessionMetricsResponse"];
+                    "application/json": components["schemas"]["SidecarSessionMetricsResponse"];
                 };
             };
         };
@@ -5496,6 +8179,39 @@ export interface operations {
             };
         };
     };
+    resolve_gate_api_jobs__job_id__gate_resolve_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ResolveGateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     continue_job_api_jobs__job_id__continue_post: {
         parameters: {
             query?: never;
@@ -5652,6 +8368,40 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["DiffListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_job_diff_file_api_jobs__job_id__diff_file_get: {
+        parameters: {
+            query: {
+                /** @description Relative file path within the diff */
+                path: string;
+            };
+            header?: never;
+            path: {
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DiffFileModel"];
                 };
             };
             /** @description Validation Error */
@@ -5993,7 +8743,6 @@ export interface operations {
         parameters: {
             query?: {
                 regenerate?: boolean;
-                verbosity?: string;
             };
             header?: never;
             path: {
@@ -6010,6 +8759,331 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["StoryResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_job_structural_diff_api_jobs__job_id__structural_diff_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["StructuralDiffResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_job_multi_session_api_jobs__job_id__multi_session_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MultiSessionResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_impact_graph_api_jobs__job_id__impact_graph__symbol__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                job_id: string;
+                symbol: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ImpactGraphResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_impact_graph_batch_api_jobs__job_id__impact_graph_batch_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ImpactGraphBatchRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ImpactGraphBatchResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_job_communities_api_jobs__job_id__communities_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CommunitiesResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_review_story_api_jobs__job_id__review_story_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReviewStoryResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_job_motivations_api_jobs__job_id__motivations_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JobMotivationsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_job_covering_tests_api_jobs__job_id__covering_tests_get: {
+        parameters: {
+            query: {
+                /** @description Relative file path to query covering tests for */
+                file_path: string;
+            };
+            header?: never;
+            path: {
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CoveringTestsResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_job_line_coverage_api_jobs__job_id__line_coverage_get: {
+        parameters: {
+            query: {
+                /** @description Relative file path to query line coverage for */
+                file_path: string;
+                /** @description Optional start of line range */
+                start_line?: number | null;
+                /** @description Optional end of line range */
+                end_line?: number | null;
+            };
+            header?: never;
+            path: {
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LineCoverageResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_job_blast_radius_api_jobs__job_id__blast_radius_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BlastRadiusResponse"];
                 };
             };
             /** @description Validation Error */
@@ -6300,6 +9374,26 @@ export interface operations {
             };
         };
     };
+    claude_stop_hook_api_hooks_claude_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
     list_artifacts_api_jobs__job_id__artifacts_get: {
         parameters: {
             query?: never;
@@ -6417,6 +9511,38 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["WorkspaceFileResponse"];
                 };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_workspace_file_raw_api_jobs__job_id__workspace_file_raw_get: {
+        parameters: {
+            query: {
+                /** @description Relative path within the worktree */
+                path: string;
+            };
+            header?: never;
+            path: {
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Validation Error */
             422: {
@@ -6555,6 +9681,68 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["RegisterRepoResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_repo_health_api_settings_repos__repo_path__health_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                repo_path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RepoHealthResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_repo_summary_api_settings_repos__repo_path__summary_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                repo_path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RepoSummaryResponse"];
                 };
             };
             /** @description Validation Error */
@@ -6983,6 +10171,7 @@ export interface operations {
             query?: {
                 period?: number;
                 dimension?: string | null;
+                group_by?: string | null;
             };
             header?: never;
             path?: never;
@@ -6996,7 +10185,39 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["FleetCostDriversResponse"];
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    fleet_latency_drivers_api_analytics_latency_drivers_get: {
+        parameters: {
+            query?: {
+                period?: number;
+                dimension?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FleetLatencyDriversResponse"];
                 };
             };
             /** @description Validation Error */
@@ -7373,6 +10594,321 @@ export interface operations {
             };
         };
     };
+    analytics_yield_api_analytics_yield_get: {
+        parameters: {
+            query?: {
+                period?: number;
+                repo?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["YieldResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    analytics_model_efficiency_api_analytics_model_efficiency_get: {
+        parameters: {
+            query?: {
+                period?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ModelEfficiencyResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    analytics_cache_efficiency_api_analytics_cache_efficiency_get: {
+        parameters: {
+            query?: {
+                period?: number;
+                dimension?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CacheEfficiencyResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    analytics_file_cost_api_analytics_file_cost_get: {
+        parameters: {
+            query?: {
+                period?: number;
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FileCostResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    analytics_outcome_matrix_api_analytics_outcome_matrix_get: {
+        parameters: {
+            query?: {
+                period?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OutcomeMatrixResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    analytics_activity_phase_matrix_api_analytics_activity_phase_matrix_get: {
+        parameters: {
+            query?: {
+                period?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ActivityPhaseMatrixResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    analytics_action_purpose_matrix_api_analytics_action_purpose_matrix_get: {
+        parameters: {
+            query?: {
+                period?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ActionPurposeMatrixResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    analytics_executive_summary_api_analytics_executive_summary_get: {
+        parameters: {
+            query?: {
+                period?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ExecutiveSummaryResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    analytics_export_api_analytics_export_get: {
+        parameters: {
+            query?: {
+                period?: number;
+                fmt?: string;
+                sections?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    analytics_sidecar_costs_api_analytics_sidecar_costs_get: {
+        parameters: {
+            query?: {
+                period?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SidecarCostEntry"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_vapid_key_api_notifications_vapid_key_get: {
         parameters: {
             query?: never;
@@ -7537,37 +11073,6 @@ export interface operations {
             };
         };
     };
-    get_observer_terminal_api_terminal_observer__job_id__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                job_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["TerminalSessionInfo"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
     ask_ai_api_terminal_ask_post: {
         parameters: {
             query?: never;
@@ -7601,7 +11106,7 @@ export interface operations {
             };
         };
     };
-    preview_proxy_api_preview__port___path__patch: {
+    preview_proxy_api_preview__port___path__delete: {
         parameters: {
             query?: never;
             header?: never;
@@ -7631,7 +11136,7 @@ export interface operations {
             };
         };
     };
-    preview_proxy_api_preview__port___path__patch: {
+    preview_proxy_api_preview__port___path__delete: {
         parameters: {
             query?: never;
             header?: never;
@@ -7661,7 +11166,7 @@ export interface operations {
             };
         };
     };
-    preview_proxy_api_preview__port___path__patch: {
+    preview_proxy_api_preview__port___path__delete: {
         parameters: {
             query?: never;
             header?: never;
@@ -7691,7 +11196,7 @@ export interface operations {
             };
         };
     };
-    preview_proxy_api_preview__port___path__patch: {
+    preview_proxy_api_preview__port___path__delete: {
         parameters: {
             query?: never;
             header?: never;
@@ -7721,7 +11226,7 @@ export interface operations {
             };
         };
     };
-    preview_proxy_api_preview__port___path__patch: {
+    preview_proxy_api_preview__port___path__delete: {
         parameters: {
             query?: never;
             header?: never;
@@ -7751,7 +11256,7 @@ export interface operations {
             };
         };
     };
-    preview_proxy_api_preview__port___path__patch: {
+    preview_proxy_api_preview__port___path__delete: {
         parameters: {
             query?: never;
             header?: never;
@@ -8723,6 +12228,424 @@ export interface operations {
         responses: {
             /** @description Successful Response */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: string;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    chat_ask_api_metrics_chat_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["MetricsChatRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MetricsChatResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_conversations_api_metrics_chat_conversations_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConversationListResponse"];
+                };
+            };
+        };
+    };
+    delete_conversation_api_metrics_chat_conversations__conversation_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                conversation_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_custom_metrics_api_metrics_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CustomMetricsListResponse"];
+                };
+            };
+        };
+    };
+    pin_metric_api_metrics_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PinMetricRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CustomMetricResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_metric_api_metrics__metric_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                metric_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_metric_api_metrics__metric_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                metric_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateMetricRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CustomMetricResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_sidecar_templates_api_sidecar_templates_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SidecarTemplateListResponse"];
+                };
+            };
+        };
+    };
+    create_sidecar_template_api_sidecar_templates_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateSidecarTemplateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SidecarTemplateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_sidecar_template_api_sidecar_templates__template_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                template_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SidecarTemplateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_sidecar_template_api_sidecar_templates__template_id__put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                template_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateSidecarTemplateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SidecarTemplateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_sidecar_template_api_sidecar_templates__template_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                template_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    generate_sidecar_definition_api_sidecar_templates_generate_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["GenerateSidecarRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GenerateSidecarResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    fire_sidecar_api_jobs__job_id__sidecars__sidecar_name__fire_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                job_id: string;
+                sidecar_name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["FireSidecarRequest"] | null;
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            202: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/hooks/useSSE.ts
+++ b/frontend/src/hooks/useSSE.ts
@@ -9,6 +9,7 @@
 import { useCallback, useEffect, useRef } from "react";
 import { fetchJob, fetchJobSnapshot } from "../api/client";
 import { enrichJob, useStore } from "../store";
+import { normalizeTFEvent, type TFSessionEvent } from "../store/sseNormalize";
 import type { JobSummary } from "../store";
 
 /** Reconnection parameters per SPEC §3.5 */
@@ -85,55 +86,68 @@ export function useSSE(jobId?: string): { reconnect: () => void } {
         }
       };
 
-      // Handle named event types
+      // Handle named event types. Each name is a traceforge dotted event kind
+      // serialized on the SSE `event:` line (except `snapshot`, a bespoke
+      // camelCase frame). The listener unwraps the traceforge envelope and
+      // normalizes the payload before dispatching (see ../store/sseNormalize).
       const eventTypes = [
-        "job_state_changed",
-        "log_line",
-        "transcript_update",
-        "diff_update",
-        "approval_requested",
-        "approval_resolved",
-        "batch_approval_requested",
-        "batch_approval_resolved",
-        "session_heartbeat",
-        "snapshot",
-        "job_review",
-        "job_completed",
-        "job_failed",
-        "job_resolved",
-        "job_archived",
-        "session_resumed",
-        "job_title_updated",
-        "model_downgraded",
-        "tool_group_summary",
-        "merge_completed",
-        "merge_conflict",
-        "telemetry_updated",
+        // Job lifecycle
+        "job.created",
+        "job.state_changed",
+        "job.setup_progress",
+        "job.review",
+        "job.completed",
+        "job.failed",
+        "job.canceled",
+        "job.resolved",
+        "job.archived",
+        "job.title_updated",
+        "model.downgraded",
+        "merge.completed",
+        "merge.conflict",
+        // Transcript / logs (role-split dotted kinds all route to the
+        // transcript handler, which branches on payload.role)
+        "log",
+        "message.user",
+        "message.assistant",
+        "message.delta",
+        "tool.call.started",
+        "tool.call.completed",
+        "tool.group_summary",
+        // Diffs
+        "diff.updated",
+        // Approvals / permissions
+        "permission.requested",
+        "permission.resolved",
+        "permission.batch.requested",
+        "permission.batch.resolved",
+        // Session
+        "session.heartbeat",
+        "session.resumed",
+        "telemetry.updated",
         // Plan steps — the only step-level event the frontend handles
-        "plan_step_updated",
+        "plan.step_updated",
         // Activity timeline
-        "turn_summary",
+        "turn.summary",
         // Step reassignment (classifier moved turn to different plan item)
-        "step_entries_reassigned",
+        "step.entries_reassigned",
         // Action policy tier classification
-        "action_classified",
-        // Job workspace setup progress (preparing → queued)
-        "job_setup_progress",
+        "action.classified",
         // Policy settings changed (triggers settings panel refresh)
-        "policy_settings_changed",
+        "policy.settings_changed",
         // Repository structural index progress
-        "repo_index_progress",
-        "repo_index_complete",
+        "repo.index_progress",
+        "repo.index_complete",
         // Structural health warnings at step boundaries (§7.2)
-        "structural_warning",
-        // Sidecar transcript entries (legacy — kept for replay compat)
-        "sidecar_transcript",
+        "structural.warning",
         // Unified secondary session events
-        "secondary_session_started",
-        "secondary_session_entry",
-        "secondary_session_completed",
+        "secondary_session.started",
+        "secondary_session.entry",
+        "secondary_session.completed",
         // Context handoff visibility
-        "context_handoff",
+        "context.handoff",
+        // Bespoke camelCase snapshot frame (not a traceforge event)
+        "snapshot",
       ];
 
       for (const eventType of eventTypes) {
@@ -147,26 +161,39 @@ export function useSSE(jobId?: string): { reconnect: () => void } {
             // same microtask checkpoint as React's useSyncExternalStore flush.
             // See comment on onopen above for the full explanation of #185.
             setTimeout(async () => {
-              // If a state change arrives for a job not yet in the store
-              // (e.g. created on another device), fetch the full job from the
-              // REST API and insert it before dispatching the state update so
-              // it appears on the Kanban board without a page refresh.
-              if (eventType === "job_state_changed") {
-                const payload = data as Record<string, unknown>;
-                const jobId = payload.jobId as string | undefined;
-                if (jobId && !useStore.getState().jobs[jobId]) {
+              // `snapshot` is a bespoke camelCase frame, not a traceforge
+              // event — dispatch it through untouched.
+              if (eventType === "snapshot") {
+                dispatchSSEEvent(eventType, data as Record<string, unknown>);
+                return;
+              }
+
+              const tfEvent = data as TFSessionEvent;
+
+              // If a lifecycle transition arrives for a job not yet in the
+              // store (e.g. created on another device), fetch the full job from
+              // the REST API and insert it before dispatching so it appears on
+              // the Kanban board without a page refresh.
+              if (
+                eventType === "job.created" ||
+                eventType === "job.canceled" ||
+                eventType === "job.state_changed"
+              ) {
+                const sid = tfEvent.session_id;
+                if (sid && !useStore.getState().jobs[sid]) {
                   try {
-                    const job = await fetchJob(jobId);
+                    const job = await fetchJob(sid);
                     useStore.setState((state) => ({
                       jobs: { ...state.jobs, [job.id]: enrichJob(job as unknown as JobSummary) },
                     }));
                   } catch {
-                    // Job may not be readable yet; the state change dispatch
-                    // below will be a no-op for unknown jobs, which is safe.
+                    // Job may not be readable yet; the dispatch below is a safe
+                    // no-op for unknown jobs.
                   }
                 }
               }
-              dispatchSSEEvent(eventType, data);
+
+              dispatchSSEEvent(eventType, normalizeTFEvent(tfEvent));
             }, 0);
           } catch {
             // Ignore unparseable events

--- a/frontend/src/store/__tests__/sse-events.test.ts
+++ b/frontend/src/store/__tests__/sse-events.test.ts
@@ -56,7 +56,7 @@ beforeEach(() => {
 describe("dispatchSSEEvent — additional events", () => {
   it("handles job_review with prUrl and resolution", () => {
     useStore.setState({ jobs: { "job-1": makeJob({ progressHeadline: "Audit", progressSummary: "Reviewing shortcuts" }) } });
-    useStore.getState().dispatchSSEEvent("job_review", {
+    useStore.getState().dispatchSSEEvent("job.review", {
       jobId: "job-1",
       prUrl: "https://github.com/pr/1",
       resolution: "merged",
@@ -73,7 +73,7 @@ describe("dispatchSSEEvent — additional events", () => {
 
   it("handles job_review with model downgrade", () => {
     useStore.setState({ jobs: { "job-1": makeJob() } });
-    useStore.getState().dispatchSSEEvent("job_review", {
+    useStore.getState().dispatchSSEEvent("job.review", {
       jobId: "job-1",
       modelDowngraded: true,
       requestedModel: "gpt-4",
@@ -85,7 +85,7 @@ describe("dispatchSSEEvent — additional events", () => {
   });
 
   it("ignores job_review for unknown job", () => {
-    useStore.getState().dispatchSSEEvent("job_review", {
+    useStore.getState().dispatchSSEEvent("job.review", {
       jobId: "unknown",
     });
     expect(Object.keys(selectJobs(useStore.getState()))).toHaveLength(0);
@@ -93,7 +93,7 @@ describe("dispatchSSEEvent — additional events", () => {
 
   it("handles job_failed", () => {
     useStore.setState({ jobs: { "job-1": makeJob({ progressHeadline: "Audit", progressSummary: "Reviewing shortcuts" }) } });
-    useStore.getState().dispatchSSEEvent("job_failed", {
+    useStore.getState().dispatchSSEEvent("job.failed", {
       jobId: "job-1",
       reason: "Timeout",
     });
@@ -106,7 +106,7 @@ describe("dispatchSSEEvent — additional events", () => {
 
   it("handles job_failed with default reason", () => {
     useStore.setState({ jobs: { "job-1": makeJob() } });
-    useStore.getState().dispatchSSEEvent("job_failed", {
+    useStore.getState().dispatchSSEEvent("job.failed", {
       jobId: "job-1",
     });
     const job = selectJobs(useStore.getState())["job-1"]!;
@@ -114,7 +114,7 @@ describe("dispatchSSEEvent — additional events", () => {
   });
 
   it("ignores job_failed for unknown job", () => {
-    useStore.getState().dispatchSSEEvent("job_failed", {
+    useStore.getState().dispatchSSEEvent("job.failed", {
       jobId: "unknown",
       reason: "Oops",
     });
@@ -123,7 +123,7 @@ describe("dispatchSSEEvent — additional events", () => {
 
   it("handles job_resolved", () => {
     useStore.setState({ jobs: { "job-1": makeJob({ state: "review" }) } });
-    useStore.getState().dispatchSSEEvent("job_resolved", {
+    useStore.getState().dispatchSSEEvent("job.resolved", {
       jobId: "job-1",
       resolution: "merged",
       prUrl: "https://github.com/pr/1",
@@ -137,7 +137,7 @@ describe("dispatchSSEEvent — additional events", () => {
 
   it("handles job_resolved with conflict", () => {
     useStore.setState({ jobs: { "job-1": makeJob({ state: "review" }) } });
-    useStore.getState().dispatchSSEEvent("job_resolved", {
+    useStore.getState().dispatchSSEEvent("job.resolved", {
       jobId: "job-1",
       resolution: "conflict",
       conflictFiles: ["a.ts", "b.ts"],
@@ -148,7 +148,7 @@ describe("dispatchSSEEvent — additional events", () => {
 
   it("stores unresolved job_resolved errors", () => {
     useStore.setState({ jobs: { "job-1": makeJob({ state: "review" }) } });
-    useStore.getState().dispatchSSEEvent("job_resolved", {
+    useStore.getState().dispatchSSEEvent("job.resolved", {
       jobId: "job-1",
       resolution: "unresolved",
       error: "Cherry-pick failed without conflict markers; check git configuration or hooks",
@@ -159,7 +159,7 @@ describe("dispatchSSEEvent — additional events", () => {
   });
 
   it("ignores job_resolved for unknown job", () => {
-    useStore.getState().dispatchSSEEvent("job_resolved", {
+    useStore.getState().dispatchSSEEvent("job.resolved", {
       jobId: "unknown",
       resolution: "merged",
     });
@@ -168,7 +168,7 @@ describe("dispatchSSEEvent — additional events", () => {
 
   it("handles job_archived", () => {
     useStore.setState({ jobs: { "job-1": makeJob({ state: "review" }) } });
-    useStore.getState().dispatchSSEEvent("job_archived", {
+    useStore.getState().dispatchSSEEvent("job.archived", {
       jobId: "job-1",
     });
     const job = selectJobs(useStore.getState())["job-1"]!;
@@ -177,13 +177,13 @@ describe("dispatchSSEEvent — additional events", () => {
   });
 
   it("ignores job_archived for unknown job", () => {
-    useStore.getState().dispatchSSEEvent("job_archived", { jobId: "unknown" });
+    useStore.getState().dispatchSSEEvent("job.archived", { jobId: "unknown" });
     expect(Object.keys(selectJobs(useStore.getState()))).toHaveLength(0);
   });
 
   it("handles diff_update and stores diffs", () => {
     const files = [{ path: "a.ts", status: "modified", additions: 1, deletions: 0, hunks: [] }];
-    useStore.getState().dispatchSSEEvent("diff_update", {
+    useStore.getState().dispatchSSEEvent("diff.updated", {
       jobId: "job-1",
       changedFiles: files,
     });
@@ -192,7 +192,7 @@ describe("dispatchSSEEvent — additional events", () => {
 
   it("handles job_title_updated", () => {
     useStore.setState({ jobs: { "job-1": makeJob() } });
-    useStore.getState().dispatchSSEEvent("job_title_updated", {
+    useStore.getState().dispatchSSEEvent("job.title_updated", {
       jobId: "job-1",
       title: "New Title",
       branch: "feat/new",
@@ -203,7 +203,7 @@ describe("dispatchSSEEvent — additional events", () => {
   });
 
   it("ignores job_title_updated for unknown job", () => {
-    useStore.getState().dispatchSSEEvent("job_title_updated", {
+    useStore.getState().dispatchSSEEvent("job.title_updated", {
       jobId: "unknown",
       title: "Title",
     });
@@ -212,7 +212,7 @@ describe("dispatchSSEEvent — additional events", () => {
 
   it("handles agent_plan_updated — creates plan steps", () => {
     useStore.setState({ jobs: { "job-1": makeJob() } });
-    useStore.getState().dispatchSSEEvent("agent_plan_updated", {
+    useStore.getState().dispatchSSEEvent("plan.updated", {
       jobId: "job-1",
       steps: [
         { label: "Analyze code", status: "active" },
@@ -227,7 +227,7 @@ describe("dispatchSSEEvent — additional events", () => {
 
   it("handles model_downgraded", () => {
     useStore.setState({ jobs: { "job-1": makeJob() } });
-    useStore.getState().dispatchSSEEvent("model_downgraded", {
+    useStore.getState().dispatchSSEEvent("model.downgraded", {
       jobId: "job-1",
       requestedModel: "gpt-4",
       actualModel: "gpt-3.5",
@@ -239,7 +239,7 @@ describe("dispatchSSEEvent — additional events", () => {
   });
 
   it("ignores model_downgraded for unknown job", () => {
-    useStore.getState().dispatchSSEEvent("model_downgraded", {
+    useStore.getState().dispatchSSEEvent("model.downgraded", {
       jobId: "unknown",
       requestedModel: "gpt-4",
       actualModel: "gpt-3.5",
@@ -248,14 +248,14 @@ describe("dispatchSSEEvent — additional events", () => {
   });
 
   it("transcript_update deduplicates", () => {
-    useStore.getState().dispatchSSEEvent("transcript_update", {
+    useStore.getState().dispatchSSEEvent("message.assistant", {
       jobId: "job-1",
       seq: 1,
       timestamp: "2025-01-01T00:00:00Z",
       role: "agent",
       content: "Hello",
     });
-    useStore.getState().dispatchSSEEvent("transcript_update", {
+    useStore.getState().dispatchSSEEvent("message.assistant", {
       jobId: "job-1",
       seq: 1,
       timestamp: "2025-01-01T00:00:00Z",
@@ -369,7 +369,7 @@ describe("job_state_changed evicts stale approvals", () => {
     });
 
     // Server recovery sends job_state_changed back to running, no approval_resolved
-    useStore.getState().dispatchSSEEvent("job_state_changed", {
+    useStore.getState().dispatchSSEEvent("job.state_changed", {
       jobId: "job-1",
       newState: "running",
       timestamp: "2025-01-01T00:01:00Z",
@@ -398,7 +398,7 @@ describe("job_state_changed evicts stale approvals", () => {
       },
     });
 
-    useStore.getState().dispatchSSEEvent("job_state_changed", {
+    useStore.getState().dispatchSSEEvent("job.state_changed", {
       jobId: "job-1",
       newState: "running",
       timestamp: "2025-01-01T00:01:00Z",
@@ -442,7 +442,7 @@ describe("job_state_changed evicts stale approvals", () => {
       },
     });
 
-    useStore.getState().dispatchSSEEvent("job_state_changed", {
+    useStore.getState().dispatchSSEEvent("job.state_changed", {
       jobId: "job-1",
       newState: "running",
       timestamp: "2025-01-01T00:01:00Z",

--- a/frontend/src/store/handlers/approvalHandlers.ts
+++ b/frontend/src/store/handlers/approvalHandlers.ts
@@ -47,7 +47,7 @@ export function handleApprovalResolved(state: AppState, payload: Record<string, 
 export function handleBatchApprovalRequested(state: AppState, payload: Record<string, unknown>): Partial<AppState> | null {
   const actions = (payload.actions as Array<Record<string, unknown>>) ?? [];
   const batch: BatchApproval = {
-    batchId: payload.batch_id as string,
+    batchId: payload.batchId as string,
     jobId: payload.jobId as string,
     actions: actions.map((a) => ({
       id: a.id as string,
@@ -56,7 +56,7 @@ export function handleBatchApprovalRequested(state: AppState, payload: Record<st
       reason: a.reason as string,
       reversible: a.reversible as boolean,
       contained: a.contained as boolean,
-      checkpointRef: (a.checkpoint_ref as string | null) ?? null,
+      checkpointRef: (a.checkpointRef as string | null) ?? null,
       description: a.description as string,
     })),
     summary: (payload.summary as string) ?? "",
@@ -70,7 +70,7 @@ export function handleBatchApprovalRequested(state: AppState, payload: Record<st
 }
 
 export function handleBatchApprovalResolved(state: AppState, payload: Record<string, unknown>): Partial<AppState> | null {
-  const batchId = payload.batch_id as string;
+  const batchId = payload.batchId as string;
   const existing = state.batchApprovals[batchId];
   if (existing) {
     return {
@@ -88,8 +88,8 @@ export function handleBatchApprovalResolved(state: AppState, payload: Record<str
 }
 
 export const approvalHandlers: Record<string, SSEHandler> = {
-  approval_requested: handleApprovalRequested,
-  approval_resolved: handleApprovalResolved,
-  batch_approval_requested: handleBatchApprovalRequested,
-  batch_approval_resolved: handleBatchApprovalResolved,
+  "permission.requested": handleApprovalRequested,
+  "permission.resolved": handleApprovalResolved,
+  "permission.batch.requested": handleBatchApprovalRequested,
+  "permission.batch.resolved": handleBatchApprovalResolved,
 };

--- a/frontend/src/store/handlers/jobHandlers.ts
+++ b/frontend/src/store/handlers/jobHandlers.ts
@@ -284,15 +284,15 @@ export function handleMergeConflict(state: AppState, payload: Record<string, unk
 
 // SSEHandler type assertion to keep signatures compatible with the lookup table
 export const jobHandlers: Record<string, SSEHandler> = {
-  job_state_changed: handleJobStateChanged,
-  job_setup_progress: handleJobSetupProgress,
-  job_review: handleJobReview,
-  job_completed: handleJobCompleted,
-  job_failed: handleJobFailed,
-  job_archived: handleJobArchived,
-  job_resolved: handleJobResolved,
-  job_title_updated: handleJobTitleUpdated,
-  model_downgraded: handleModelDowngraded,
-  merge_completed: handleMergeCompleted,
-  merge_conflict: handleMergeConflict,
+  "job.state_changed": handleJobStateChanged,
+  "job.setup_progress": handleJobSetupProgress,
+  "job.review": handleJobReview,
+  "job.completed": handleJobCompleted,
+  "job.failed": handleJobFailed,
+  "job.archived": handleJobArchived,
+  "job.resolved": handleJobResolved,
+  "job.title_updated": handleJobTitleUpdated,
+  "model.downgraded": handleModelDowngraded,
+  "merge.completed": handleMergeCompleted,
+  "merge.conflict": handleMergeConflict,
 };

--- a/frontend/src/store/handlers/miscHandlers.ts
+++ b/frontend/src/store/handlers/miscHandlers.ts
@@ -181,15 +181,15 @@ export function handleContextHandoff(state: AppState, payload: Record<string, un
 
 export const miscHandlers: Record<string, SSEHandler> = {
   snapshot: handleSnapshot,
-  session_heartbeat: handleSessionHeartbeat,
-  diff_update: handleDiffUpdate,
-  session_resumed: handleSessionResumed,
-  telemetry_updated: handleTelemetryUpdated,
-  policy_settings_changed: handlePolicySettingsChanged,
-  repo_index_progress: handleRepoIndexProgress,
-  repo_index_complete: handleRepoIndexComplete,
-  context_handoff: handleContextHandoff,
-  structural_warning: (state, payload) => {
+  "session.heartbeat": handleSessionHeartbeat,
+  "diff.updated": handleDiffUpdate,
+  "session.resumed": handleSessionResumed,
+  "telemetry.updated": handleTelemetryUpdated,
+  "policy.settings_changed": handlePolicySettingsChanged,
+  "repo.index_progress": handleRepoIndexProgress,
+  "repo.index_complete": handleRepoIndexComplete,
+  "context.handoff": handleContextHandoff,
+  "structural.warning": (state, payload) => {
     const jobId = payload.jobId as string | undefined;
     if (!jobId) return {};
     const warning = {

--- a/frontend/src/store/handlers/timelineHandlers.ts
+++ b/frontend/src/store/handlers/timelineHandlers.ts
@@ -276,10 +276,10 @@ export function handleActionClassified(_state: AppState, payload: Record<string,
 }
 
 export const timelineHandlers: Record<string, SSEHandler> = {
-  progress_headline: handleProgressHeadline,
-  agent_plan_updated: handleAgentPlanUpdated,
-  plan_step_updated: handlePlanStepUpdated,
-  turn_summary: handleTurnSummary,
-  step_entries_reassigned: handleStepEntriesReassigned,
-  action_classified: handleActionClassified,
+  "progress.headline": handleProgressHeadline,
+  "plan.updated": handleAgentPlanUpdated,
+  "plan.step_updated": handlePlanStepUpdated,
+  "turn.summary": handleTurnSummary,
+  "step.entries_reassigned": handleStepEntriesReassigned,
+  "action.classified": handleActionClassified,
 };

--- a/frontend/src/store/handlers/transcriptHandlers.ts
+++ b/frontend/src/store/handlers/transcriptHandlers.ts
@@ -310,11 +310,17 @@ export function handleToolGroupSummary(state: AppState, payload: Record<string, 
 }
 
 export const transcriptHandlers: Record<string, SSEHandler> = {
-  log_line: handleLogLine,
-  transcript_update: handleTranscriptUpdate,
-  tool_group_summary: handleToolGroupSummary,
-  sidecar_transcript: handleSidecarTranscript,
-  secondary_session_started: handleSecondarySessionStarted,
-  secondary_session_entry: handleSecondarySessionEntry,
-  secondary_session_completed: handleSecondarySessionCompleted,
+  log: handleLogLine,
+  // All transcript kinds route to the same handler, which branches on the
+  // preserved `payload.role`. The backend splits transcript events into these
+  // role-specific dotted kinds (see `transcript_kind_for_role`).
+  "message.user": handleTranscriptUpdate,
+  "message.assistant": handleTranscriptUpdate,
+  "message.delta": handleTranscriptUpdate,
+  "tool.call.started": handleTranscriptUpdate,
+  "tool.call.completed": handleTranscriptUpdate,
+  "tool.group_summary": handleToolGroupSummary,
+  "secondary_session.started": handleSecondarySessionStarted,
+  "secondary_session.entry": handleSecondarySessionEntry,
+  "secondary_session.completed": handleSecondarySessionCompleted,
 };

--- a/frontend/src/store/index.test.ts
+++ b/frontend/src/store/index.test.ts
@@ -101,7 +101,7 @@ describe("AppStore", () => {
         jobs: { "job-1": makeJob() },
       });
 
-      useStore.getState().dispatchSSEEvent("job_state_changed", {
+      useStore.getState().dispatchSSEEvent("job.state_changed", {
         jobId: "job-1",
         newState: "review",
         timestamp: "2025-01-01T01:00:00Z",
@@ -113,7 +113,7 @@ describe("AppStore", () => {
     });
 
     it("ignores job_state_changed for unknown job", () => {
-      useStore.getState().dispatchSSEEvent("job_state_changed", {
+      useStore.getState().dispatchSSEEvent("job.state_changed", {
         jobId: "job-999",
         newState: "review",
         timestamp: "2025-01-01T01:00:00Z",
@@ -123,7 +123,7 @@ describe("AppStore", () => {
     });
 
     it("handles log_line", () => {
-      useStore.getState().dispatchSSEEvent("log_line", {
+      useStore.getState().dispatchSSEEvent("log", {
         jobId: "job-1",
         seq: 1,
         timestamp: "2025-01-01T00:00:00Z",
@@ -138,7 +138,7 @@ describe("AppStore", () => {
     });
 
     it("appends log lines to existing logs", () => {
-      useStore.getState().dispatchSSEEvent("log_line", {
+      useStore.getState().dispatchSSEEvent("log", {
         jobId: "job-1",
         seq: 1,
         timestamp: "2025-01-01T00:00:00Z",
@@ -146,7 +146,7 @@ describe("AppStore", () => {
         message: "first",
         context: null,
       });
-      useStore.getState().dispatchSSEEvent("log_line", {
+      useStore.getState().dispatchSSEEvent("log", {
         jobId: "job-1",
         seq: 2,
         timestamp: "2025-01-01T00:00:01Z",
@@ -159,7 +159,7 @@ describe("AppStore", () => {
     });
 
     it("handles transcript_update", () => {
-      useStore.getState().dispatchSSEEvent("transcript_update", {
+      useStore.getState().dispatchSSEEvent("message.assistant", {
         jobId: "job-1",
         seq: 1,
         timestamp: "2025-01-01T00:00:00Z",
@@ -175,7 +175,7 @@ describe("AppStore", () => {
     });
 
     it("handles approval_requested", () => {
-      useStore.getState().dispatchSSEEvent("approval_requested", {
+      useStore.getState().dispatchSSEEvent("permission.requested", {
         approvalId: "apr-1",
         jobId: "job-1",
         description: "Delete file?",
@@ -190,7 +190,7 @@ describe("AppStore", () => {
     });
 
     it("approval_requested falls back to now when timestamp missing", () => {
-      useStore.getState().dispatchSSEEvent("approval_requested", {
+      useStore.getState().dispatchSSEEvent("permission.requested", {
         approvalId: "apr-2",
         jobId: "job-1",
         description: "No timestamp",
@@ -222,7 +222,7 @@ describe("AppStore", () => {
         },
       });
 
-      useStore.getState().dispatchSSEEvent("approval_resolved", {
+      useStore.getState().dispatchSSEEvent("permission.resolved", {
         approvalId: "apr-1",
         resolution: "approved",
         timestamp: "2025-01-01T01:00:00Z",
@@ -234,7 +234,7 @@ describe("AppStore", () => {
     });
 
     it("ignores approval_resolved for unknown approval", () => {
-      useStore.getState().dispatchSSEEvent("approval_resolved", {
+      useStore.getState().dispatchSSEEvent("permission.resolved", {
         approvalId: "apr-999",
         resolution: "approved",
         timestamp: "2025-01-01T01:00:00Z",
@@ -261,7 +261,7 @@ describe("AppStore", () => {
         "disconnected"
       );
 
-      useStore.getState().dispatchSSEEvent("session_heartbeat", {
+      useStore.getState().dispatchSSEEvent("session.heartbeat", {
         jobId: "job-1",
         sessionId: "sess-1",
         timestamp: "2025-01-01T00:00:00Z",
@@ -275,7 +275,7 @@ describe("AppStore", () => {
     it("session_heartbeat is no-op when already connected", () => {
       useStore.getState().setConnectionStatus("connected");
 
-      useStore.getState().dispatchSSEEvent("session_heartbeat", {
+      useStore.getState().dispatchSSEEvent("session.heartbeat", {
         jobId: "job-1",
         sessionId: "sess-1",
         timestamp: "2025-01-01T00:00:00Z",
@@ -288,7 +288,7 @@ describe("AppStore", () => {
 
     it("handles diff_update without error", () => {
       const beforeState = useStore.getState();
-      useStore.getState().dispatchSSEEvent("diff_update", {
+      useStore.getState().dispatchSSEEvent("diff.updated", {
         jobId: "job-1",
         changedFiles: ["src/app.ts"],
       });
@@ -326,7 +326,7 @@ describe("AppStore", () => {
         },
       });
 
-      useStore.getState().dispatchSSEEvent("session_resumed", {
+      useStore.getState().dispatchSSEEvent("session.resumed", {
         jobId: "job-1",
         timestamp: "2025-06-02T00:00:00Z",
         session_number: 2,
@@ -373,7 +373,7 @@ describe("AppStore", () => {
       });
 
       // Same timestamp triggers dedup branch
-      useStore.getState().dispatchSSEEvent("session_resumed", {
+      useStore.getState().dispatchSSEEvent("session.resumed", {
         jobId: "job-1",
         timestamp: "2025-06-02T00:00:00Z",
         session_number: 2,

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -14,6 +14,7 @@ import { create } from "zustand";
 import { fetchSDKs, fetchModels, createTerminalSession as apiCreateTerminalSession, deleteTerminalSession as apiDeleteTerminalSession } from "../api/client";
 import { sseHandlers, enrichJob } from "./sseHandlers";
 export { enrichJob } from "./sseHandlers";
+import { deriveJobStateFrame } from "./sseNormalize";
 
 // Re-export all types so existing `import { ... } from "../store"` still works
 export type {
@@ -485,16 +486,39 @@ export const useStore = create<AppState>((set, get) => ({
   },
 
   dispatchSSEEvent: (eventType, data) => {
-    const handler = sseHandlers[eventType];
-    if (!handler) return;
-    const state = get();
     const payload = data as Record<string, unknown>;
-    const update = handler(state, payload, get);
-    if (update !== null) {
-      set(update);
+
+    // `snapshot` is a passthrough camelCase frame (not a traceforge event) and
+    // never drives a derived state transition.
+    if (eventType === "snapshot") {
+      const handler = sseHandlers[eventType];
+      if (handler) {
+        const update = handler(get(), payload, get);
+        if (update !== null) set(update);
+      }
+      return;
     }
-    // Side-effect: prefetch structural review data when job enters review state
-    if (eventType === "job_review") {
+
+    // Primary handler for the dotted kind (may be absent, e.g. job.created /
+    // job.canceled, which are expressed purely as a derived state frame).
+    const handler = sseHandlers[eventType];
+    if (handler) {
+      const update = handler(get(), payload, get);
+      if (update !== null) set(update);
+    }
+
+    // Re-derive the job-state transition the backend previously synthesized as
+    // a secondary `job_state_changed` frame. Runs after the primary handler so
+    // it observes the freshly-set state (idempotent, no-ops on unknown jobs).
+    const derived = deriveJobStateFrame(eventType, payload);
+    if (derived) {
+      const stateHandler = sseHandlers["job.state_changed"];
+      const update = stateHandler ? stateHandler(get(), derived, get) : null;
+      if (update !== null) set(update);
+    }
+
+    // Side-effect: prefetch structural review data when a job enters review.
+    if (eventType === "job.review") {
       const jobId = (payload as { jobId?: string }).jobId;
       if (jobId) get().prefetchReviewData(jobId);
     }

--- a/frontend/src/store/sseNormalize.test.ts
+++ b/frontend/src/store/sseNormalize.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import { deepSnakeToCamel, normalizeTFEvent, deriveJobStateFrame, type TFSessionEvent } from "./sseNormalize";
+
+describe("deepSnakeToCamel", () => {
+  it("converts top-level snake keys to camelCase", () => {
+    expect(deepSnakeToCamel({ tool_name: "x", raw_size: 3 })).toEqual({ toolName: "x", rawSize: 3 });
+  });
+
+  it("handles multi-underscore keys", () => {
+    expect(deepSnakeToCamel({ tool_duration_ms: 5, source_session_id: "s" })).toEqual({
+      toolDurationMs: 5,
+      sourceSessionId: "s",
+    });
+  });
+
+  it("recurses into nested objects and arrays", () => {
+    const input = {
+      changed_files: [{ file_path: "a.ts", raw_size: 1 }],
+      entry: { tool_name: "grep", nested_obj: { deep_key: true } },
+    };
+    expect(deepSnakeToCamel(input)).toEqual({
+      changedFiles: [{ filePath: "a.ts", rawSize: 1 }],
+      entry: { toolName: "grep", nestedObj: { deepKey: true } },
+    });
+  });
+
+  it("leaves already-camel and single-word keys unchanged", () => {
+    expect(deepSnakeToCamel({ role: "agent", jobId: "j1", content: "hi" })).toEqual({
+      role: "agent",
+      jobId: "j1",
+      content: "hi",
+    });
+  });
+
+  it("never mutates string values (discriminators survive)", () => {
+    expect(deepSnakeToCamel({ role: "agent_delta", warning_type: "drift" })).toEqual({
+      role: "agent_delta",
+      warningType: "drift",
+    });
+  });
+
+  it("is idempotent", () => {
+    const once = deepSnakeToCamel({ tool_name: "x", nested: { a_b: 1 } });
+    expect(deepSnakeToCamel(once)).toEqual(once);
+  });
+});
+
+describe("normalizeTFEvent", () => {
+  function ev(overrides: Partial<TFSessionEvent> = {}): TFSessionEvent {
+    return {
+      id: "evt-1",
+      kind: "tool.call.completed",
+      session_id: "job-1",
+      timestamp: "2025-01-01T00:00:00Z",
+      payload: {},
+      metadata: null,
+      ...overrides,
+    };
+  }
+
+  it("injects jobId from the envelope session_id", () => {
+    const out = normalizeTFEvent(ev({ payload: { tool_name: "grep" } }));
+    expect(out.jobId).toBe("job-1");
+    expect(out.toolName).toBe("grep");
+  });
+
+  it("falls back to the envelope timestamp when payload lacks one", () => {
+    const out = normalizeTFEvent(ev({ payload: {} }));
+    expect(out.timestamp).toBe("2025-01-01T00:00:00Z");
+  });
+
+  it("prefers the payload timestamp when present", () => {
+    const out = normalizeTFEvent(ev({ payload: { timestamp: "2030-02-02T00:00:00Z" } }));
+    expect(out.timestamp).toBe("2030-02-02T00:00:00Z");
+  });
+
+  it("carries turn_id from metadata as camelCase turnId", () => {
+    const out = normalizeTFEvent(ev({ metadata: { turn_id: "turn-9" } }));
+    expect(out.turnId).toBe("turn-9");
+  });
+
+  it("prefers a payload turnId over metadata", () => {
+    const out = normalizeTFEvent(ev({ payload: { turn_id: "payload-turn" }, metadata: { turn_id: "meta-turn" } }));
+    expect(out.turnId).toBe("payload-turn");
+  });
+
+  it("handles a null/absent payload", () => {
+    const out = normalizeTFEvent(ev({ payload: null }));
+    expect(out.jobId).toBe("job-1");
+  });
+});
+
+describe("deriveJobStateFrame", () => {
+  const p = { jobId: "job-1", timestamp: "2025-01-01T00:00:00Z" };
+
+  it("maps lifecycle kinds to their implied state", () => {
+    expect(deriveJobStateFrame("job.created", p)).toMatchObject({ jobId: "job-1", newState: "running" });
+    expect(deriveJobStateFrame("job.canceled", p)).toMatchObject({ newState: "canceled" });
+    expect(deriveJobStateFrame("job.review", p)).toMatchObject({ newState: "review" });
+    expect(deriveJobStateFrame("job.completed", p)).toMatchObject({ newState: "completed" });
+    expect(deriveJobStateFrame("job.failed", p)).toMatchObject({ newState: "failed" });
+  });
+
+  it("maps permission.requested to waiting_for_approval", () => {
+    expect(deriveJobStateFrame("permission.requested", p)).toMatchObject({ newState: "waiting_for_approval" });
+  });
+
+  it("derives permission.resolved state from the resolution", () => {
+    expect(deriveJobStateFrame("permission.resolved", { ...p, resolution: "approved" })).toMatchObject({
+      newState: "running",
+    });
+    expect(deriveJobStateFrame("permission.resolved", { ...p, resolution: "denied" })).toMatchObject({
+      newState: "failed",
+    });
+  });
+
+  it("returns null for kinds that imply no job-state transition", () => {
+    expect(deriveJobStateFrame("job.state_changed", p)).toBeNull();
+    expect(deriveJobStateFrame("tool.call.completed", p)).toBeNull();
+    expect(deriveJobStateFrame("permission.batch.requested", p)).toBeNull();
+    expect(deriveJobStateFrame("message.assistant", p)).toBeNull();
+  });
+
+  it("carries jobId and timestamp through", () => {
+    expect(deriveJobStateFrame("job.review", p)).toEqual({
+      jobId: "job-1",
+      timestamp: "2025-01-01T00:00:00Z",
+      newState: "review",
+    });
+  });
+});

--- a/frontend/src/store/sseNormalize.ts
+++ b/frontend/src/store/sseNormalize.ts
@@ -1,0 +1,125 @@
+/**
+ * TraceForge SSE ingestion adapter.
+ *
+ * The backend serializes each `traceforge.SessionEvent` to the SSE wire as-is:
+ *   - the SSE `event:` line is the dotted kind (e.g. "job.state_changed",
+ *     "tool.call.completed", "permission.requested");
+ *   - the SSE `data:` line is the full event envelope
+ *     `{ id, kind, session_id, timestamp, payload, metadata }` where `payload`
+ *     is the raw control-plane payload in **snake_case**.
+ *
+ * This module adapts that wire shape into the store's internal camelCase
+ * domain model at the ingestion boundary (used by `useSSE`), so the store
+ * handlers keep reading the camelCase fields they always have. It:
+ *   1. deep-converts payload keys snake_case -> camelCase (`normalizeTFEvent`);
+ *   2. injects the envelope-derived fields handlers expect (`jobId` from
+ *      `session_id`, `timestamp`, `turnId` from `metadata.turn_id`);
+ *   3. re-derives the job-state transitions the backend previously emitted as a
+ *      secondary `job_state_changed` frame — those are now computed on the FE
+ *      from the dotted kind (`deriveJobStateFrame`).
+ *
+ * There is no reverse (camel -> snake) path and no old-wire vocabulary: the
+ * wire speaks TraceForge; this adapter is purely the FE's own domain mapping.
+ */
+
+/** Minimal shape of a serialized `traceforge.SessionEvent` on the SSE wire. */
+export interface TFSessionEvent {
+  id?: string;
+  kind: string;
+  session_id: string;
+  timestamp?: string;
+  payload?: Record<string, unknown> | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+const SNAKE_SEGMENT = /_([a-z0-9])/g;
+
+function snakeKeyToCamel(key: string): string {
+  return key.replace(SNAKE_SEGMENT, (_m, c: string) => c.toUpperCase());
+}
+
+/**
+ * Recursively convert object keys from snake_case to camelCase.
+ *
+ * - Only keys are transformed; values are left untouched (so a discriminator
+ *   like `role: "agent_delta"` survives verbatim).
+ * - Recurses through nested objects and arrays (transcript entries, approval
+ *   actions, plan steps, diff hunks, symbols, ...).
+ * - Idempotent: already-camel and single-word keys are unchanged.
+ */
+export function deepSnakeToCamel(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(deepSnakeToCamel);
+  }
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[snakeKeyToCamel(k)] = deepSnakeToCamel(v);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Unwrap a TF event envelope into the camelCase payload the store handlers
+ * consume, injecting `jobId`/`timestamp`/`turnId` from the envelope.
+ */
+export function normalizeTFEvent(ev: TFSessionEvent): Record<string, unknown> {
+  const payload = deepSnakeToCamel(ev.payload ?? {}) as Record<string, unknown>;
+
+  // `jobId` is authoritative from the envelope session id.
+  payload.jobId = ev.session_id;
+
+  if (payload.timestamp === undefined && ev.timestamp !== undefined) {
+    payload.timestamp = ev.timestamp;
+  }
+
+  // turn_id lives on EventMetadata; carry it as camelCase `turnId` unless the
+  // payload already provides one.
+  const meta = ev.metadata;
+  const metaTurnId = meta == null ? undefined : (meta as Record<string, unknown>).turn_id;
+  if (payload.turnId === undefined && metaTurnId != null) {
+    payload.turnId = metaTurnId;
+  }
+
+  return payload;
+}
+
+/** Dotted kinds that map directly to a single implied job state. */
+const JOB_STATE_BY_KIND: Record<string, string> = {
+  "job.created": "running",
+  "job.canceled": "canceled",
+  "job.review": "review",
+  "job.completed": "completed",
+  "job.failed": "failed",
+};
+
+/**
+ * Re-derive the job-state transition the backend used to synthesize as a
+ * secondary `job_state_changed` frame after certain primary events.
+ *
+ * Returns a `handleJobStateChanged`-shaped payload (`{ jobId, newState,
+ * timestamp }`) or `null` when a kind implies no state change. `permission.*`
+ * kinds derive their state from the resolution; batch permission kinds derive
+ * nothing (they never drove a job-state frame).
+ */
+export function deriveJobStateFrame(
+  kind: string,
+  payload: Record<string, unknown>,
+): Record<string, unknown> | null {
+  const base = { jobId: payload.jobId, timestamp: payload.timestamp };
+
+  if (kind === "permission.requested") {
+    return { ...base, newState: "waiting_for_approval" };
+  }
+  if (kind === "permission.resolved") {
+    return { ...base, newState: payload.resolution === "approved" ? "running" : "failed" };
+  }
+
+  const mapped = JOB_STATE_BY_KIND[kind];
+  if (mapped) {
+    return { ...base, newState: mapped };
+  }
+  return null;
+}


### PR DESCRIPTION
## What & why

Retires CodePlane's hand-rolled event model wholesale and makes **`traceforge.SessionEvent` + `EventMetadata` the ONE canonical event object end to end**, keyed by **open dotted TraceForge kinds** (`job.created`, `tool.call.completed`, `permission.requested`, …). This is a **direct replacement** — no onramp, no outbound shim, no TF→old-wire translator, no parity harness, no feature flag. The frontend **adapts in this same PR** (it is not a protected contract), including the regenerated OpenAPI types.

Supersedes the additive/flag-gated spine originally scoped in #29.

Refs #29 #28

## Commits
1. `6d35e0d1` — delete the `DomainEvent` dataclass; `traceforge.SessionEvent` becomes the `EventBus` currency; migrate ~30 producers + ~11 subscribers + persistence.
2. `be6ed12b` — delete `DomainEventKind`; introduce the dotted event-kind enum; split the single transcript kind into role kinds; `sse_manager` serializes the TF event **as-is**.
3. `e7d62931` — frontend adapts to the dotted TF SSE wire.
4. `010fac06` — fix 6 pre-existing OpenAPI forward-ref bugs that broke `generate:api`; regenerate `schema.d.ts` via the documented openapi-typescript tooling.
5. `19678340` — repair sidecar dispatcher kind guards missed by the migration (dotted-kind comparisons) + `TestExtractContent` regression suite.
6. `42fffd09` — rename the kind enum `CPEventKind → EventKind` (drop the CP/"Domain" prefix so the adopted vocabulary is TraceForge-native) + sync `SPEC.md` to the dotted TF event/SSE model.

## Backend — keystone `backend/models/events.py`
- **Deleted** `DomainEvent` dataclass, `make_event_id`, `for_job`.
- **Deleted** the `DomainEventKind` PascalCase enum; **added `EventKind`** — a dotted `StrEnum` (`job.created`, `job.failed`, `merge.completed`, `permission.requested`, `step.started`/`completed`, `model.downgraded`, `log`, `message.user`/`message.assistant`, `tool.call.started`/`completed`/`failed`, `file.edited`, `session.ended`, …) with safe symbol member names over TraceForge's open string grammar. CP-specific fields ride `payload`; `turn_id` rides `EventMetadata`. `traceforge.types.EventKind` is not imported anywhere in the backend today, so the name collides with nothing now (a future P1/P2 that adopts TF's `Pipeline` can alias `EventKind as TFEventKind` at that seam).
- **Added** `new_event(session_id, kind, payload, *, timestamp, metadata, sequence, event_id) -> SessionEvent` as the single construction point; re-exports `SessionEvent`/`EventMetadata` from `traceforge.types`.
- **Transcript role-split:** `TRANSCRIPT_KINDS` + `transcript_kind_for_role()` map each transcript role to a dotted `message.*` / `tool.call.*` kind (unknown → `message.assistant`).

## Backend — field migration (dotted-kind codemod across 59 files)
| old (`DomainEvent`) | new (`traceforge.SessionEvent`) |
|---|---|
| `.event_id` | `.id` |
| `.job_id` | `.session_id` |
| `.db_id` | `.metadata.sequence` |
| `.kind` (`DomainEventKind`) | `.kind` (dotted `EventKind` / `str`) |

- Job-less/global events use `session_id = job_id or ""`; jobless checks became `if not event.session_id`.
- **Frozen-model semantics:** `EventRepository.append` returns the DB rowid; `lifespan._persist_and_broadcast` stamps it onto a *new* event via `model_copy(update={"metadata": md.model_copy(update={"sequence": db_id})})`. No in-place mutation. The SSE resume cursor rides `metadata.sequence`.
- **Name-collision fix:** `backend/models/domain.py` defines a CP-input `SessionEvent`; in files using both, the CP input is aliased `CPSessionEvent` and the traceforge event stays bare `SessionEvent`.
- **Real runtime bug caught by the suite:** `snapshot_helpers._build_logs` / `_build_transcript` read `e.job_id` on `list[Any]` events (invisible to mypy) → fixed to `e.session_id`.

## SSE — serialize the TF event as-is (no translator)
`sse_manager.py` was rebuilt around dotted kinds: the wire `event:` is `str(event.kind)` (dotted); `data:` is `event.model_dump_json()` (`{id, kind, session_id, timestamp, payload, metadata}`); `id:` is `metadata.sequence`. **No TF→old-shape mapping exists anywhere.** The one exception is the `snapshot` frame, which remains a separate camelCase `SnapshotPayload` (it was never a TF event).

## Frontend — adapts to the dotted TF wire (#29 deliverable 7)
- **`store/sseNormalize.ts` (new):** ingestion adapter — recursive snake→camel **key** mapping (values untouched, so `role: "agent_delta"` survives), TF-envelope unwrap (injects `jobId=session_id`, `timestamp` fallback, `turnId` from `metadata.turn_id`), and `deriveJobStateFrame()` which reproduces the backend's former derived `job_state_changed` frame **on the client**.
- **Handlers:** all 5 lookup tables (`job`/`transcript`/`timeline`/`approval`/`misc`) remapped to dotted kinds; the 5 role-split transcript kinds all route to the one `handleTranscriptUpdate`, which still branches on `payload.role`. Fixed 3 approval snake reads (`batchId` ×2, `checkpointRef`).
- **`store/index.ts`:** `dispatchSSEEvent` rewritten — snapshot passthrough, primary dotted handler, then derived `job.state_changed` frame.
- **`hooks/useSSE.ts`:** dotted `eventTypes`, `normalizeTFEvent` at the wire boundary, lifecycle hydrate keyed on `session_id`.
- **Tests:** store tests moved to dotted kinds; added `sseNormalize.test.ts` (17 tests).

## Frontend — `schema.d.ts` regenerated (+ OpenAPI fix that unblocks it)
The owner requires the FE schema regenerated in this PR. The event-model change itself makes **no REST/OpenAPI change** (`api_schemas.py` untouched, no route signature/response-model/param changed; the SSE event model is not in the OpenAPI surface — `schema.d.ts` has **zero** `DomainEvent`/`SessionEvent`/`EventKind` refs). But `generate:api` had long been **broken**, so the committed schema was badly stale.

Root cause: 6 pre-existing forward-ref bugs under `from __future__ import annotations` made `app.openapi()` (and `/openapi.json`, `/docs`) 500:
- 5 routes returning Response subclasses omitted `response_model=None` (`hooks.claude`, artifacts download, workspace raw-file, analytics export, preview proxy) — now fixed to match the existing `events.py`/`share.py` convention.
- `analytics/sidecar-costs` returned the subscripted generic `list[SidecarCostEntry]`, whose forward ref never resolved into the response field — pinned with an explicit `response_model=list[SidecarCostEntry]`.

With those fixed, `app.openapi()` builds cleanly (132 paths) and the documented openapi-typescript tooling regenerates `schema.d.ts`. The resulting churn (**+4914/−991**) is **pre-existing REST endpoint drift** from unrelated features (`analytics/*`, `metrics/*`, `impact-graph`, `sidecar-templates`, `coderecon`, …) that accumulated while `generate:api` was broken — **none of it event-related**. FE `tsc --noEmit` passes clean against the regenerated schema.

## Docs — `SPEC.md` synced to the dotted model
`SPEC.md` still documented the retired model, so it was brought in line (docs-only; no code/ruff/mypy/pytest impact):
- §11 canonical event model: the `EventKind(StrEnum)` dotted enum + `traceforge.SessionEvent`/`EventMetadata` envelope replace the old `DomainEventKind` PascalCase enum and bespoke `DomainEvent` dataclass.
- §11.1/§11.2/§12.2 kind tables → dotted; the transcript row → the role-split family.
- §5.3/§5.3.1 SSE sections rewritten: the wire carries the `SessionEvent` as-is (`event:` = dotted kind, `data:` = `model_dump_json()`) with the broadcast-allowlist rules; removed the retired snake_case `DomainEvent`→SSE indirection catalog.
- `EventRepository` interface + scattered prose references → `SessionEvent`/dotted kinds.

## Scope / non-goals
- **No module added or deleted.** The `DomainEvent`/`DomainEventKind` symbols are gone from `events.py` but the module remains.
- Watchers (`watcher/copilot.py`, `watcher/claude.py`) only have their event **type** swapped to `new_event(...)`; swapping the file-tailing **mechanism** for TF `file_watch` is **P1**.
- `traceforge` is imported only where events are constructed; only `traceforge.types` is touched — no Pipeline/LLM.
- The 6-route OpenAPI fix is a genuine pre-existing-bug fix (unblocks `/openapi.json` + `/docs` + `generate:api`); it changes no response behavior (verified by the route suites).

## Validation (`uv`, Windows/PowerShell) — at HEAD `42fffd09`
**Backend**
- `uv run mypy backend` — clean apart from 2 pre-existing Windows-only errors (`pty`/`fcntl` in the unmodified `terminal_service.py`).
- `uv run ruff check backend` — all checks passed.
- `uv run pytest backend` — **3296 passed, 36 skipped, 16 failed**. All 16 are the **pre-existing Windows-only set** (path-sep asserts, symlink-privilege, git-CLI, Windows-pty across `test_api_settings`/`test_api_workspace`/`test_integration`/`test_artifact_service`/`test_config_registration`/`test_git_service`/`test_job_service`/`test_terminal_service`) — **zero migration-caused failures**; the pass/fail counts are stable across the nuke, dispatcher-fix, and rename commits.

**Frontend**
- `npm run typecheck` — clean (against the regenerated `schema.d.ts`), re-verified at HEAD after the rename.
- `npm run lint` — 0 errors (21 pre-existing warnings in unrelated files).
- `npx vitest run` — **192 passed, 1 skipped** (17 files).