### PR TITLE
fix(cli): correct Windows port/process detection for cpl up/down/restart

### DIFF
--- a/backend/cli.py
+++ b/backend/cli.py
@@ -492,29 +492,61 @@ def doctor(as_json: bool) -> None:
 
 
 def _find_pids_on_port(port: int) -> list[int]:
-    """Return PIDs of processes listening on the given TCP port."""
+    """Return PIDs of processes listening on the given TCP port (deduplicated)."""
+    import platform
+
+    if platform.system() == "Windows":
+        return _find_pids_on_port_windows(port)
+    return _find_pids_on_port_posix(port)
+
+
+def _find_pids_on_port_windows(port: int) -> list[int]:
+    """Windows: enumerate TCP listeners via psutil (no lsof/ss on this platform)."""
+    import psutil  # type: ignore[import-untyped]
+
+    try:
+        conns = psutil.net_connections(kind="tcp")
+    except (psutil.Error, OSError):
+        # Permission/enumeration issues — treat as "nothing found" rather than
+        # crashing the shutdown flow. No traceback spam for an expected race.
+        structlog.get_logger().debug("psutil_net_connections_failed", port=port, exc_info=True)
+        return []
+
+    pids = [
+        conn.pid
+        for conn in conns
+        if conn.status == psutil.CONN_LISTEN and conn.laddr and conn.laddr.port == port and conn.pid
+    ]
+    return list(dict.fromkeys(pids))  # dedupe, preserve order
+
+
+def _find_pids_on_port_posix(port: int) -> list[int]:
+    """POSIX: try ``lsof``, then ``ss``. Missing tools are expected — log quietly."""
     import subprocess as _sp
+
+    logger = structlog.get_logger()
 
     # Try lsof first (most POSIX systems)
     try:
         result = _sp.run(["lsof", "-ti", f":{port}"], capture_output=True, text=True)
         if result.returncode == 0 and result.stdout.strip():
-            return [int(p) for p in result.stdout.strip().splitlines() if p.strip().isdigit()]
+            pids = [int(p) for p in result.stdout.strip().splitlines() if p.strip().isdigit()]
+            return list(dict.fromkeys(pids))
     except FileNotFoundError:
-        import structlog
-
-        structlog.get_logger().debug("lsof_not_found", port=port)
+        logger.debug("lsof_not_found", port=port)
 
     # Fallback: ss (Linux)
     try:
         import re
 
         result = _sp.run(["ss", "-tlnp", f"sport = :{port}"], capture_output=True, text=True)
-        return [int(p) for p in re.findall(r"pid=(\d+)", result.stdout)]
-    except Exception:  # noqa: BLE001
-        import structlog
-
-        structlog.get_logger().warning("ss_probe_failed", port=port, exc_info=True)
+        pids = [int(p) for p in re.findall(r"pid=(\d+)", result.stdout)]
+        return list(dict.fromkeys(pids))
+    except FileNotFoundError:
+        logger.debug("ss_not_found", port=port)
+    except OSError:
+        # Genuine unexpected failure (not a missing-command case) — surface it.
+        logger.warning("ss_probe_failed", port=port, exc_info=True)
 
     return []
 
@@ -524,27 +556,27 @@ def _is_server_running(host: str, port: int) -> tuple[bool, list[int]]:
 
     Uses the same layered strategy as ``cpl doctor``:
     1. /health endpoint (definitive)
-    2. Process scan for ``cpl up`` / ``cpl restart`` commands
-    3. Port-level PID detection
+    2. Port-level PID detection (real TCP listeners)
+
+    A process merely *matching* ``cpl up``/``cpl restart`` in its command
+    line (``find_cpl_processes``) is NOT sufficient evidence on its own —
+    stale or orphaned processes can match without actually holding the port,
+    and the match is machine-wide so it can't be trusted to belong to *this*
+    port. Trusting that alone previously caused false "already running"
+    conflicts. ``_stop_server`` does not consult ``find_cpl_processes`` at
+    all — it only ever signals PIDs actually bound to the requested port.
 
     Returns (running, pids).  *pids* may be empty when detection succeeded
     via health-probe alone — callers that need PIDs should fall back to
     ``_find_pids_on_port``.
     """
-    from backend.services.setup.checks import find_cpl_processes
-
     # 1. Health endpoint
     status, _ = _api_get(f"http://{host}:{port}", "/health")
     if status == 200:
         pids = _find_pids_on_port(port)
         return True, pids
 
-    # 2. Process scan (cross-platform)
-    pids = find_cpl_processes()
-    if pids:
-        return True, pids
-
-    # 3. Port-level detection
+    # 2. Port-level detection (definitive real-listener check)
     pids = _find_pids_on_port(port)
     if pids:
         return True, pids
@@ -634,22 +666,39 @@ def _kill_process_group(pid: int, sig: int) -> None:
 def _stop_server(port: int, timeout_seconds: int = 10) -> bool:
     """Send SIGTERM, wait up to *timeout_seconds*, then SIGKILL if still alive.
 
