### PR TITLE
feat(events): P0 follow-up — transcript role-split completion (tool.call.failed)

### DIFF
--- a/backend/models/events.py
+++ b/backend/models/events.py
@@ -48,6 +48,7 @@ class EventKind(StrEnum):
     message_delta = "message.delta"
     tool_call_started = "tool.call.started"
     tool_call_completed = "tool.call.completed"
+    tool_call_failed = "tool.call.failed"
     # --- Logs / diffs ---
     log_line_emitted = "log"
     diff_updated = "diff.updated"
@@ -120,16 +121,24 @@ TRANSCRIPT_KINDS: frozenset[EventKind] = frozenset(
         EventKind.message_delta,
         EventKind.tool_call_started,
         EventKind.tool_call_completed,
+        EventKind.tool_call_failed,
     }
 )
 
 
-def transcript_kind_for_role(role: str) -> EventKind:
+def transcript_kind_for_role(role: str, *, tool_success: bool | None = None) -> EventKind:
     """Map a transcript ``role`` to its dotted CodePlane event kind.
 
     Roles emitted by the adapters/watchers: ``operator``/``user`` (human input),
     ``agent``/``assistant`` (complete agent message), ``agent_delta`` (streaming
-    partial), ``tool_running`` (a tool began), ``tool_call`` (a tool completed).
+    partial), ``tool_running`` (a tool began — a *real* distinct start signal, so
+    ``tool.call.started`` is genuine, not synthesized), ``tool_call`` (a tool
+    finished).
+
+    A finished tool fans out on its corrected ``tool_success`` flag: a ``False``
+    value yields ``tool.call.failed`` so downstream consumers key off the kind
+    rather than re-deriving success from the payload; anything else (including a
+    missing flag) yields ``tool.call.completed``.
     """
     if role in ("operator", "user"):
         return EventKind.message_user
@@ -140,6 +149,8 @@ def transcript_kind_for_role(role: str) -> EventKind:
     if role == "tool_running":
         return EventKind.tool_call_started
     if role == "tool_call":
+        if tool_success is False:
+            return EventKind.tool_call_failed
         return EventKind.tool_call_completed
     # Unknown roles default to a full assistant message (safest for display).
     return EventKind.message_assistant

--- a/backend/services/events/event_processor.py
+++ b/backend/services/events/event_processor.py
@@ -159,7 +159,11 @@ class EventProcessor:
         }
         kind: EventKind | None
         if event.kind == SessionEventKind.transcript:
-            kind = transcript_kind_for_role(str(event.payload.get("role", "")))
+            tpayload = cast("dict[str, Any]", event.payload)
+            kind = transcript_kind_for_role(
+                str(tpayload.get("role", "")),
+                tool_success=cast("bool | None", tpayload.get("tool_success")),
+            )
         else:
             kind = mapping.get(event.kind)
         if kind is None:

--- a/backend/services/runtime/service.py
+++ b/backend/services/runtime/service.py
@@ -2577,7 +2577,11 @@ class RuntimeService:
         }
         kind: EventKind | None
         if event.kind == SessionEventKind.transcript:
-            kind = transcript_kind_for_role(str(event.payload.get("role", "")))
+            tpayload = cast("dict[str, Any]", event.payload)
+            kind = transcript_kind_for_role(
+                str(tpayload.get("role", "")),
+                tool_success=cast("bool | None", tpayload.get("tool_success")),
+            )
         else:
             kind = mapping.get(event.kind)
         if kind is None:

--- a/backend/services/trail/node_builder.py
+++ b/backend/services/trail/node_builder.py
@@ -629,11 +629,19 @@ class TrailNodeBuilder:
     async def _on_transcript_updated(self, event: SessionEvent) -> None:
         """Create or update trail nodes for transcript messages.
 
-        Handles three transcript roles:
-        - operator/user: Creates request nodes (operator messages).
-        - tool_call: Updates matching write sub-nodes with tool metadata
-          (tool_display, tool_intent, tool_success) per §13.3.
-        - agent/assistant: Updates step node agent_message if not already set.
+        Routes on the granular transcript kind:
+        - ``message.user``: creates request nodes (operator messages).
+        - ``tool.call.completed`` / ``tool.call.failed``: updates matching write
+          sub-nodes with tool metadata (tool_display, tool_intent, tool_success)
+          per §13.3. Both share ``role == "tool_call"`` and carry ``tool_success``.
+        - ``message.assistant`` (with an agent/assistant role): updates the step
+          node agent_message if not already set.
+
+        Streaming/partial transcript kinds (``message.delta``, ``tool.call.started``)
+        produce no trail nodes. The reasoning sub-stream shares the
+        ``message.assistant`` kind but carries a reasoning role, so the assistant
+        branch is role-refined to exclude it — preserving the prior behavior where
+        only complete agent messages reached the assistant handler.
         """
         job_id = event.session_id
         assert job_id is not None
@@ -642,13 +650,13 @@ class TrailNodeBuilder:
             return
 
         payload = event.payload or {}
-        role = payload.get("role", "")
+        role = str(payload.get("role", ""))
 
-        if role in ("operator", "user"):
+        if event.kind == EventKind.message_user:
             await self._handle_operator_transcript(event, state)
-        elif role == "tool_call":
+        elif event.kind in (EventKind.tool_call_completed, EventKind.tool_call_failed):
             await self._handle_tool_call_transcript(event, state)