-    Kills both port-owning processes (uvicorn workers) and parent ``cpl up``
-    / ``uv run cpl up`` processes so the entire process tree is cleaned up.
-    Uses process-group signals so that child processes (tunnel daemons,
-    uvicorn workers) are terminated together with their parent.
+    Only targets processes actually bound to *port* (via
+    ``_find_pids_on_port``) — never a machine-wide process-name/command-line
+    scan. ``find_cpl_processes`` is deliberately NOT consulted here: since
+    ``cpl down``/``cpl restart`` accept an explicit ``--port``, running
+    multiple CodePlane instances on different ports is a supported usage,
+    and a "cpl up"/"cpl restart" command-line match is machine-wide — it
+    would return PIDs belonging to a *different*, unrelated instance bound
+    to a different port (or a transient self-match of the scanning process
+    itself) and kill/misreport it by mistake. Uses process-group signals so
+    that child processes (tunnel daemons, uvicorn workers) are terminated
+    together with their parent.
     """
     import os
     import time
 
-    from backend.services.setup.checks import find_cpl_processes
+    from backend.services.setup.checks import _port_is_listening
 
     pids = _find_pids_on_port(port)
-    # Also include parent cpl-up processes that may not own the port directly
-    cpl_pids = find_cpl_processes()
-    all_pids = list(dict.fromkeys(pids + cpl_pids))  # deduplicate, preserve order
 
-    if not all_pids:
+    if not pids:
+        if _port_is_listening(port):
+            # Something is bound to the port but we couldn't attribute a PID
+            # to it (e.g. psutil.AccessDenied, or POSIX with neither lsof
+            # nor ss available). This is NOT "already stopped" — fail
+            # loudly instead of silently claiming success, and don't widen
+            # to a machine-wide process scan to compensate.
+            click.secho(
+                f"  A process is listening on port {port} but its PID could not be "
+                "determined (permission denied or detection failure). Please stop it "
+                "manually.",
+                fg="yellow",
+            )
+            return False
         click.echo("  No process found — already stopped.")
         return True
 
@@ -658,7 +707,7 @@ def _stop_server(port: int, timeout_seconds: int = 10) -> bool:
     pgids_seen: set[int] = set()
     ordered_pids: list[int] = []
     getpgid = getattr(os, "getpgid", None)
-    for pid in all_pids:
+    for pid in pids:
         if getpgid is None:
             ordered_pids.append(pid)
             continue
@@ -670,19 +719,17 @@ def _stop_server(port: int, timeout_seconds: int = 10) -> bool:
             pgids_seen.add(pgid)
             ordered_pids.append(pid)
 
-    click.echo(f"  Sending SIGTERM to PID(s) {all_pids}…")
+    click.echo(f"  Sending SIGTERM to PID(s) {pids}…")
     for pid in ordered_pids:
         _kill_process_group(pid, signal.SIGTERM)
     # Also signal any PID we couldn't resolve a group for
-    for pid in all_pids:
+    for pid in pids:
         with contextlib.suppress(ProcessLookupError, PermissionError):
             os.kill(pid, signal.SIGTERM)
 
     deadline = time.monotonic() + timeout_seconds
     while True:
-        remaining_port = _find_pids_on_port(port)
-        remaining_cpl = find_cpl_processes()
-        remaining = list(dict.fromkeys(remaining_port + remaining_cpl))
+        remaining = _find_pids_on_port(port)
         if not remaining:
             break
         if time.monotonic() > deadline:

--- a/backend/services/setup/checks.py
+++ b/backend/services/setup/checks.py
@@ -104,10 +104,17 @@ def _check_gh_auth() -> tuple[bool, str]:
 
 
 def _check_server_running(host: str, port: int) -> tuple[bool, str]:
-    """Probe the /health endpoint, falling back to process detection.
+    """Probe the /health endpoint, falling back to a real TCP-listener check.
 
     Returns (running, detail).  The detail string includes version/uptime when
     the health endpoint is reachable, or PID info when only the process is found.
+
+    A process merely *matching* ``cpl up``/``cpl restart`` in its command line
+    (see ``find_cpl_processes``) is NOT sufficient evidence on its own — stale
+    or orphaned processes can match without actually holding the port, which
+    previously caused false "already running" conflicts during ``cpl up``
+    preflight. We only trust the process scan once we've confirmed something
+    is actually listening on the port.
     """
     import json
     from urllib.error import URLError
@@ -129,13 +136,64 @@ def _check_server_running(host: str, port: int) -> tuple[bool, str]:
     except (URLError, OSError, ValueError):
         pass
 
-    # 2. Fallback — scan for a cpl process (cross-platform)
+    # 2. Require an actual listening socket before trusting anything else.
+    if not _port_is_listening(port):
+        return False, "not reachable"
+
+    # 3. Something is listening but /health didn't respond — enrich with
+    # process detail when we can attribute it to a cpl process.
     pids = find_cpl_processes()
     if pids:
         pids_str = ", ".join(str(p) for p in pids)
         return True, f"process detected (PID {pids_str}) but /health not reachable"
 
-    return False, "not reachable"
+    return True, "port in use but /health not reachable"
+
+
+def _windows_ancestor_pids() -> set[int]:
+    """Return the current process's PID plus every ancestor's PID (Windows).
+
+    ``find_cpl_processes``'s WMIC query matches on command-line substrings
+    ("cpl" + "up"/"restart"), which the *current* invocation of ``cpl up``/
+    ``cpl restart`` itself always satisfies (its own command line literally
+    contains those words), as do its uv/venv-python ancestors. Without this
+    exclusion, ``find_cpl_processes`` would report the running invocation's
+    own process tree as "another" cpl process — harmless for the read-only
+    preflight detail message, but actively dangerous for ``_stop_server``
+    (``cli.py``), which sends real signals to every PID it returns: during
+    ``cpl restart`` that would mean killing the restart command's own
+    process tree mid-flight. Mirrors the equivalent ancestor-walk already
+    done on the POSIX branch below.
+    """
+    exclude: set[int] = set()
+    pid_to_ppid: dict[int, int] = {}
+    try:
+        result = subprocess.run(
+            ["wmic", "process", "get", "ProcessId,ParentProcessId"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        lines = result.stdout.splitlines()
+        if lines:
+            header = lines[0].split()
+            if "ProcessId" in header and "ParentProcessId" in header:
+                pid_idx = header.index("ProcessId")
+                ppid_idx = header.index("ParentProcessId")
+                for line in lines[1:]:
+                    parts = line.split()
+                    if len(parts) <= max(pid_idx, ppid_idx):
+                        continue
+                    if parts[pid_idx].isdigit() and parts[ppid_idx].isdigit():
+                        pid_to_ppid[int(parts[pid_idx])] = int(parts[ppid_idx])
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        pass  # Fall through — exclude will still contain at least our own PID.
+
+    ancestor = os.getpid()
+    while ancestor and ancestor not in exclude:
+        exclude.add(ancestor)
+        ancestor = pid_to_ppid.get(ancestor, 0)
+    return exclude
 
 
 def find_cpl_processes() -> list[int]:
@@ -159,10 +217,14 @@ def find_cpl_processes() -> list[int]:
                 text=True,
                 timeout=5,
             )
+            candidate_pids: list[int] = []
             for line in result.stdout.splitlines():
                 line = line.strip()
                 if line.isdigit():
-                    pids.append(int(line))
+                    candidate_pids.append(int(line))
+            if candidate_pids:
+                ancestor_pids = _windows_ancestor_pids()
+                pids = [p for p in candidate_pids if p not in ancestor_pids]
         except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
             pass
     else:
@@ -206,11 +268,32 @@ def find_cpl_processes() -> list[int]:
     return pids
 
 
-def _check_port(port: int) -> tuple[bool, str]:
-    """Check if a port is available. Returns (available, detail)."""
+def _port_is_listening(port: int) -> bool:
+    """True if something is actively accepting TCP connections on this port (loopback).
+
+    This is the only reliable cross-platform signal that a real listener owns
+    the port — unlike command-line/process-name matching (``find_cpl_processes``),
+    it can't produce false positives from stale or unrelated processes.
+    """
     probe_targets: list[tuple[int, str]] = [(socket.AF_INET, "127.0.0.1")]
     if socket.has_ipv6:
         probe_targets.append((socket.AF_INET6, "::1"))
+
+    for family, host in probe_targets:
+        try:
+            with socket.socket(family, socket.SOCK_STREAM) as probe:
+                probe.settimeout(0.2)
+                if probe.connect_ex((host, port)) == 0:
+                    return True
+        except OSError:
+            continue
+    return False
+
+
+def _check_port(port: int) -> tuple[bool, str]:
+    """Check if a port is available. Returns (available, detail)."""
+    if _port_is_listening(port):
+        return False, "in use"
 
     refused_errnos = {
         0,
@@ -219,15 +302,6 @@ def _check_port(port: int) -> tuple[bool, str]:
         errno.ENETUNREACH,
         errno.EADDRNOTAVAIL,
     }
-
-    for family, host in probe_targets:
-        try:
-            with socket.socket(family, socket.SOCK_STREAM) as probe:
-                probe.settimeout(0.2)
-                if probe.connect_ex((host, port)) == 0:
-                    return False, "in use"
-        except OSError:
-            continue
 
     try:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:

--- a/backend/tests/unit/test_cli.py
+++ b/backend/tests/unit/test_cli.py
@@ -2,10 +2,18 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from click.testing import CliRunner
 
+from backend.cli import (
+    _find_pids_on_port,
+    _find_pids_on_port_posix,
+    _find_pids_on_port_windows,
+    _is_server_running,
+    _stop_server,
+)
 from backend.main import cli
 
 
@@ -38,6 +46,255 @@ def test_doctor_json_output() -> None:
     assert "passed" in data
     assert "warnings" in data
     assert "failed" in data
+
+
+# ---------------------------------------------------------------------------
+# _find_pids_on_port
+# ---------------------------------------------------------------------------
+
+
+def _mk_conn(pid: int | None, port: int, status: str = "LISTEN", ip: str = "0.0.0.0") -> SimpleNamespace:
+    laddr = SimpleNamespace(ip=ip, port=port) if port else None
+    return SimpleNamespace(pid=pid, status=status, laddr=laddr)
+
+
+class TestFindPidsOnPortDispatch:
+    @patch("platform.system", return_value="Windows")
+    @patch("backend.cli._find_pids_on_port_windows", return_value=[111])
+    @patch("backend.cli._find_pids_on_port_posix")
+    def test_dispatches_to_windows(self, mock_posix, mock_windows, _mock_sys) -> None:
+        assert _find_pids_on_port(8080) == [111]
+        mock_windows.assert_called_once_with(8080)
+        mock_posix.assert_not_called()
+
+    @patch("platform.system", return_value="Linux")
+    @patch("backend.cli._find_pids_on_port_posix", return_value=[222])
+    @patch("backend.cli._find_pids_on_port_windows")
+    def test_dispatches_to_posix(self, mock_windows, mock_posix, _mock_sys) -> None:
+        assert _find_pids_on_port(8080) == [222]
+        mock_posix.assert_called_once_with(8080)
+        mock_windows.assert_not_called()
+
+
+class TestFindPidsOnPortWindows:
+    @patch("psutil.net_connections")
+    def test_never_invokes_lsof_or_ss(self, mock_net_connections) -> None:
+        """Windows path must not shell out to POSIX-only tools."""
+        mock_net_connections.return_value = [_mk_conn(pid=42, port=8080)]
+        with patch("subprocess.run") as mock_run:
+            pids = _find_pids_on_port_windows(8080)
+        mock_run.assert_not_called()
+        assert pids == [42]
+
+    @patch("psutil.net_connections")
+    def test_filters_by_port_and_listen_status(self, mock_net_connections) -> None:
+        mock_net_connections.return_value = [
+            _mk_conn(pid=1, port=8080, status="LISTEN"),
+            _mk_conn(pid=2, port=9090, status="LISTEN"),  # different port
+            _mk_conn(pid=3, port=8080, status="ESTABLISHED"),  # not listening
+            _mk_conn(pid=4, port=8080, status="TIME_WAIT"),  # not listening
+        ]
+        assert _find_pids_on_port_windows(8080) == [1]
+
+    @patch("psutil.net_connections")
+    def test_dedupes_pids(self, mock_net_connections) -> None:
+        """A process can hold multiple listening sockets (IPv4 + IPv6) on the same port."""
+        mock_net_connections.return_value = [
+            _mk_conn(pid=7, port=8080, ip="0.0.0.0"),
+            _mk_conn(pid=7, port=8080, ip="::"),
+        ]
+        assert _find_pids_on_port_windows(8080) == [7]
+
+    @patch("psutil.net_connections")
+    def test_no_listener_returns_empty(self, mock_net_connections) -> None:
+        mock_net_connections.return_value = []
+        assert _find_pids_on_port_windows(8080) == []
+
+    @patch("psutil.net_connections")
+    def test_ignores_connections_without_pid(self, mock_net_connections) -> None:
+        """Sockets we can't attribute to a PID (pid=None/0) must not be returned."""
+        mock_net_connections.return_value = [
+            _mk_conn(pid=None, port=8080),
+            _mk_conn(pid=0, port=8080),
+        ]
+        assert _find_pids_on_port_windows(8080) == []
+
+    def test_access_denied_returns_empty_without_raising(self) -> None:
+        import psutil
+
+        with patch("psutil.net_connections", side_effect=psutil.AccessDenied()):
+            assert _find_pids_on_port_windows(8080) == []
+
+    def test_os_error_returns_empty_without_raising(self) -> None:
+        with patch("psutil.net_connections", side_effect=OSError("boom")):
+            assert _find_pids_on_port_windows(8080) == []
+
+
+class TestFindPidsOnPortPosix:
+    @patch("subprocess.run")
+    def test_uses_lsof_when_available(self, mock_run) -> None:
+        mock_run.return_value = SimpleNamespace(returncode=0, stdout="123\n456\n")
+        assert _find_pids_on_port_posix(8080) == [123, 456]
+
+    @patch("subprocess.run")
+    def test_dedupes_lsof_output(self, mock_run) -> None:
+        mock_run.return_value = SimpleNamespace(returncode=0, stdout="123\n123\n")
+        assert _find_pids_on_port_posix(8080) == [123]
+
+    def test_falls_back_to_ss_when_lsof_missing(self) -> None:
+        def fake_run(cmd, **_kwargs):
+            if cmd[0] == "lsof":
+                raise FileNotFoundError("lsof not found")
+            return SimpleNamespace(returncode=0, stdout='tcp LISTEN 0 128 *:8080 *:* users:(("x",pid=789,fd=3))')
+
+        with patch("subprocess.run", side_effect=fake_run):
+            assert _find_pids_on_port_posix(8080) == [789]
+
+    def test_no_listener_returns_empty_when_both_missing(self) -> None:
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            assert _find_pids_on_port_posix(8080) == []
+
+    def test_genuine_ss_error_does_not_raise(self) -> None:
+        """A real (non-missing-command) failure should be swallowed, not propagated."""
+
+        def fake_run(cmd, **_kwargs):
+            if cmd[0] == "lsof":
+                raise FileNotFoundError("lsof not found")
+            raise OSError("permission denied")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            assert _find_pids_on_port_posix(8080) == []
+
+
+# ---------------------------------------------------------------------------
+# _is_server_running
+# ---------------------------------------------------------------------------
+
+
+class TestIsServerRunning:
+    @patch("backend.cli._api_get", return_value=(200, {}))
+    @patch("backend.cli._find_pids_on_port", return_value=[42])
+    def test_health_reachable_is_running(self, _mock_pids, _mock_api) -> None:
+        running, pids = _is_server_running("127.0.0.1", 8080)
+        assert running is True
+        assert pids == [42]
+
+    @patch("backend.cli._api_get", return_value=(0, None))
+    @patch("backend.cli._find_pids_on_port", return_value=[99])
+    def test_real_listener_without_health_is_running(self, _mock_pids, _mock_api) -> None:
+        """A real port listener alone (health unreachable) is still "running"."""
+        running, pids = _is_server_running("127.0.0.1", 8080)
+        assert running is True
+        assert pids == [99]
+
+    @patch("backend.cli._api_get", return_value=(0, None))
+    @patch("backend.cli._find_pids_on_port", return_value=[])
+    def test_no_listener_and_no_health_is_not_running(self, _mock_pids, _mock_api) -> None:
+        """Regression: with no real listener and unreachable health, `down`/`restart`
+        must report "not running" even if stale processes exist elsewhere —
+        find_cpl_processes is intentionally not consulted here anymore."""
+        running, pids = _is_server_running("127.0.0.1", 8080)
+        assert running is False
+        assert pids == []
+
+
+# ---------------------------------------------------------------------------
+# _stop_server
+# ---------------------------------------------------------------------------
+
+
+class TestStopServer:
+    """`_stop_server` must only ever act on PIDs actually bound to the
+    requested port. `find_cpl_processes` is a machine-wide command-line
+    scan, and since `cpl down`/`cpl restart` accept an explicit `--port`,
+    running multiple CodePlane instances on different ports is supported —
+    so a machine-wide match must never be unioned into the kill-target list
+    or the shutdown-wait condition. These tests give a different, unrelated
+    instance (or a permanent self-match) a real chance to be pulled in via
+    `find_cpl_processes` and assert it never is.
+    """
+
+    @patch("time.sleep", return_value=None)
+    @patch("backend.services.setup.checks.find_cpl_processes")
+    @patch("backend.cli._kill_process_group")
+    @patch("os.kill")
+    @patch("backend.cli._find_pids_on_port")
+    def test_only_targets_pids_bound_to_requested_port(
+        self, mock_find_pids, mock_os_kill, mock_kill_group, mock_find_cpl, _mock_sleep
+    ) -> None:
+        """Regression: an unrelated CodePlane instance on a different port
+        (PID 200, e.g. bound to 8081) and a phantom WMIC self-match (PID
+        999) must never be signalled when stopping port 8080 — and
+        find_cpl_processes must not even be consulted."""
+        mock_find_cpl.return_value = [200, 999]  # would-be false extra targets
+        mock_find_pids.side_effect = [[100], [], []]  # initial, wait-loop check, final leftover check
+
+        result = _stop_server(8080, timeout_seconds=5)
+
+        assert result is True
+        mock_find_cpl.assert_not_called()
+        touched = {c.args[0] for c in mock_kill_group.call_args_list} | {c.args[0] for c in mock_os_kill.call_args_list}
+        assert touched == {100}
+
+    @patch("time.sleep", return_value=None)
+    @patch("backend.services.setup.checks.find_cpl_processes", return_value=[999, 999, 999])
+    @patch("backend.cli._kill_process_group")
+    @patch("os.kill")
+    @patch("backend.cli._find_pids_on_port")
+    def test_wmic_self_match_cannot_extend_wait_loop_or_force_kill(
+        self, mock_find_pids, _mock_os_kill, _mock_kill_group, mock_find_cpl, _mock_sleep, capsys
+    ) -> None:
+        """Regression: a permanently non-empty find_cpl_processes() (e.g. a
+        WMIC self-match that never clears) must not keep the shutdown wait
+        loop alive or trigger a false SIGKILL/force-kill message — the wait
+        loop only ever consults _find_pids_on_port for the target port."""
+        mock_find_pids.side_effect = [[100], [], []]
+
+        result = _stop_server(8080, timeout_seconds=5)
+
+        assert result is True
+        mock_find_cpl.assert_not_called()
+        output = capsys.readouterr().out
+        assert "SIGKILL" not in output
+        assert "timed out" not in output.lower()
+
+    @patch("backend.services.setup.checks._port_is_listening", return_value=True)
+    @patch("backend.cli._find_pids_on_port", return_value=[])
+    def test_listener_with_unattributable_pid_fails_safely(self, _mock_find_pids, _mock_listening) -> None:
+        """Regression: if something is listening on the port but no PID can
+        be attributed to it (e.g. psutil.AccessDenied), this must NOT be
+        silently reported as "already stopped" — nothing was verified
+        stopped, and we must not widen to a machine-wide process scan to
+        compensate."""
+        result = _stop_server(8080)
+        assert result is False
+
+    @patch("backend.services.setup.checks._port_is_listening", return_value=False)
+    @patch("backend.cli._find_pids_on_port", return_value=[])
+    def test_idempotent_when_nothing_listening(self, _mock_find_pids, _mock_listening) -> None:
+        """No listener at all -> cleanly report already-stopped (idempotent)."""
+        result = _stop_server(8080)
+        assert result is True
+
+    @patch("time.monotonic", side_effect=[0, 0, 100])
+    @patch("time.sleep", return_value=None)
+    @patch("backend.cli._kill_process_group")
+    @patch("os.kill")
+    @patch("backend.cli._find_pids_on_port")
+    def test_escalates_to_sigkill_after_timeout(
+        self, mock_find_pids, _mock_os_kill, mock_kill_group, _mock_sleep, _mock_monotonic, capsys
+    ) -> None:
+        """Preserve existing graceful-then-force behavior for the target
+        PID(s): still bound to the port after the timeout -> escalate."""
+        mock_find_pids.side_effect = [[100], [100], [100], []]
+
+        result = _stop_server(8080, timeout_seconds=1)
+
+        assert result is True
+        output = capsys.readouterr().out
+        assert "SIGKILL" in output
+        # Signalled twice: once with SIGTERM, once with the escalated signal.
+        assert [c.args[0] for c in mock_kill_group.call_args_list] == [100, 100]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_setup_service.py
+++ b/backend/tests/unit/test_setup_service.py
@@ -14,6 +14,7 @@ from backend.services.setup.checks import (
     _check_command,
     _check_port,
     _check_server_running,
+    _windows_ancestor_pids,
     find_cpl_processes,
     verify_requirements,
 )
@@ -428,6 +429,95 @@ class TestFindCplProcesses:
     def test_returns_empty_on_missing_ps(self, _mock_run, _mock_sys) -> None:
         assert find_cpl_processes() == []
 
+    @patch("platform.system", return_value="Windows")
+    @patch("os.getpid", return_value=100)
+    @patch("subprocess.run")
+    def test_windows_excludes_self_and_ancestor_pids(self, mock_run, _mock_pid, _mock_sys) -> None:
+        """Regression: running `cpl up`/`cpl restart` on Windows means the CURRENT
+        invocation's own command line (and its uv/venv-python ancestors) always
+        matches the wmic `%cpl%up%`/`%cpl%restart%` pattern too. Without excluding
+        the ancestor chain, `_stop_server` (cli.py) would treat the running
+        command's own process tree as "another" cpl process and send it a real
+        kill signal — i.e. `cpl restart` could kill itself mid-flight on Windows.
+        """
+        candidates = type(
+            "R",
+            (),
+            {"stdout": "ProcessId  \n\n100        \n\n200        \n\n300        \n", "returncode": 0},
+        )()
+        ancestors = type(
+            "R",
+            (),
+            {
+                "stdout": (
+                    "ParentProcessId  ProcessId  \n\n"
+                    "50               100        \n\n"
+                    "4                50         \n\n"
+                    "0                4          \n"
+                ),
+                "returncode": 0,
+            },
+        )()
+        mock_run.side_effect = [candidates, ancestors]
+        pids = find_cpl_processes()
+        # 100 (self) and its ancestors 50/4 are excluded; 200/300 are genuinely
+        # separate processes and must still be reported.
+        assert pids == [200, 300]
+        assert mock_run.call_count == 2
+        for call in mock_run.call_args_list:
+            assert call.args[0][0] == "wmic"
+
+    @patch("platform.system", return_value="Windows")
+    @patch("subprocess.run")
+    def test_windows_no_candidates_skips_ancestor_query(self, mock_run, _mock_sys) -> None:
+        """When the process scan finds nothing, we shouldn't bother querying the
+        ancestor chain (no candidates left to filter)."""
+        mock_run.return_value = type("R", (), {"stdout": "ProcessId  \n", "returncode": 0})()
+        pids = find_cpl_processes()
+        assert pids == []
+        assert mock_run.call_count == 1
+
+    @patch("platform.system", return_value="Windows")
+    @patch("subprocess.run", side_effect=FileNotFoundError)
+    def test_windows_returns_empty_on_missing_wmic(self, _mock_run, _mock_sys) -> None:
+        assert find_cpl_processes() == []
+
+
+# ---------------------------------------------------------------------------
+# _windows_ancestor_pids
+# ---------------------------------------------------------------------------
+
+
+class TestWindowsAncestorPids:
+    @patch("os.getpid", return_value=100)
+    @patch("subprocess.run")
+    def test_walks_full_ancestor_chain(self, mock_run, _mock_pid) -> None:
+        mock_run.return_value = type(
+            "R",
+            (),
+            {
+                "stdout": (
+                    "ParentProcessId  ProcessId  \n\n"
+                    "50               100        \n\n"
+                    "4                50         \n\n"
+                    "0                4          \n"
+                ),
+                "returncode": 0,
+            },
+        )()
+        assert _windows_ancestor_pids() == {100, 50, 4}
+
+    @patch("os.getpid", return_value=42)
+    @patch("subprocess.run", side_effect=FileNotFoundError)
+    def test_returns_at_least_self_on_wmic_failure(self, _mock_run, _mock_pid) -> None:
+        assert _windows_ancestor_pids() == {42}
+
+    @patch("os.getpid", return_value=42)
+    @patch("subprocess.run")
+    def test_returns_at_least_self_on_malformed_output(self, mock_run, _mock_pid) -> None:
+        mock_run.return_value = type("R", (), {"stdout": "garbage output with no header\n", "returncode": 0})()
+        assert _windows_ancestor_pids() == {42}
+
 
 # ---------------------------------------------------------------------------
 # _check_server_running
@@ -456,14 +546,61 @@ class TestCheckServerRunning:
         assert "v1.0" in detail
 
     @patch("backend.services.setup.checks.find_cpl_processes", return_value=[1234])
+    @patch("backend.services.setup.checks._port_is_listening", return_value=True)
     @patch("urllib.request.urlopen", side_effect=OSError("refused"))
-    def test_falls_back_to_process_scan(self, _mock_url, _mock_procs) -> None:
+    def test_falls_back_to_process_scan_when_port_is_listening(self, _mock_url, _mock_listening, _mock_procs) -> None:
+        """A cpl-matching process is trusted only once a real listener corroborates it."""
         running, detail = _check_server_running("127.0.0.1", 8080)
         assert running is True
         assert "1234" in detail
 
     @patch("backend.services.setup.checks.find_cpl_processes", return_value=[])
+    @patch("backend.services.setup.checks._port_is_listening", return_value=False)
     @patch("urllib.request.urlopen", side_effect=OSError("refused"))
-    def test_not_running(self, _mock_url, _mock_procs) -> None:
-        running, _ = _check_server_running("127.0.0.1", 8080)
+    def test_not_running(self, _mock_url, _mock_listening, _mock_procs) -> None:
+        running, detail = _check_server_running("127.0.0.1", 8080)
         assert running is False
+        assert detail == "not reachable"
+
+    @patch("backend.services.setup.checks.find_cpl_processes", return_value=[23280, 6684, 22436, 30052, 16260])
+    @patch("backend.services.setup.checks._port_is_listening", return_value=False)
+    @patch("urllib.request.urlopen", side_effect=OSError("refused"))
+    def test_stale_process_match_without_listener_is_not_running(self, _mock_url, _mock_listening, _mock_procs) -> None:
+        """Regression: command-line matches from stale/orphaned processes must not
+        be reported as "running" when nothing actually listens on the port —
+        otherwise `cpl up` preflight falsely blocks startup on a free port."""
+        running, detail = _check_server_running("127.0.0.1", 8080)
+        assert running is False
+        assert detail == "not reachable"
+
+    @patch("backend.services.setup.checks.find_cpl_processes", return_value=[])
+    @patch("backend.services.setup.checks._port_is_listening", return_value=True)
+    @patch("urllib.request.urlopen", side_effect=OSError("refused"))
+    def test_listener_without_process_match_is_still_running(self, _mock_url, _mock_listening, _mock_procs) -> None:
+        """A real listener alone (no attributable cpl process) is still "running"."""
+        running, detail = _check_server_running("127.0.0.1", 8080)
+        assert running is True
+        assert detail == "port in use but /health not reachable"
+
+
+# ---------------------------------------------------------------------------
+# _port_is_listening
+# ---------------------------------------------------------------------------
+
+
+class TestPortIsListening:
+    @patch("backend.services.setup.checks.socket.has_ipv6", False)
+    @patch("backend.services.setup.checks.socket.socket")
+    def test_listener_present(self, mock_socket) -> None:
+        from backend.services.setup.checks import _port_is_listening
+
+        mock_socket.side_effect = [_FakeSocket(connect_result=0)]
+        assert _port_is_listening(8080) is True
+
+    @patch("backend.services.setup.checks.socket.has_ipv6", False)
+    @patch("backend.services.setup.checks.socket.socket")
+    def test_no_listener(self, mock_socket) -> None:
+        from backend.services.setup.checks import _port_is_listening
+
+        mock_socket.side_effect = [_FakeSocket(connect_result=errno.ECONNREFUSED)]
+        assert _port_is_listening(8080) is False


### PR DESCRIPTION
## Summary

Fixes four related bugs on native Windows in CodePlane's process/port detection, all rooted in the same underlying weakness: relying on process-name/command-line pattern matching (`lsof`/`ss`/`wmic`/process-scan) as authoritative evidence instead of validating against an actual TCP listener, and killing based on unscoped process matches instead of PIDs actually bound to the requested port.

### Bug 1 — `cpl down`/`cpl restart` traceback spam on Windows
`_find_pids_on_port` unconditionally tried POSIX-only `lsof`, then `ss -tlnp`. The resulting `FileNotFoundError` was caught by a broad `except Exception: warning(exc_info=True)`, so every invocation on Windows logged a full Rich traceback even though shutdown eventually succeeded via a process-name fallback.

**Fix:** split `_find_pids_on_port` by platform. Windows uses `psutil.net_connections(kind="tcp")`, filtered to `CONN_LISTEN` entries bound to the requested port, deduplicated, with unattributable entries (no PID) dropped. `psutil.Error`/`OSError` during enumeration logs at debug, not raised. POSIX path unchanged, but a missing optional tool now logs at debug without `exc_info`; genuine errors still log a warning with `exc_info=True`.

### Bug 2 — `cpl up` preflight false-positive "already running"
`_check_server_running` (checks.py, used by `cpl up` preflight/`cpl doctor`) and `_is_server_running` (cli.py, used by `cpl down`/`cpl restart`) both trusted `find_cpl_processes()` — a loose wmic/ps command-line pattern match — as sufficient proof the server was running, without ever confirming a real TCP listener existed.

Reproduced live: `uv run cpl up --no-password` reported `Server (:8080) already running` on a machine with **zero** TCP rows (not just zero LISTEN rows) for local or remote port 8080 — a pure false positive blocking startup on a genuinely free port, with `--skip-preflight` as the only workaround.

**Fix:** added `_port_is_listening(port)` (checks.py, extracted from the existing `_check_port` socket probe). `_check_server_running` only uses `find_cpl_processes()` to enrich the detail message once `_port_is_listening` confirms a real listener — no listener + failed health now **always** returns not-running. `_is_server_running` (cli.py) now only trusts `/health` or an actual listener (`_find_pids_on_port`); the unconditional `find_cpl_processes()` fallback is removed from the decision path entirely. Established/time-wait/remote-port connections never count (they never reach `CONN_LISTEN`/a bound local port).

### Bug 3 — Windows self-match on process ancestor chain
Root cause behind bug 2's exact reported PIDs: `find_cpl_processes()`'s Windows branch had no exclusion for the current process's own ancestor chain (unlike the POSIX branch, which already walks pid→ppid to avoid self-detection). Since running `cpl up`/`cpl restart` always produces a matching command line, the current invocation's own process tree (`uv.exe → cpl.exe → venv python.exe → python.exe`) trivially self-matched — exactly reproducing the reported PID chain (`23280, 6684, 22436, 30052, 16260`).

**Fix:** added `_windows_ancestor_pids()`, mirroring the POSIX pid→ppid walk via a separate `wmic process get ProcessId,ParentProcessId` query (kept apart from the CommandLine-matching query to avoid CSV-escaping issues). `find_cpl_processes()` filters Windows wmic-matched candidates against this set before returning, with safe fallbacks if the ancestor query fails or is unparseable.

### Bug 4 — `_stop_server` unscoped kill risk across `--port`-separated instances
Even with bugs 2/3 fixed, `_stop_server` still unconditionally unioned `_find_pids_on_port(port)` with the **unscoped**, machine-wide `find_cpl_processes()` for both its kill-target list and its wait-loop "still running" check. Since `up`/`down`/`restart` all expose `--port`, multiple CodePlane instances on distinct ports is a supported interface — so `cpl down --port 8080` could SIGTERM/SIGKILL an unrelated instance on `--port 8081` merely because it also matched the "cpl up"/"cpl restart" command-line pattern, and a transient wmic self-match could keep the wait loop "remaining processes" non-empty until timeout, producing a false forced-kill message even after the real target listener was gone.

**Fix:** scoped `_stop_server` to `_find_pids_on_port(port)` only, for both the initial kill-target list and every wait-loop iteration — `find_cpl_processes()` is no longer consulted anywhere in the stop path. If no PIDs can be attributed to the port but `_port_is_listening` confirms a real listener is still present (e.g. `psutil.AccessDenied` prevented PID attribution), `_stop_server` now fails safely with an explicit warning instead of silently reporting success.

None of these fixes introduce process-name-based killing — `_stop_server` only ever signals PIDs discovered by `_find_pids_on_port` for the specific requested port, and the graceful session-pause flow in `down`/`restart` is untouched. No WSL-specific code was added or touched.

## Tests

`backend/tests/unit/test_cli.py`, `backend/tests/unit/test_setup_service.py`:
- Platform dispatch (Windows path never invokes `lsof`/`ss` subprocess calls), LISTEN-status + port filtering, PID dedup, no-listener handling, missing-PID filtering, quiet fallback on `psutil.AccessDenied`/`OSError`; POSIX lsof/ss/fallback/error-swallowed.
- `_is_server_running`/`_check_server_running`: health-reachable, real-listener-without-health, the exact-PID false-positive regression (`[23280, 6684, 22436, 30052, 16260]`, no listener → not running), listener-without-process-match-still-running.
- `find_cpl_processes`/`_windows_ancestor_pids`: Windows self+ancestor exclusion with a genuinely separate PID surviving, no-candidates skips the ancestor wmic call, wmic-failure/malformed-output fallbacks.
- `TestStopServer`: kill/wait scoped only to the requested port's PIDs (an unrelated instance's PID on a different port, and a wmic self-match, are never touched — `find_cpl_processes` is asserted never called); a wmic self-match cannot extend the wait loop or trigger a false forced-kill message; an unattributable listener (AccessDenied) fails safely with a warning; idempotent no-listener behavior; existing escalate-to-SIGKILL-after-timeout behavior preserved.