-        elif role in ("agent", "assistant"):
+        elif event.kind == EventKind.message_assistant and role in ("agent", "assistant"):
             await self._handle_assistant_transcript(event, state)
 
     async def _handle_operator_transcript(

--- a/backend/tests/unit/test_events.py
+++ b/backend/tests/unit/test_events.py
@@ -1,0 +1,45 @@
+"""Unit tests for the transcript role -> dotted EventKind mapping."""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.models.events import EventKind, transcript_kind_for_role
+
+
+class TestTranscriptKindForRole:
+    @pytest.mark.parametrize(
+        ("role", "expected"),
+        [
+            ("operator", EventKind.message_user),
+            ("user", EventKind.message_user),
+            ("agent", EventKind.message_assistant),
+            ("assistant", EventKind.message_assistant),
+            ("agent_delta", EventKind.message_delta),
+            ("tool_running", EventKind.tool_call_started),
+            ("tool_call", EventKind.tool_call_completed),
+            # Reasoning / streaming sub-streams collapse to the full assistant
+            # message kind but keep their role as an intra-kind discriminator.
+            ("reasoning", EventKind.message_assistant),
+            ("reasoning_delta", EventKind.message_assistant),
+            ("tool_output_delta", EventKind.message_assistant),
+            ("", EventKind.message_assistant),
+            ("nonsense", EventKind.message_assistant),
+        ],
+    )
+    def test_role_maps_to_kind(self, role: str, expected: EventKind) -> None:
+        assert transcript_kind_for_role(role) == expected
+
+    def test_tool_call_defaults_to_completed_without_success_flag(self) -> None:
+        assert transcript_kind_for_role("tool_call") == EventKind.tool_call_completed
+        assert transcript_kind_for_role("tool_call", tool_success=None) == EventKind.tool_call_completed
+
+    def test_tool_call_success_true_is_completed(self) -> None:
+        assert transcript_kind_for_role("tool_call", tool_success=True) == EventKind.tool_call_completed
+
+    def test_tool_call_success_false_is_failed(self) -> None:
+        assert transcript_kind_for_role("tool_call", tool_success=False) == EventKind.tool_call_failed
+
+    def test_tool_success_flag_only_affects_tool_call_role(self) -> None:
+        # A False success on a non-tool_call role must not fan out to failed.
+        assert transcript_kind_for_role("agent", tool_success=False) == EventKind.message_assistant

--- a/backend/tests/unit/test_models.py
+++ b/backend/tests/unit/test_models.py
@@ -89,7 +89,10 @@ def test_domain_event_creation() -> None:
 
 
 def test_domain_event_kind_values() -> None:
-    assert len(EventKind) == 58
+    # 58 base kinds + tool.call.failed from the transcript role-split.
+    assert len(EventKind) == 59
+    assert EventKind.tool_call_failed in EventKind
+    assert str(EventKind.tool_call_failed) == "tool.call.failed"
 
 
 def test_job_domain_model() -> None:

--- a/backend/tests/unit/test_node_builder_extended.py
+++ b/backend/tests/unit/test_node_builder_extended.py
@@ -754,6 +754,40 @@ class TestTranscriptToolCall:
         updated = await trail_repo.get("w2")
         assert updated.tool_success is False
 
+    async def test_tool_call_failed_kind_routes_to_tool_handler(self, builder, trail_repo, job_state):
+        """A tool.call.failed event routes to the tool handler by kind (role stays tool_call)."""
+        node = TrailNodeRow(
+            id="w3",
+            job_id="job-1",
+            seq=1,
+            anchor_seq=1,
+            kind="write",
+            deterministic_kind="write",
+            timestamp=datetime.now(UTC),
+            enrichment="complete",
+            parent_id="p1",
+            turn_id="turn-1",
+            tool_name="run_command",
+        )
+        await trail_repo.create(node)
+        job_state["job-1"] = TrailJobState(active_goal_id="g1")
+
+        event = _make_event(
+            EventKind.tool_call_failed,
+            payload={
+                "role": "tool_call",
+                "turn_id": "turn-1",
+                "tool_name": "run_command",
+                "tool_display": "Run tests",
+                "tool_intent": "Verify",
+                "tool_success": False,
+            },
+        )
+        await builder.handle_event(event)
+        updated = await trail_repo.get("w3")
+        assert updated.tool_display == "Run tests"
+        assert updated.tool_success is False
+
     async def test_transcript_unknown_role_ignored(self, builder, job_state, trail_repo):
         job_state["job-1"] = TrailJobState(active_goal_id="g1")
         event = _make_event(

--- a/frontend/src/hooks/useSSE.ts
+++ b/frontend/src/hooks/useSSE.ts
@@ -113,6 +113,7 @@ export function useSSE(jobId?: string): { reconnect: () => void } {
         "message.delta",
         "tool.call.started",
         "tool.call.completed",
+        "tool.call.failed",
         "tool.group_summary",
         // Diffs
         "diff.updated",

--- a/frontend/src/store/handlers/transcriptHandlers.ts
+++ b/frontend/src/store/handlers/transcriptHandlers.ts
@@ -319,6 +319,7 @@ export const transcriptHandlers: Record<string, SSEHandler> = {
   "message.delta": handleTranscriptUpdate,
   "tool.call.started": handleTranscriptUpdate,
   "tool.call.completed": handleTranscriptUpdate,
+  "tool.call.failed": handleTranscriptUpdate,
   "tool.group_summary": handleToolGroupSummary,
   "secondary_session.started": handleSecondarySessionStarted,
   "secondary_session.entry": handleSecondarySessionEntry,

--- a/frontend/src/store/sseNormalize.test.ts
+++ b/frontend/src/store/sseNormalize.test.ts
@@ -117,6 +117,8 @@ describe("deriveJobStateFrame", () => {
   it("returns null for kinds that imply no job-state transition", () => {
     expect(deriveJobStateFrame("job.state_changed", p)).toBeNull();
     expect(deriveJobStateFrame("tool.call.completed", p)).toBeNull();
+    // `tool.call.failed` must NOT collide with the `job.failed` state mapping.
+    expect(deriveJobStateFrame("tool.call.failed", p)).toBeNull();
     expect(deriveJobStateFrame("permission.batch.requested", p)).toBeNull();
     expect(deriveJobStateFrame("message.assistant", p)).toBeNull();
   });


### PR DESCRIPTION
## What & why

**Follow-up to the merged #30** (`dde621e9`), completing the owner's **FORK-1 Option B** ruling: the transcript stream becomes fully granular traceforge-native by adding the **`tool.call.failed`** kind and routing trail nodes on the granular kinds.

#30 landed the wholesale nuke and split the single transcript kind into role kinds (`message.user`/`message.assistant`/`tool.call.started`/`tool.call.completed`), but it did **not** yet distinguish failed tool calls, and `node_builder` still routed on `payload.role`. This PR closes that gap.

Refs #29 #28 (completes the transcript role-split scoped in #29 deliverable, FORK-1 Option B).

## The delta (single commit `864c0042`, cherry-picked onto `main`)

- **`backend/models/events.py`** — add `EventKind.tool_call_failed = "tool.call.failed"`; include it in `TRANSCRIPT_KINDS`; `transcript_kind_for_role(role, *, tool_success)` now returns `tool.call.failed` when a `tool_call` entry reports `tool_success is False`, else `tool.call.completed`. (59 kinds, 6 transcript kinds.)
- **`event_processor.py` + `runtime/service.py`** — thread `payload.tool_success` into the transcript-kind derivation at both `_translate_event` sites.
- **`trail/node_builder.py`** — `_on_transcript_updated` now routes **primarily on `event.kind`** (`message.user`→operator, `tool.call.completed`/`tool.call.failed`→tool handler, `message.assistant`→assistant with a role-refine guard). Behavior-identical to the prior role-based routing; the tool handler already reads/stores `tool_success` unchanged.
- **Frontend** — register `tool.call.failed` in `useSSE` `eventTypes` + the `transcriptHandlers` dispatch map. The existing role-based renderer handles failed tools with no change (they keep `role="tool_call"`, replace the `tool_running` placeholder, store `toolSuccess`).
- **Tests** — new `test_events.py` (`transcript_kind_for_role` mapping + failure branch); `node_builder` `tool.call.failed` routing test; `sseNormalize` collision guard proving `tool.call.failed` ≠ `job.failed`; `EventKind` count → 59.

## Guardrails honored (FORK-1 design constraints)

- **No fabricated `tool.call.started`** — kept only because `tool_running` is a *real* adapter start signal (`event_pipeline.on_tool_start`), not invented.
- **All payload fields preserved** (`content`, `tool_name`, `tool_args`, `tool_result`, `tool_success`, `tool_duration_ms`, …) — the split changes only the kind discriminator.
- **`agent_delta` ephemeral streaming preserved** (broadcast-not-persisted).
- **No back-compat shim** for old persisted PascalCase kinds (dev DB is throwaway).

## Validation (`uv`, Windows/PowerShell) — tree byte-identical to the validated commit

- `uv run ruff check backend` — clean.
- `uv run mypy backend` — clean apart from the 2 pre-existing Windows-only `pty`/`fcntl` errors in the unmodified `terminal_service.py`.
- Affected backend suites (`test_events`, `test_models`, `test_node_builder_extended`, `test_event_processor`) — **115 passed**.
- FE `npm run typecheck` clean; `npx vitest run` 192 passed/1 skipped; `npm run build` success.

## Live smoke test (`make run` + real managed copilot jobs)

Drove two real `copilot` managed jobs end to end and inspected the DB + `/api/jobs/{id}/transcript`:

- **Success job** emitted the full dotted chain: `message.assistant` (role=reasoning), `tool.call.started` ×3 (role=tool_running, real starts), `tool.call.completed` ×3 (role=tool_call, `tool_success=true`), `message.assistant` (role=agent).
- **Failure job** (asked the agent to read a nonexistent file) emitted a genuine **`tool.call.failed`** — `role=tool_call`, `tool_name=view`, **`tool_success=false`** — alongside a succeeded `tool.call.completed`, proving the failure branch fires on a real agent, not just in unit tests. The `/transcript` endpoint returns both, so the FE renders failed + succeeded tool calls.

## Note on packaging

This is a **separate follow-up PR** rather than folded into #30 because #30 was already squash-merged into `main` (`dde621e9`). Content-wise `main` is identical to #30's head, so this cherry-pick applies cleanly and the branch diff is exactly the 10-file split above.