**Verification:**
- Targeted: `uv run pytest backend/tests/unit/test_cli.py backend/tests/unit/test_setup_service.py -q` → **74 passed**
- Full suite: `uv run pytest backend/tests -q` → **3111 passed, 36 skipped, 16 failed** — all 16 are pre-existing Windows-path/symlink baseline failures unrelated to this change (`test_api_settings.py`, `test_api_workspace.py`, `test_integration.py`, `test_artifact_service.py`, `test_config_registration.py`, `test_git_service.py`, `test_job_service.py`, `test_terminal_service.py`), none touching `cli.py` or `checks.py`.
- `ruff check` / `ruff format --check` clean on all changed files.
- `mypy` clean on `backend/cli.py`.
- Live-verified on native Windows: clean `cpl down` output (no traceback spam), port cleared per `netstat -ano`, idempotent re-run; `cpl up` preflight no longer self-conflicts on a free port despite a matching process scan; ancestor self-match reproduced and confirmed fixed; `cpl down --port` confirmed to only target the requested port's PIDs.

## Notes

- Deferred (explicitly non-blocking per reviewer): wording correction so "listener present + health unavailable + no attributable CodePlane PID" says "port in use" rather than implying "server already running" — not implemented to avoid scope creep on this safety-focused revision.
- No new dependencies (`psutil` was already a project dependency). No WSL-specific code.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
