### PR TITLE
fix: finalize terminal job artifacts

### DIFF
--- a/alembic/versions/0057_add_artifact_collection_status.py
+++ b/alembic/versions/0057_add_artifact_collection_status.py
@@ -1,0 +1,34 @@
+"""Add durable terminal artifact collection status to jobs.
+
+Revision ID: 0057
+Revises: 0056
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0057"
+down_revision = "0056"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "jobs",
+        sa.Column("artifact_collection_status", sa.String(), nullable=False, server_default="pending"),
+    )
+    op.add_column("jobs", sa.Column("artifact_collection_error", sa.Text(), nullable=True))
+    op.add_column(
+        "jobs",
+        sa.Column("artifact_collection_session_count", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.add_column("jobs", sa.Column("artifact_collection_updated_at", sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("jobs", "artifact_collection_updated_at")
+    op.drop_column("jobs", "artifact_collection_session_count")
+    op.drop_column("jobs", "artifact_collection_error")
+    op.drop_column("jobs", "artifact_collection_status")

--- a/backend/api/artifacts.py
+++ b/backend/api/artifacts.py
@@ -9,7 +9,9 @@ from fastapi import APIRouter, HTTPException
 from fastapi.responses import FileResponse
 
 from backend.models.api_schemas import ArtifactListResponse, ArtifactResponse
+from backend.models.domain import JobNotFoundError
 from backend.services.artifacts.artifact_service import ArtifactService, get_artifacts_base
+from backend.services.job.job_service import JobService
 
 router = APIRouter(tags=["artifacts"], route_class=DishkaRoute)
 
@@ -18,9 +20,14 @@ router = APIRouter(tags=["artifacts"], route_class=DishkaRoute)
 async def list_artifacts(
     job_id: str,
     svc: FromDishka[ArtifactService],
+    job_svc: FromDishka[JobService],
 ) -> ArtifactListResponse:
     """List all artifacts for a job."""
     artifacts = await svc.list_for_job(job_id)
+    try:
+        job = await job_svc.get_job(job_id)
+    except JobNotFoundError:
+        job = None
 
     items = [
         ArtifactResponse(
@@ -35,7 +42,12 @@ async def list_artifacts(
         )
         for a in artifacts
     ]
-    return ArtifactListResponse(items=items)
+    return ArtifactListResponse(
+        items=items,
+        collection_status=job.artifact_collection_status if job is not None else "completed",
+        collection_error=job.artifact_collection_error if job is not None else None,
+        collection_updated_at=job.artifact_collection_updated_at if job is not None else None,
+    )
 
 
 @router.get("/artifacts/{artifact_id}", response_class=FileResponse, response_model=None)

--- a/backend/api/job_artifacts.py
+++ b/backend/api/job_artifacts.py
@@ -412,8 +412,8 @@ async def get_job_transcript(
             )
         )
 
-    # Persisted events carry the canonical TraceForge sequence. Avoid inventing
-    # an order for any producer that does not provide it.
+    # Producer-stream sequence can order the transcript only when every event
+    # provides one. Otherwise retain deterministic storage query order.
     if all(item.sequence is not None for item in items):
         items.sort(key=lambda item: item.sequence or 0)
 

--- a/backend/api/job_artifacts.py
+++ b/backend/api/job_artifacts.py
@@ -369,12 +369,14 @@ async def get_job_transcript(
     items: list[TranscriptPayload] = [
         TranscriptPayload(
             job_id=event.session_id,
-            seq=(p := event.payload).get("seq", 0),
-            timestamp=p.get("timestamp", event.timestamp),
+            event_id=event.id,
+            sequence=event.metadata.sequence,
+            timestamp=(p := event.payload).get("timestamp", event.timestamp),
             kind=str(event.kind),
             content=p.get("content", ""),
             title=p.get("title"),
-            turn_id=p.get("turn_id"),
+            turn_id=event.metadata.turn_id or p.get("turn_id"),
+            tool_call_id=p.get("tool_call_id"),
             tool_name=p.get("tool_name"),
             arguments=_stringify_tool_args(p.get("arguments")),
             result=p.get("result"),
@@ -382,8 +384,8 @@ async def get_job_transcript(
             tool_issue=p.get("tool_issue"),
             tool_intent=(event.metadata.motivation.intent if event.metadata.motivation else None),
             tool_title=p.get("tool_title"),
-            tool_display=resolve_tool_display(p),
-            tool_display_full=resolve_tool_display_full(p),
+            tool_display=p.get("tool_display") or event.metadata.tool_display,
+            tool_display_full=p.get("tool_display_full") or p.get("tool_display") or event.metadata.tool_display,
             tool_duration_ms=(
                 int(event.metadata.duration_ms) if event.metadata.duration_ms is not None else None
             ),
@@ -398,7 +400,8 @@ async def get_job_transcript(
         items.append(
             TranscriptPayload(
                 job_id=event.session_id,
-                seq=p.get("seq", 0),
+                event_id=event.id,
+                sequence=event.metadata.sequence,
                 timestamp=p.get("timestamp", event.timestamp),
                 kind=str(event.kind),
                 content=p.get("content", ""),
@@ -409,8 +412,10 @@ async def get_job_transcript(
             )
         )
 
-    # Sort all entries by timestamp for correct interleaving
-    items.sort(key=lambda x: x.timestamp)
+    # Persisted events carry the canonical TraceForge sequence. Avoid inventing
+    # an order for any producer that does not provide it.
+    if all(item.sequence is not None for item in items):
+        items.sort(key=lambda item: item.sequence or 0)
 
     return TranscriptListResponse(items=items)
 

--- a/backend/lifespan.py
+++ b/backend/lifespan.py
@@ -22,7 +22,7 @@ from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from backend.config import MCP_PATH, VOICE_MAX_AUDIO_SIZE_MB, CPLConfig, get_codeplane_dir, load_config
 from backend.di import AppProvider, CachedModelsBySdk, RequestProvider, VoiceMaxBytes
-from backend.models.events import EventKind, EventMetadata, SessionEvent, new_event
+from backend.models.events import EventKind, SessionEvent, new_event
 from backend.persistence.database import create_engine, create_session_factory, serialized_write
 from backend.persistence.event_repo import EventRepository
 from backend.persistence.step_repo import StepRepository
@@ -297,8 +297,8 @@ def _init_event_infrastructure(
     sse_manager = SSEManager()
     dead_letter: asyncio.Queue[tuple[SessionEvent, int]] = asyncio.Queue()
 
-    # Persist-then-broadcast subscriber: stamps the autoincrement DB id onto
-    # metadata.sequence (the SSE resume cursor) before SSE frames are built.
+    # Persist-then-broadcast subscriber: keeps the storage-local SSE resume
+    # cursor separate from the canonical TraceForge event envelope.
     async def _persist_and_broadcast(event: SessionEvent) -> None:
         # message.delta events are ephemeral streaming chunks — broadcast
         # immediately without writing to DB (the complete agent message
@@ -327,16 +327,11 @@ def _init_event_infrastructure(
             )
             dead_letter.put_nowait((event, 0))
             # Broadcast anyway so the SSE stream doesn't silently drop the
-            # event; the client will get it without a sequence which means the
-            # replay cursor won't cover it, but it's better than silence.
+            # event; the client will get it without a storage cursor, so replay
+            # won't cover it, but it's better than silence.
             await sse_manager.broadcast_domain_event(event)
             return
-        # Stamp the SSE resume cursor (autoincrement id) onto metadata.sequence
-        # before broadcasting so clients receive a monotonic Last-Event-ID.
-        if db_id is not None:
-            metadata = event.metadata or EventMetadata()
-            event = event.model_copy(update={"metadata": metadata.model_copy(update={"sequence": db_id})})
-        await sse_manager.broadcast_domain_event(event)
+        await sse_manager.broadcast_domain_event(event, storage_cursor=db_id)
 
     async def _dead_letter_retry_loop() -> None:
         """Background task: retry persisting events that failed initially."""

--- a/backend/models/api_schemas.py
+++ b/backend/models/api_schemas.py
@@ -323,6 +323,9 @@ class ArtifactResponse(CamelModel):
 
 class ArtifactListResponse(CamelModel):
     items: list[ArtifactResponse]
+    collection_status: Literal["pending", "collecting", "completed", "failed"] = "pending"
+    collection_error: str | None = None
+    collection_updated_at: datetime | None = None
 
 
 class ModelListResponse(CamelModel):
@@ -472,13 +475,15 @@ class LogLinePayload(CamelModel):
 
 class TranscriptPayload(CamelModel):
     job_id: str
-    seq: int
+    event_id: str
+    sequence: int | None = None
     timestamp: datetime
     kind: str  # dotted TF event kind (e.g. "message.assistant", "tool.call.completed")
     content: str
     # Optional rich fields — only present for specific kinds
     title: str | None = None  # annotation title on agent messages
     turn_id: str | None = None  # groups reasoning + tool_calls + message
+    tool_call_id: str | None = None  # pairs tool.call.started/completed
     tool_name: str | None = None  # tool.call.*: tool identifier
     arguments: str | None = None  # tool.call.*: JSON-serialized arguments
     result: str | None = None  # tool.call.completed: text output from tool

--- a/backend/models/db.py
+++ b/backend/models/db.py
@@ -66,6 +66,14 @@ class JobRow(Base):
     structural_change_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
     structural_merge_confidence: Mapped[str | None] = mapped_column(String(10), nullable=True)
     trail_state_snapshot: Mapped[str | None] = mapped_column(Text, nullable=True)  # JSON
+    artifact_collection_status: Mapped[str] = mapped_column(
+        String, nullable=False, default="pending", server_default="pending"
+    )
+    artifact_collection_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    artifact_collection_session_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+    artifact_collection_updated_at: Mapped[datetime | None] = mapped_column(TZDateTime, nullable=True)
 
 
 class EventRow(Base):

--- a/backend/models/domain.py
+++ b/backend/models/domain.py
@@ -713,6 +713,10 @@ class Job:
     external_session_id: str | None = None
     tail_offset: int = 0
     mode: JobMode = JobMode.standard
+    artifact_collection_status: str = "pending"
+    artifact_collection_error: str | None = None
+    artifact_collection_session_count: int = 0
+    artifact_collection_updated_at: datetime | None = None
 
 
 @dataclass

--- a/backend/models/events.py
+++ b/backend/models/events.py
@@ -104,6 +104,7 @@ class EventKind(StrEnum):
     agent_plan_updated = "plan.updated"
     execution_phase_changed = "execution.phase_changed"
     telemetry_updated = "telemetry.updated"
+    artifacts_updated = "artifacts.updated"
     # --- Steps / plan ---
     step_started = "step.started"
     step_completed = "step.completed"

--- a/backend/models/events.py
+++ b/backend/models/events.py
@@ -462,9 +462,9 @@ def new_event(
 
     Single construction point that replaces the retired ``DomainEvent`` dataclass.
     ``session_id`` carries the CodePlane job id (``""`` for job-less/global events).
-    The persisted autoincrement id (the SSE resume cursor, formerly ``DomainEvent.db_id``)
-    rides on ``metadata.sequence``. ``timestamp`` and event ``id`` are auto-filled when
-    omitted, matching the old ``DomainEvent.for_job`` convenience.
+    ``sequence`` is canonical producer order and is never populated from CodePlane's
+    storage cursor. ``timestamp`` and event ``id`` are auto-filled when omitted,
+    matching the old ``DomainEvent.for_job`` convenience.
     """
     if metadata is None:
         metadata = EventMetadata(sequence=sequence)

--- a/backend/models/events.py
+++ b/backend/models/events.py
@@ -462,9 +462,9 @@ def new_event(
 
     Single construction point that replaces the retired ``DomainEvent`` dataclass.
     ``session_id`` carries the CodePlane job id (``""`` for job-less/global events).
-    ``sequence`` is canonical producer order and is never populated from CodePlane's
-    storage cursor. ``timestamp`` and event ``id`` are auto-filled when omitted,
-    matching the old ``DomainEvent.for_job`` convenience.
+    ``sequence`` is optional producer-stream order and is never a persistence cursor.
+    ``timestamp`` and event ``id`` are auto-filled when omitted, matching the old
+    ``DomainEvent.for_job`` convenience.
     """
     if metadata is None:
         metadata = EventMetadata(sequence=sequence)

--- a/backend/persistence/event_repo.py
+++ b/backend/persistence/event_repo.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 
 from sqlalchemy import func, select
 from traceforge.types import EventMetadata
@@ -10,6 +11,14 @@ from traceforge.types import EventMetadata
 from backend.models.db import EventRow
 from backend.models.events import TRANSCRIPT_KINDS, EventKind, SessionEvent, new_event
 from backend.persistence.repository import BaseRepository
+
+
+@dataclass(frozen=True, slots=True)
+class StoredEvent:
+    """A canonical event paired with its storage-local replay cursor."""
+
+    storage_cursor: int
+    event: SessionEvent
 
 
 class EventRepository(BaseRepository):
@@ -28,7 +37,6 @@ class EventRepository(BaseRepository):
             kind=EventKind(row.kind),
             payload=json.loads(row.payload),
             metadata=metadata,
-            sequence=row.id,
         )
 
     async def append(self, event: SessionEvent) -> int:
@@ -50,14 +58,17 @@ class EventRepository(BaseRepository):
         after_id: int,
         job_id: str | None = None,
         limit: int = 500,
-    ) -> list[SessionEvent]:
-        """List events with auto-increment id > after_id, optionally scoped to a job."""
+    ) -> list[StoredEvent]:
+        """List canonical events with their storage-local cursors."""
         stmt = select(EventRow).where(EventRow.id > after_id).order_by(EventRow.id)
         if job_id is not None:
             stmt = stmt.where(EventRow.job_id == job_id)
         stmt = stmt.limit(limit)
         result = await self._session.execute(stmt)
-        return [self._to_domain(row) for row in result.scalars().all()]
+        return [
+            StoredEvent(storage_cursor=row.id, event=self._to_domain(row))
+            for row in result.scalars().all()
+        ]
 
     async def list_by_job(
         self,

--- a/backend/persistence/job_repo.py
+++ b/backend/persistence/job_repo.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from sqlalchemy import and_, or_, select
+from sqlalchemy import and_, exists, or_, select
 
-from backend.models.db import DiffSnapshotRow, JobRow
+from backend.models.db import ArtifactRow, DiffSnapshotRow, JobRow
 from backend.models.domain import GitMergeOutcome, Job, JobMode, JobNotFoundError, JobState, Preset, Resolution
 from backend.persistence.repository import BaseRepository
 
@@ -89,6 +89,10 @@ class JobRepository(BaseRepository):
             external_session_id=row.external_session_id,
             tail_offset=row.tail_offset or 0,
             mode=JobMode(row.mode) if row.mode else JobMode.standard,
+            artifact_collection_status=row.artifact_collection_status or "pending",
+            artifact_collection_error=row.artifact_collection_error,
+            artifact_collection_session_count=row.artifact_collection_session_count or 0,
+            artifact_collection_updated_at=row.artifact_collection_updated_at,
         )
 
     async def create(self, job: Job) -> Job:
@@ -130,10 +134,98 @@ class JobRepository(BaseRepository):
             external_session_id=job.external_session_id,
             tail_offset=job.tail_offset,
             mode=job.mode,
+            artifact_collection_status=job.artifact_collection_status,
+            artifact_collection_error=job.artifact_collection_error,
+            artifact_collection_session_count=job.artifact_collection_session_count,
+            artifact_collection_updated_at=job.artifact_collection_updated_at,
         )
         self._session.add(row)
         await self._session.flush()
         return job
+
+    async def claim_artifact_collection(
+        self,
+        job_id: str,
+        *,
+        updated_at: datetime,
+        allow_stale: bool = False,
+    ) -> Job | None:
+        """Claim terminal artifact collection unless this session is already complete."""
+        result = await self._session.execute(select(JobRow).where(JobRow.id == job_id))
+        row = result.scalar_one_or_none()
+        if row is None:
+            raise JobNotFoundError(f"Job {job_id!r} not found")
+        if row.state not in {
+            JobState.review.value,
+            JobState.completed.value,
+            JobState.failed.value,
+            JobState.canceled.value,
+        }:
+            return None
+
+        artifact_exists = await self._session.scalar(
+            select(exists().where(ArtifactRow.job_id == job_id))
+        )
+        current_session = row.session_count or 1
+        already_complete = (
+            row.artifact_collection_status == "completed"
+            and (row.artifact_collection_session_count or 0) >= current_session
+            and bool(artifact_exists)
+        )
+        if already_complete or (row.artifact_collection_status == "collecting" and not allow_stale):
+            return None
+
+        row.artifact_collection_status = "collecting"
+        row.artifact_collection_error = None
+        row.artifact_collection_updated_at = updated_at
+        row.version = (row.version or 0) + 1
+        await self._session.flush()
+        return self._to_domain(row)
+
+    async def finish_artifact_collection(
+        self,
+        job_id: str,
+        *,
+        status: str,
+        error: str | None,
+        session_count: int,
+        updated_at: datetime,
+    ) -> None:
+        """Persist the terminal result of an artifact collection attempt."""
+        await self._update_row(
+            job_id,
+            artifact_collection_status=status,
+            artifact_collection_error=error,
+            artifact_collection_session_count=session_count,
+            artifact_collection_updated_at=updated_at,
+        )
+
+    async def list_artifact_collection_candidates(self) -> list[str]:
+        """Return terminal jobs whose current session has not produced artifacts."""
+        has_artifact = exists().where(ArtifactRow.job_id == JobRow.id)
+        stmt = (
+            select(JobRow.id)
+            .where(
+                JobRow.state.in_(
+                    [
+                        JobState.review.value,
+                        JobState.completed.value,
+                        JobState.failed.value,
+                        JobState.canceled.value,
+                    ]
+                )
+            )
+            .where(
+                or_(
+                    JobRow.artifact_collection_status != "completed",
+                    JobRow.artifact_collection_session_count < JobRow.session_count,
+                    ~has_artifact,
+                )
+            )
+            .order_by(JobRow.completed_at, JobRow.updated_at)
+        )
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
 
     async def get(self, job_id: str) -> Job | None:
         """Retrieve a job by ID, or None if not found."""

--- a/backend/persistence/job_repo.py
+++ b/backend/persistence/job_repo.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from sqlalchemy import and_, exists, or_, select
+from sqlalchemy import and_, or_, select
 
-from backend.models.db import ArtifactRow, DiffSnapshotRow, JobRow
+from backend.models.db import DiffSnapshotRow, JobRow
 from backend.models.domain import GitMergeOutcome, Job, JobMode, JobNotFoundError, JobState, Preset, Resolution
 from backend.persistence.repository import BaseRepository
 
@@ -163,14 +163,10 @@ class JobRepository(BaseRepository):
         }:
             return None
 
-        artifact_exists = await self._session.scalar(
-            select(exists().where(ArtifactRow.job_id == job_id))
-        )
         current_session = row.session_count or 1
         already_complete = (
             row.artifact_collection_status == "completed"
             and (row.artifact_collection_session_count or 0) >= current_session
-            and bool(artifact_exists)
         )
         if already_complete or (row.artifact_collection_status == "collecting" and not allow_stale):
             return None
@@ -201,8 +197,7 @@ class JobRepository(BaseRepository):
         )
 
     async def list_artifact_collection_candidates(self) -> list[str]:
-        """Return terminal jobs whose current session has not produced artifacts."""
-        has_artifact = exists().where(ArtifactRow.job_id == JobRow.id)
+        """Return terminal jobs without a completed current-session collection."""
         stmt = (
             select(JobRow.id)
             .where(
@@ -219,7 +214,6 @@ class JobRepository(BaseRepository):
                 or_(
                     JobRow.artifact_collection_status != "completed",
                     JobRow.artifact_collection_session_count < JobRow.session_count,
-                    ~has_artifact,
                 )
             )
             .order_by(JobRow.completed_at, JobRow.updated_at)

--- a/backend/services/artifacts/artifact_service.py
+++ b/backend/services/artifacts/artifact_service.py
@@ -89,6 +89,8 @@ class ArtifactService:
         artifacts_dir = Path(worktree_path) / ".codeplane" / "artifacts"
         if not artifacts_dir.is_dir():
             return collected
+        existing_artifacts = await self._repo.list_for_job(job_id)
+        existing_by_name = {a.name: a for a in existing_artifacts if a.type == ArtifactType.custom}
 
         for entry in sorted(artifacts_dir.iterdir()):
             if not entry.is_file() or entry.is_symlink():
@@ -102,6 +104,14 @@ class ArtifactService:
             if entry_size > _MAX_WORKSPACE_ARTIFACT_BYTES:
                 log.warning("artifact_too_large", path=str(entry), size=entry_size)
                 continue
+            existing = existing_by_name.get(entry.name)
+            if existing is not None:
+                dest = Path(existing.disk_path)
+                dest.write_bytes(entry.read_bytes())
+                await self._repo.update_size_bytes(existing.id, dest.stat().st_size)
+                collected.append(existing)
+                continue
+
             artifact_id = f"art-{uuid.uuid4().hex[:12]}"
             # Copy to central store
             disk_dir = _ARTIFACTS_BASE / job_id
@@ -301,13 +311,13 @@ class ArtifactService:
             try:
                 log_contents = json.loads(Path(existing_log.disk_path).read_text(encoding="utf-8"))
             except (json.JSONDecodeError, OSError):
-                log.warning(
+                log.error(
                     "session_log_read_failed",
                     job_id=job_id,
                     disk_path=existing_log.disk_path,
                     exc_info=True,
                 )
-                log_contents = {"sessions": []}
+                raise
 
             # Avoid duplicate session entries
             existing_nums = {s.get("session_number") for s in log_contents.get("sessions", [])}
@@ -484,9 +494,12 @@ class ArtifactService:
             tag = job_id[:12]
         name = f"{tag}-agent.log"
 
-        # Sort by sequence number (or timestamp as fallback).
+        # Sort by canonical TraceForge sequence (or timestamp as fallback).
         # Events without session_number (legacy) are treated as session 1.
-        sorted_events = sorted(log_events, key=lambda e: (e.get("session_number") or 1, e.get("seq") or 0))
+        sorted_events = sorted(
+            log_events,
+            key=lambda e: (e.get("session_number") or 1, e.get("sequence") or 0, e.get("timestamp") or ""),
+        )
 
         lines: list[str] = []
         current_session: int | None = None
@@ -593,7 +606,7 @@ class ArtifactService:
     async def store_agent_plan(
         self,
         job_id: str,
-        steps: list[dict[str, str]],
+        steps: list[dict[str, Any]],
         *,
         slug: str = "",
     ) -> Artifact | None:

--- a/backend/services/artifacts/finalization_service.py
+++ b/backend/services/artifacts/finalization_service.py
@@ -1,0 +1,108 @@
+"""Idempotent terminal artifact collection orchestration."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from weakref import WeakValueDictionary
+
+import structlog
+
+from backend.models.events import EventKind, new_event
+from backend.persistence.database import serialized_write
+from backend.persistence.job_repo import JobRepository
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    from backend.services.completers.summarization_service import SummarizationService
+    from backend.services.events.event_bus import EventBus
+    from backend.services.runtime.telemetry import RuntimeTelemetry
+
+log = structlog.get_logger()
+
+
+class ArtifactFinalizationService:
+    """Collect all terminal artifacts once per job session."""
+
+    def __init__(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        event_bus: EventBus,
+        summarization_service: SummarizationService | None,
+        telemetry: RuntimeTelemetry,
+    ) -> None:
+        self._session_factory = session_factory
+        self._event_bus = event_bus
+        self._summarization_service = summarization_service
+        self._telemetry = telemetry
+        self._locks: WeakValueDictionary[str, asyncio.Lock] = WeakValueDictionary()
+
+    async def finalize(self, job_id: str, *, recover_stale: bool = False) -> str:
+        """Finalize artifacts and return the durable collection status."""
+        lock = self._locks.setdefault(job_id, asyncio.Lock())
+        async with lock:
+            now = datetime.now(UTC)
+            async with serialized_write(self._session_factory) as session:
+                job = await JobRepository(session).claim_artifact_collection(
+                    job_id,
+                    updated_at=now,
+                    allow_stale=recover_stale,
+                )
+            if job is None:
+                async with self._session_factory() as session:
+                    current = await JobRepository(session).get(job_id)
+                return current.artifact_collection_status if current is not None else "pending"
+
+            try:
+                if self._summarization_service is None:
+                    raise RuntimeError("Summarization service is unavailable")
+                await self._summarization_service.save_snapshot_to_disk(job_id)
+                await self._telemetry.store_post_completion_artifacts(job_id)
+            except Exception as exc:
+                error = f"{type(exc).__name__}: {exc}"[:2000]
+                await self._finish(job_id, status="failed", error=error, session_count=job.session_count)
+                log.error("artifact_collection_failed", job_id=job_id, error=error, exc_info=True)
+                await self._publish(job_id, status="failed", error=error)
+                return "failed"
+
+            await self._finish(job_id, status="completed", error=None, session_count=job.session_count)
+            await self._publish(job_id, status="completed", error=None)
+            log.info("artifact_collection_completed", job_id=job_id, session_count=job.session_count)
+            return "completed"
+
+    async def recover_eligible(self) -> int:
+        """Backfill terminal jobs whose current session has no complete artifact set."""
+        async with self._session_factory() as session:
+            job_ids = await JobRepository(session).list_artifact_collection_candidates()
+        recovered = 0
+        for job_id in job_ids:
+            if await self.finalize(job_id, recover_stale=True) == "completed":
+                recovered += 1
+        if job_ids:
+            log.info("artifact_collection_recovery_finished", candidates=len(job_ids), completed=recovered)
+        return recovered
+
+    async def _finish(self, job_id: str, *, status: str, error: str | None, session_count: int) -> None:
+        async with serialized_write(self._session_factory) as session:
+            await JobRepository(session).finish_artifact_collection(
+                job_id,
+                status=status,
+                error=error,
+                session_count=session_count,
+                updated_at=datetime.now(UTC),
+            )
+
+    async def _publish(self, job_id: str, *, status: str, error: str | None) -> None:
+        await self._event_bus.publish(
+            new_event(
+                session_id=job_id,
+                kind=EventKind.artifacts_updated,
+                payload={
+                    "job_id": job_id,
+                    "collection_status": status,
+                    "collection_error": error,
+                },
+            )
+        )

--- a/backend/services/artifacts/finalization_service.py
+++ b/backend/services/artifacts/finalization_service.py
@@ -73,7 +73,7 @@ class ArtifactFinalizationService:
             return "completed"
 
     async def recover_eligible(self) -> int:
-        """Backfill terminal jobs whose current session has no complete artifact set."""
+        """Backfill terminal jobs without a completed current-session attempt."""
         async with self._session_factory() as session:
             job_ids = await JobRepository(session).list_artifact_collection_candidates()
         recovered = 0

--- a/backend/services/completers/summarization_service.py
+++ b/backend/services/completers/summarization_service.py
@@ -219,8 +219,7 @@ class SummarizationService:
                 job_repo = JobRepository(session)
                 job = await job_repo.get(job_id)
             if job is None:
-                log.warning("session_snapshot_job_missing", job_id=job_id)
-                return
+                raise RuntimeError(f"Cannot collect artifacts for missing job {job_id}")
 
             from backend.persistence.database import serialized_write
 
@@ -312,7 +311,8 @@ class SummarizationService:
 
             log.info("session_log_stored", job_id=job_id, session=job.session_count, turns=len(turns))
         except Exception:
-            log.warning("session_log_failed", job_id=job_id, exc_info=True)
+            log.error("session_log_failed", job_id=job_id, exc_info=True)
+            raise
 
 
 # ---------------------------------------------------------------------------

--- a/backend/services/events/sse_manager.py
+++ b/backend/services/events/sse_manager.py
@@ -182,17 +182,23 @@ class SSEManager:
         """Update the active job count for selective streaming decisions."""
         self._active_job_count = count
 
-    async def broadcast_domain_event(self, event: SessionEvent) -> None:
+    async def broadcast_domain_event(
+        self,
+        event: SessionEvent,
+        *,
+        storage_cursor: int | None = None,
+    ) -> None:
         """Event bus subscriber — serialize a TF event to the SSE wire as-is.
 
         The ``event:`` type is the event's dotted ``kind`` and ``data:`` is the
         TraceForge ``SessionEvent`` serialized verbatim. Kinds outside the
-        broadcast allowlist are internal-only and dropped here.
+        broadcast allowlist are internal-only and dropped here. The optional SSE
+        resume cursor is storage-local and never changes event metadata.
         """
         if event.kind not in _BROADCAST_KINDS:
             return  # internal-only event
 
-        sse_id = str(event.metadata.sequence) if event.metadata.sequence is not None else event.id
+        sse_id = str(storage_cursor) if storage_cursor is not None else None
         frame = _format_sse(sse_id, str(event.kind), _serialize_tf_event(event))
         selective = self._active_job_count > 20
 
@@ -275,19 +281,19 @@ class SSEManager:
         """
         cutoff = datetime.now(UTC) - MAX_REPLAY_AGE
 
-        events = await event_repo.list_after(
+        stored_events = await event_repo.list_after(
             after_id=last_event_id,
             job_id=conn.job_id,
             limit=MAX_REPLAY_EVENTS + 1,  # +1 to detect overflow
         )
 
         needs_snapshot = False
-        if len(events) > MAX_REPLAY_EVENTS:
+        if len(stored_events) > MAX_REPLAY_EVENTS:
             needs_snapshot = True
-            events = events[:MAX_REPLAY_EVENTS]
+            stored_events = stored_events[:MAX_REPLAY_EVENTS]
 
         # Check if oldest event is beyond replay window
-        if events and events[0].timestamp.replace(tzinfo=UTC) < cutoff:
+        if stored_events and stored_events[0].event.timestamp.replace(tzinfo=UTC) < cutoff:
             needs_snapshot = True
 
         if needs_snapshot:
@@ -323,14 +329,22 @@ class SSEManager:
             self.send_snapshot(conn, snapshot)
 
             # Filter events to only those within the replay window
-            events = [e for e in events if e.timestamp.replace(tzinfo=UTC) >= cutoff]
+            stored_events = [
+                stored
+                for stored in stored_events
+                if stored.event.timestamp.replace(tzinfo=UTC) >= cutoff
+            ]
 
         # Replay the events
-        for event in events:
+        for stored in stored_events:
+            event = stored.event
             if event.kind not in _BROADCAST_KINDS:
                 continue
-            sse_id = str(event.metadata.sequence) if event.metadata.sequence is not None else event.id
-            frame = _format_sse(sse_id, str(event.kind), _serialize_tf_event(event))
+            frame = _format_sse(
+                str(stored.storage_cursor),
+                str(event.kind),
+                _serialize_tf_event(event),
+            )
             conn.send(frame)
 
     async def replay_from_factory(

--- a/backend/services/runtime/service.py
+++ b/backend/services/runtime/service.py
@@ -404,6 +404,19 @@ class RuntimeService:
         except (Exception, asyncio.CancelledError):
             log.warning("diff_finalize_failed", job_id=job_id, exc_info=True)
 
+    async def _finalize_artifacts_safe(self, job_id: str) -> None:
+        """Finalize terminal artifacts without blocking remaining runtime cleanup."""
+        try:
+            await self._artifact_finalizer.finalize(job_id)
+        except Exception as exc:
+            log.error(
+                "artifact_finalization_failed",
+                job_id=job_id,
+                error_type=type(exc).__name__,
+                error=str(exc),
+                exc_info=True,
+            )
+
     async def _finalize_naming(self, job_id: str) -> None:
         """Retry title generation and produce description for untitled/undescribed jobs."""
         if self._sidecar_sessions is None:
@@ -1306,7 +1319,7 @@ class RuntimeService:
         # Last-resort guard: if the job is still non-terminal after all error
         # handlers have run, force it to failed so it doesn't stay stuck.
         await self._ensure_terminal_state(job_id)
-        await self._artifact_finalizer.finalize(job_id)
+        await self._finalize_artifacts_safe(job_id)
 
         # Close CodeRecon session for this job's worktree — no-op with ReviewKit
         # (in-process kits are shared and closed on shutdown, not per-job)
@@ -1624,7 +1637,7 @@ class RuntimeService:
         if self._trail_service is not None:
             self._trail_service.stop_tracking(job_id)
             await self._trail_service.finalize(job_id, succeeded=error_reason is None)
-        await self._artifact_finalizer.finalize(job_id)
+        await self._finalize_artifacts_safe(job_id)
         if self._trail_service is not None:
             self._trail_service.cleanup(job_id)
 

--- a/backend/services/runtime/service.py
+++ b/backend/services/runtime/service.py
@@ -300,7 +300,6 @@ class RuntimeService:
         self._policy_batchers: dict[str, Any] = {}  # job_id → ApprovalBatcher
         self._dequeue_lock = asyncio.Lock()
         self._shutting_down = False
-        self._snapshot_tasks: dict[str, asyncio.Task[None]] = {}
         self._pending_starts: dict[str, tuple[str | None, str | None]] = {}
         self._preflight_curator: PreflightCurator | None = None
         self._ingest_service: IngestService | None = None
@@ -324,6 +323,14 @@ class RuntimeService:
             make_job_service=self._make_job_service,
             resolve_adapter=self._resolve_adapter,
             trail_service=trail_service,
+        )
+        from backend.services.artifacts.finalization_service import ArtifactFinalizationService
+
+        self._artifact_finalizer = ArtifactFinalizationService(
+            session_factory=session_factory,
+            event_bus=event_bus,
+            summarization_service=summarization_service,
+            telemetry=self._telemetry,
         )
 
     def set_trail_service(self, svc: TrailService) -> None:
@@ -1112,35 +1119,6 @@ class RuntimeService:
     async def _finalize_job_telemetry(self, job_id: str, wall_start: float, config: SessionConfig) -> None:
         await self._telemetry.finalize_job_telemetry(job_id, wall_start, config)
 
-    async def _store_post_completion_artifacts(
-        self,
-        job_id: str,
-    ) -> None:
-        """Persist internal state (telemetry, plan, approvals) as downloadable artifacts."""
-        await self._telemetry.store_post_completion_artifacts(job_id)
-
-    def _start_snapshot_task(self, job_id: str) -> None:
-        if self._shutting_down:
-            return
-        if self._summarization_service is None:
-            return
-        existing = self._snapshot_tasks.get(job_id)
-        if existing is not None and not existing.done():
-            return
-
-        task = asyncio.create_task(
-            self._summarization_service.save_snapshot_to_disk(job_id),
-            name=f"snapshot-{job_id}",
-        )
-        self._snapshot_tasks[job_id] = task
-
-        def _cleanup_snapshot_task(completed: asyncio.Task[None]) -> None:
-            current = self._snapshot_tasks.get(job_id)
-            if current is completed:
-                self._snapshot_tasks.pop(job_id, None)
-
-        task.add_done_callback(_cleanup_snapshot_task)
-
     async def _set_step_terminal_state(self, job_id: str, outcome: str) -> None:
         """Forward terminal outcome to the step tracker."""
         if self._step_tracker is not None:
@@ -1328,6 +1306,7 @@ class RuntimeService:
         # Last-resort guard: if the job is still non-terminal after all error
         # handlers have run, force it to failed so it doesn't stay stuck.
         await self._ensure_terminal_state(job_id)
+        await self._artifact_finalizer.finalize(job_id)
 
         # Close CodeRecon session for this job's worktree — no-op with ReviewKit
         # (in-process kits are shared and closed on shutdown, not per-job)
@@ -1388,7 +1367,6 @@ class RuntimeService:
             await self._approval_service.cleanup_job(job_id)
         if self._diff_service is not None:
             self._diff_service.cleanup(job_id)
-        self._start_snapshot_task(job_id)
         await self._dequeue_next()
 
     async def _ensure_terminal_state(self, job_id: str) -> None:
@@ -1646,6 +1624,8 @@ class RuntimeService:
         if self._trail_service is not None:
             self._trail_service.stop_tracking(job_id)
             await self._trail_service.finalize(job_id, succeeded=error_reason is None)
+        await self._artifact_finalizer.finalize(job_id)
+        if self._trail_service is not None:
             self._trail_service.cleanup(job_id)
 
         # Retry title + generate description while sidecar is still alive
@@ -1683,8 +1663,6 @@ class RuntimeService:
         self._stall_check_pending.discard(job_id)
         self._last_stall_check.pop(job_id, None)
 
-        # Persist trail snapshot to disk
-        self._start_snapshot_task(job_id)
         log.debug("external_session_finalized", job_id=job_id, outcome=outcome)
 
     # ------------------------------------------------------------------
@@ -2598,6 +2576,8 @@ class RuntimeService:
                 except Exception:
                     log.debug("orphaned_job_recovery_failed", job_id=job.id, exc_info=True)
 
+        await self._artifact_finalizer.recover_eligible()
+
         for job in queued_jobs:
             await self.start_or_enqueue(job)
 
@@ -2618,10 +2598,6 @@ class RuntimeService:
         tasks = list(self._tasks.values())
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
-
-        snapshot_tasks = list(self._snapshot_tasks.values())
-        if snapshot_tasks:
-            await asyncio.gather(*snapshot_tasks, return_exceptions=True)
 
     # -- Preflight context curation ------------------------------------------
 

--- a/backend/services/runtime/telemetry.py
+++ b/backend/services/runtime/telemetry.py
@@ -167,85 +167,64 @@ class RuntimeTelemetry:
         except DBAPIError:
             log.warning("telemetry_finalize_failed", job_id=job_id, exc_info=True)
 
-        # Store post-completion artifacts
-        await self.store_post_completion_artifacts(job_id)
-
     async def store_post_completion_artifacts(self, job_id: str) -> None:
-        """Persist internal state (telemetry, plan, approvals) as downloadable artifacts."""
-        from backend.services.tools.parsing_utils import best_effort
+        """Persist telemetry, plan, approval, and log artifacts from durable rows."""
+        async with self._session_factory() as session:
+            svc = self._make_job_service(session)
+            job = await svc.get_job(job_id)
+        if job is None:
+            raise RuntimeError(f"Cannot collect durable artifacts for missing job {job_id}")
+        slug = (job.worktree_name or job.title or "").strip()
 
-        try:
-            # Look up job slug for human-friendly artifact names
-            slug = ""
-            async with best_effort(log, "slug_extraction", job_id=job_id):
-                async with self._session_factory() as session:
-                    svc = self._make_job_service(session)
-                    job = await svc.get_job(job_id)
-                if job is not None:
-                    slug = (job.worktree_name or job.title or "").strip()
+        from backend.persistence.database import serialized_write
 
-            from backend.persistence.database import serialized_write
+        async with serialized_write(self._session_factory) as session:
+            from backend.persistence.approval_repo import ApprovalRepository
+            from backend.persistence.artifact_repo import ArtifactRepository
+            from backend.persistence.event_repo import EventRepository
+            from backend.persistence.telemetry_summary_repo import TelemetrySummaryRepository
+            from backend.services.artifacts.artifact_service import ArtifactService
 
-            async with serialized_write(self._session_factory) as session:
-                from backend.persistence.artifact_repo import ArtifactRepository
-                from backend.services.artifacts.artifact_service import ArtifactService
+            artifact_svc = ArtifactService(ArtifactRepository(session))
+            event_repo = EventRepository(session)
 
-                artifact_svc = ArtifactService(ArtifactRepository(session))
+            summary = await TelemetrySummaryRepository(session).get(job_id)
+            if summary is not None:
+                await artifact_svc.store_telemetry_report(job_id, dict(summary), slug=slug)
 
-                # Telemetry report
-                async with best_effort(log, "telemetry_artifact", job_id=job_id):
-                    from backend.persistence.telemetry_summary_repo import TelemetrySummaryRepository
+            plan_events = await event_repo.list_all_by_job(job_id, [EventKind.plan_step_updated])
+            latest_steps: dict[str, dict[str, object]] = {}
+            for event in plan_events:
+                payload = dict(event.payload)
+                step_id = str(payload.get("plan_step_id") or "")
+                if step_id:
+                    latest_steps[step_id] = payload
+            if latest_steps:
+                await artifact_svc.store_agent_plan(job_id, list(latest_steps.values()), slug=slug)
 
-                    summary = await TelemetrySummaryRepository(session).get(job_id)
-                    if summary is not None:
-                        await artifact_svc.store_telemetry_report(
-                            job_id,
-                            dict(summary),
-                            slug=slug,
-                        )
+            approvals = await ApprovalRepository(session).list_for_job(job_id)
+            if approvals:
+                approval_dicts = [
+                    {
+                        "id": a.id,
+                        "description": a.description,
+                        "proposed_action": a.proposed_action,
+                        "requested_at": a.requested_at.isoformat(),
+                        "resolved_at": a.resolved_at.isoformat() if a.resolved_at else None,
+                        "resolution": a.resolution,
+                    }
+                    for a in approvals
+                ]
+                await artifact_svc.store_approval_history(job_id, approval_dicts, slug=slug)
 
-                # Agent plan steps
-                if self._trail_service is not None:
-                    steps = self._trail_service.get_plan_steps(job_id)
-                    if steps:
-                        async with best_effort(log, "plan_artifact", job_id=job_id):
-                            await artifact_svc.store_agent_plan(job_id, steps, slug=slug)
-
-                # Approval history
-                async with best_effort(log, "approval_artifact", job_id=job_id):
-                    from backend.persistence.approval_repo import ApprovalRepository
-
-                    approval_repo = ApprovalRepository(session)
-                    approvals = await approval_repo.list_for_job(job_id)
-                    if approvals:
-                        approval_dicts = [
-                            {
-                                "id": a.id,
-                                "description": a.description,
-                                "proposed_action": a.proposed_action,
-                                "requested_at": a.requested_at.isoformat(),
-                                "resolved_at": a.resolved_at.isoformat() if a.resolved_at else None,
-                                "resolution": a.resolution,
-                            }
-                            for a in approvals
-                        ]
-                        await artifact_svc.store_approval_history(
-                            job_id,
-                            approval_dicts,
-                            slug=slug,
-                        )
-
-                # Agent log artifact
-                async with best_effort(log, "log_artifact", job_id=job_id):
-                    from backend.persistence.event_repo import EventRepository
-
-                    event_repo = EventRepository(session)
-                    log_events = await event_repo.list_all_by_job(job_id, [EventKind.log_line_emitted])
-                    if log_events:
-                        await artifact_svc.store_log_artifact(
-                            job_id,
-                            [dict(e.payload) for e in log_events],
-                            slug=slug,
-                        )
-        except DBAPIError:
-            log.warning("post_completion_artifacts_failed", job_id=job_id, exc_info=True)
+            log_events = await event_repo.list_all_by_job(job_id, [EventKind.log_line_emitted])
+            if log_events:
+                log_records = [
+                    {
+                        **dict(event.payload),
+                        "sequence": event.metadata.sequence,
+                        "timestamp": event.payload.get("timestamp", event.timestamp),
+                    }
+                    for event in log_events
+                ]
+                await artifact_svc.store_log_artifact(job_id, log_records, slug=slug)

--- a/backend/tests/integration/test_api_artifacts.py
+++ b/backend/tests/integration/test_api_artifacts.py
@@ -75,6 +75,8 @@ class TestListArtifacts:
         assert resp.status_code == 200
         body = resp.json()
         assert body["items"] == []
+        assert body["collectionStatus"] == "pending"
+        assert body["collectionError"] is None
 
     @pytest.mark.asyncio
     async def test_returns_artifacts_for_job(
@@ -120,6 +122,7 @@ class TestListArtifacts:
         assert "sizeBytes" in item
         assert "phase" in item
         assert "createdAt" in item
+        assert resp.json()["collectionStatus"] == "pending"
 
     @pytest.mark.asyncio
     async def test_does_not_leak_artifacts_from_other_jobs(
@@ -147,6 +150,7 @@ class TestListArtifacts:
         resp = await client.get("/api/jobs/no-such-job/artifacts")
         assert resp.status_code == 200
         assert resp.json()["items"] == []
+        assert resp.json()["collectionStatus"] == "completed"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/integration/test_api_jobs.py
+++ b/backend/tests/integration/test_api_jobs.py
@@ -574,34 +574,45 @@ class TestJobData:
         resp = await client.get(f"/api/jobs/{jid}/transcript", params={"limit": 10})
         assert resp.status_code == 200
 
-    async def test_transcript_uses_traceforge_envelope_identity(
+    async def test_transcript_exposes_event_identity_and_optional_producer_sequence(
         self,
         client: AsyncClient,
         seed_job: SeedJobFn,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
         jid = await seed_job(state="running", job_id="transcript-identity")
+        producer_sequence = 10_000
         async with session_factory() as session:
-            row = EventRow(
-                event_id="evt-canonical",
+            sequenced_row = EventRow(
+                event_id="evt-sequenced",
                 job_id=jid,
                 kind=EventKind.message_assistant.value,
                 timestamp=datetime.now(UTC),
-                payload='{"seq":0,"content":"Done"}',
-                event_metadata='{"sequence":9001}',
+                payload='{"content":"Sequenced"}',
+                event_metadata=f'{{"sequence":{producer_sequence}}}',
             )
-            session.add(row)
+            unsequenced_row = EventRow(
+                event_id="evt-unsequenced",
+                job_id=jid,
+                kind=EventKind.message_assistant.value,
+                timestamp=datetime.now(UTC),
+                payload='{"content":"Unsequenced"}',
+                event_metadata="{}",
+            )
+            session.add_all([sequenced_row, unsequenced_row])
             await session.flush()
-            assert row.id != 9001
+            assert sequenced_row.id != producer_sequence
             await session.commit()
 
         resp = await client.get(f"/api/jobs/{jid}/transcript")
 
         assert resp.status_code == 200
-        item = resp.json()["items"][0]
-        assert item["eventId"] == "evt-canonical"
-        assert item["sequence"] == 9001
-        assert "seq" not in item
+        items = resp.json()["items"]
+        assert [(item["eventId"], item["sequence"]) for item in items] == [
+            ("evt-sequenced", producer_sequence),
+            ("evt-unsequenced", None),
+        ]
+        assert all("seq" not in item for item in items)
 
     # ── Timeline ──
 

--- a/backend/tests/integration/test_api_jobs.py
+++ b/backend/tests/integration/test_api_jobs.py
@@ -588,11 +588,11 @@ class TestJobData:
                 kind=EventKind.message_assistant.value,
                 timestamp=datetime.now(UTC),
                 payload='{"seq":0,"content":"Done"}',
-                event_metadata="{}",
+                event_metadata='{"sequence":9001}',
             )
             session.add(row)
             await session.flush()
-            canonical_sequence = row.id
+            assert row.id != 9001
             await session.commit()
 
         resp = await client.get(f"/api/jobs/{jid}/transcript")
@@ -600,7 +600,7 @@ class TestJobData:
         assert resp.status_code == 200
         item = resp.json()["items"][0]
         assert item["eventId"] == "evt-canonical"
-        assert item["sequence"] == canonical_sequence
+        assert item["sequence"] == 9001
         assert "seq" not in item
 
     # ── Timeline ──

--- a/backend/tests/integration/test_api_jobs.py
+++ b/backend/tests/integration/test_api_jobs.py
@@ -574,6 +574,35 @@ class TestJobData:
         resp = await client.get(f"/api/jobs/{jid}/transcript", params={"limit": 10})
         assert resp.status_code == 200
 
+    async def test_transcript_uses_traceforge_envelope_identity(
+        self,
+        client: AsyncClient,
+        seed_job: SeedJobFn,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        jid = await seed_job(state="running", job_id="transcript-identity")
+        async with session_factory() as session:
+            row = EventRow(
+                event_id="evt-canonical",
+                job_id=jid,
+                kind=EventKind.message_assistant.value,
+                timestamp=datetime.now(UTC),
+                payload='{"seq":0,"content":"Done"}',
+                event_metadata="{}",
+            )
+            session.add(row)
+            await session.flush()
+            canonical_sequence = row.id
+            await session.commit()
+
+        resp = await client.get(f"/api/jobs/{jid}/transcript")
+
+        assert resp.status_code == 200
+        item = resp.json()["items"][0]
+        assert item["eventId"] == "evt-canonical"
+        assert item["sequence"] == canonical_sequence
+        assert "seq" not in item
+
     # ── Timeline ──
 
     async def test_timeline_empty(self, client: AsyncClient, seed_job: SeedJobFn) -> None:

--- a/backend/tests/unit/test_artifact_finalization_service.py
+++ b/backend/tests/unit/test_artifact_finalization_service.py
@@ -1,0 +1,203 @@
+"""Tests for terminal artifact collection orchestration."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import event as sa_event
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from backend.models.api_schemas import ArtifactType, ExecutionPhase
+from backend.models.db import Base
+from backend.models.domain import Artifact, Job, JobState
+from backend.models.events import EventKind
+from backend.persistence.artifact_repo import ArtifactRepository
+from backend.persistence.database import _set_sqlite_pragmas, serialized_write
+from backend.persistence.job_repo import JobRepository
+from backend.services.artifacts.finalization_service import ArtifactFinalizationService
+from backend.services.events.event_bus import EventBus
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+    from pathlib import Path
+
+    from sqlalchemy.ext.asyncio import AsyncEngine
+
+
+@pytest.fixture
+async def engine() -> AsyncGenerator[AsyncEngine, None]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    sa_event.listen(engine.sync_engine, "connect", _set_sqlite_pragmas)
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    yield engine
+    await engine.dispose()
+
+
+@pytest.fixture
+def session_factory(engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:
+    return async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _create_job(
+    session_factory: async_sessionmaker[AsyncSession],
+    *,
+    job_id: str = "job-1",
+    status: str = "pending",
+) -> None:
+    now = datetime.now(UTC)
+    job = Job(
+        id=job_id,
+        repo="C:/repo",
+        prompt="Audit the repository",
+        state=JobState.review,
+        base_ref="main",
+        branch="audit",
+        worktree_path="C:/worktree",
+        session_id=None,
+        created_at=now,
+        updated_at=now,
+        completed_at=now,
+        artifact_collection_status=status,
+    )
+    async with serialized_write(session_factory) as session:
+        await JobRepository(session).create(job)
+
+
+def _make_service(
+    session_factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    *,
+    snapshot_error: Exception | None = None,
+) -> tuple[ArtifactFinalizationService, AsyncMock, AsyncMock, list[object]]:
+    summarization = AsyncMock()
+    telemetry = AsyncMock()
+    published: list[object] = []
+    event_bus = EventBus()
+
+    async def collect_event(event: object) -> None:
+        published.append(event)
+
+    event_bus.subscribe(collect_event)
+
+    async def save_snapshot(job_id: str) -> None:
+        if snapshot_error is not None:
+            raise snapshot_error
+        disk_path = tmp_path / f"{job_id}-session-log.json"
+        disk_path.write_text('{"sessions": []}', encoding="utf-8")
+        async with serialized_write(session_factory) as session:
+            existing = await ArtifactRepository(session).list_for_job(job_id)
+            if existing:
+                return
+            await ArtifactRepository(session).create(
+                Artifact(
+                    id=f"art-{job_id}",
+                    job_id=job_id,
+                    name="session-log.json",
+                    type=ArtifactType.session_log,
+                    mime_type="application/json",
+                    size_bytes=disk_path.stat().st_size,
+                    disk_path=str(disk_path),
+                    phase=ExecutionPhase.post_completion,
+                    created_at=datetime.now(UTC),
+                )
+            )
+
+    summarization.save_snapshot_to_disk.side_effect = save_snapshot
+    return (
+        ArtifactFinalizationService(session_factory, event_bus, summarization, telemetry),
+        summarization,
+        telemetry,
+        published,
+    )
+
+
+@pytest.mark.asyncio
+async def test_review_finalization_creates_artifacts_once(
+    session_factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    await _create_job(session_factory)
+    service, summarization, telemetry, published = _make_service(session_factory, tmp_path)
+
+    assert await service.finalize("job-1") == "completed"
+    assert await service.finalize("job-1") == "completed"
+
+    summarization.save_snapshot_to_disk.assert_awaited_once_with("job-1")
+    telemetry.store_post_completion_artifacts.assert_awaited_once_with("job-1")
+    async with session_factory() as session:
+        job = await JobRepository(session).get("job-1")
+        artifacts = await ArtifactRepository(session).list_for_job("job-1")
+    assert job is not None
+    assert job.artifact_collection_status == "completed"
+    assert job.artifact_collection_error is None
+    assert len(artifacts) == 1
+    assert [event.kind for event in published] == [EventKind.artifacts_updated]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_finalization_runs_collection_once(
+    session_factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    await _create_job(session_factory)
+    service, summarization, telemetry, published = _make_service(session_factory, tmp_path)
+
+    statuses = await asyncio.gather(
+        service.finalize("job-1"),
+        service.finalize("job-1"),
+        service.finalize("job-1"),
+    )
+
+    assert statuses == ["completed", "completed", "completed"]
+    summarization.save_snapshot_to_disk.assert_awaited_once_with("job-1")
+    telemetry.store_post_completion_artifacts.assert_awaited_once_with("job-1")
+    assert [event.kind for event in published] == [EventKind.artifacts_updated]
+
+
+@pytest.mark.asyncio
+async def test_collection_failure_is_durable_and_published(
+    session_factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    await _create_job(session_factory)
+    service, _summarization, telemetry, published = _make_service(
+        session_factory,
+        tmp_path,
+        snapshot_error=OSError("workspace disappeared"),
+    )
+
+    assert await service.finalize("job-1") == "failed"
+
+    telemetry.store_post_completion_artifacts.assert_not_awaited()
+    async with session_factory() as session:
+        job = await JobRepository(session).get("job-1")
+    assert job is not None
+    assert job.artifact_collection_status == "failed"
+    assert job.artifact_collection_error == "OSError: workspace disappeared"
+    assert published[-1].payload["collection_status"] == "failed"
+
+
+@pytest.mark.asyncio
+async def test_recovery_backfills_terminal_zero_artifact_jobs(
+    session_factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    await _create_job(session_factory, job_id="pending-job")
+    await _create_job(session_factory, job_id="stale-job", status="collecting")
+    service, summarization, telemetry, _published = _make_service(session_factory, tmp_path)
+
+    assert await service.recover_eligible() == 2
+
+    assert summarization.save_snapshot_to_disk.await_count == 2
+    assert telemetry.store_post_completion_artifacts.await_count == 2
+    async with session_factory() as session:
+        jobs = [
+            await JobRepository(session).get("pending-job"),
+            await JobRepository(session).get("stale-job"),
+        ]
+    assert all(job is not None and job.artifact_collection_status == "completed" for job in jobs)

--- a/backend/tests/unit/test_artifact_finalization_service.py
+++ b/backend/tests/unit/test_artifact_finalization_service.py
@@ -73,6 +73,7 @@ def _make_service(
     tmp_path: Path,
     *,
     snapshot_error: Exception | None = None,
+    create_artifact: bool = True,
 ) -> tuple[ArtifactFinalizationService, AsyncMock, AsyncMock, list[object]]:
     summarization = AsyncMock()
     telemetry = AsyncMock()
@@ -87,6 +88,8 @@ def _make_service(
     async def save_snapshot(job_id: str) -> None:
         if snapshot_error is not None:
             raise snapshot_error
+        if not create_artifact:
+            return
         disk_path = tmp_path / f"{job_id}-session-log.json"
         disk_path.write_text('{"sessions": []}', encoding="utf-8")
         async with serialized_write(session_factory) as session:
@@ -201,3 +204,31 @@ async def test_recovery_backfills_terminal_zero_artifact_jobs(
             await JobRepository(session).get("stale-job"),
         ]
     assert all(job is not None and job.artifact_collection_status == "completed" for job in jobs)
+
+
+@pytest.mark.asyncio
+async def test_completed_zero_artifact_job_is_not_recovered_repeatedly(
+    session_factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    await _create_job(session_factory)
+    service, summarization, telemetry, published = _make_service(
+        session_factory,
+        tmp_path,
+        create_artifact=False,
+    )
+
+    assert await service.finalize("job-1") == "completed"
+    assert await service.finalize("job-1") == "completed"
+    assert await service.recover_eligible() == 0
+
+    summarization.save_snapshot_to_disk.assert_awaited_once_with("job-1")
+    telemetry.store_post_completion_artifacts.assert_awaited_once_with("job-1")
+    async with session_factory() as session:
+        job = await JobRepository(session).get("job-1")
+        artifacts = await ArtifactRepository(session).list_for_job("job-1")
+    assert job is not None
+    assert job.artifact_collection_status == "completed"
+    assert job.artifact_collection_session_count == job.session_count
+    assert artifacts == []
+    assert [event.kind for event in published] == [EventKind.artifacts_updated]

--- a/backend/tests/unit/test_audit_changes.py
+++ b/backend/tests/unit/test_audit_changes.py
@@ -300,12 +300,20 @@ class TestEventRepoListAllByJob:
         await job_repo.create(make_job(id=job_id, worktree_path="/repos/test"))
 
         for i in range(5):
-            await repo.append(new_event(job_id, EventKind.log_line_emitted, {"seq": i}))
+            await repo.append(
+                new_event(
+                    job_id,
+                    EventKind.log_line_emitted,
+                    {"seq": i},
+                    event_id=f"evt-{i}",
+                    sequence=5 - i,
+                )
+            )
         await session.commit()
 
         results = await repo.list_all_by_job(job_id, kinds=[EventKind.log_line_emitted])
-        db_ids = [r.metadata.sequence for r in results]
-        assert db_ids == sorted(db_ids)
+        assert [event.id for event in results] == [f"evt-{i}" for i in range(5)]
+        assert [event.metadata.sequence for event in results] == [5, 4, 3, 2, 1]
 
     @pytest.mark.asyncio
     async def test_list_by_job_with_low_limit_truncates(self, session: AsyncSession) -> None:

--- a/backend/tests/unit/test_concurrency_stress.py
+++ b/backend/tests/unit/test_concurrency_stress.py
@@ -228,6 +228,7 @@ class TestConcurrentEventAppends:
             events = await event_repo.list_by_job("ev-job", [EventKind.log_line_emitted], limit=100)
         assert len(events) == 20
 
-        # IDs should be monotonically increasing
-        event_ids = [e.metadata.sequence for e in events if e.metadata.sequence is not None]
-        assert event_ids == sorted(event_ids)
+        # Storage order stays internal; absent producer sequences remain absent.
+        expected_payload_order = sorted(range(20), key=db_ids.__getitem__)
+        assert [event.payload["seq"] for event in events] == expected_payload_order
+        assert all(event.metadata.sequence is None for event in events)

--- a/backend/tests/unit/test_plan_mode_flow.py
+++ b/backend/tests/unit/test_plan_mode_flow.py
@@ -221,9 +221,6 @@ async def runtime(
     all_tasks = list(service._tasks.values()) + list(service._heartbeat_tasks.values())
     if all_tasks:
         await asyncio.gather(*all_tasks, return_exceptions=True)
-    snapshot_tasks = list(service._snapshot_tasks.values())
-    if snapshot_tasks:
-        await asyncio.gather(*snapshot_tasks, return_exceptions=True)
     await asyncio.sleep(0.05)
 
 

--- a/backend/tests/unit/test_redteam_persistence.py
+++ b/backend/tests/unit/test_redteam_persistence.py
@@ -139,7 +139,7 @@ class TestSQLInjection:
 
         events = await event_repo.list_after(0)
         assert len(events) == 1
-        assert events[0].payload == evil_payload
+        assert events[0].event.payload == evil_payload
 
 
 # ── FK constraint violations ─────────────────────────────────────
@@ -539,7 +539,7 @@ class TestEventPayloadEdgeCases:
         )
         await session.commit()
         events = await event_repo.list_after(0)
-        assert events[0].payload == {}
+        assert events[0].event.payload == {}
 
     @pytest.mark.asyncio
     async def test_deeply_nested_payload(self, session: AsyncSession) -> None:
@@ -563,7 +563,7 @@ class TestEventPayloadEdgeCases:
         )
         await session.commit()
         events = await event_repo.list_after(0)
-        assert events[0].payload["level"] == 0
+        assert events[0].event.payload["level"] == 0
 
     @pytest.mark.asyncio
     async def test_payload_with_special_json_types(self, session: AsyncSession) -> None:
@@ -589,4 +589,4 @@ class TestEventPayloadEdgeCases:
         )
         await session.commit()
         events = await event_repo.list_after(0)
-        assert events[0].payload == payload
+        assert events[0].event.payload == payload

--- a/backend/tests/unit/test_repositories.py
+++ b/backend/tests/unit/test_repositories.py
@@ -161,11 +161,52 @@ async def test_event_append_and_list(session: AsyncSession) -> None:
     await event_repo.append(event)
     await session.commit()
 
-    events = await event_repo.list_after(0)
-    assert len(events) == 1
-    assert events[0].id == "evt-1"
-    assert events[0].kind == EventKind.job_created
-    assert events[0].payload == {"repo": "/repos/test"}
+    stored_events = await event_repo.list_after(0)
+    assert len(stored_events) == 1
+    assert stored_events[0].event.id == "evt-1"
+    assert stored_events[0].event.kind == EventKind.job_created
+    assert stored_events[0].event.payload == {"repo": "/repos/test"}
+
+
+@pytest.mark.asyncio
+async def test_event_sequence_round_trips_separately_from_storage_cursor(
+    session: AsyncSession,
+) -> None:
+    job_repo = JobRepository(session)
+    await job_repo.create(make_job(id="job-1", worktree_path="/repos/test"))
+    await session.commit()
+
+    event_repo = EventRepository(session)
+    sequenced = new_event(
+        event_id="evt-sequenced",
+        session_id="job-1",
+        kind=EventKind.message_assistant,
+        payload={"content": "first"},
+        sequence=9001,
+    )
+    unsequenced = new_event(
+        event_id="evt-unsequenced",
+        session_id="job-1",
+        kind=EventKind.message_assistant,
+        payload={"content": "second"},
+    )
+
+    first_cursor = await event_repo.append(sequenced)
+    second_cursor = await event_repo.append(unsequenced)
+    await session.commit()
+
+    assert first_cursor != 9001
+    stored_events = await event_repo.list_after(0)
+    assert [stored.storage_cursor for stored in stored_events] == [
+        first_cursor,
+        second_cursor,
+    ]
+    assert [stored.event.id for stored in stored_events] == [
+        "evt-sequenced",
+        "evt-unsequenced",
+    ]
+    assert stored_events[0].event.metadata.sequence == 9001
+    assert stored_events[1].event.metadata.sequence is None
 
 
 @pytest.mark.asyncio
@@ -212,7 +253,7 @@ async def test_event_list_after_scoped_to_job(session: AsyncSession) -> None:
 
     events = await event_repo.list_after(0, job_id="job-1")
     assert len(events) == 1
-    assert events[0].session_id == "job-1"
+    assert events[0].event.session_id == "job-1"
 
 
 # --- ArtifactRepository tests ---

--- a/backend/tests/unit/test_runtime_service.py
+++ b/backend/tests/unit/test_runtime_service.py
@@ -1411,6 +1411,43 @@ class TestBuildSessionConfig:
 
 
 class TestConcurrencyGuards:
+    async def test_managed_cleanup_continues_when_artifact_finalization_raises(
+        self,
+        runtime: RuntimeService,
+    ) -> None:
+        job_id = "job-finalizer-failure"
+        task = asyncio.current_task()
+        assert task is not None
+        runtime._tasks[job_id] = task
+        runtime._last_activity[job_id] = 1.0
+        runtime._ensure_terminal_state = AsyncMock()  # type: ignore[method-assign]
+        runtime._artifact_finalizer.finalize = AsyncMock(side_effect=RuntimeError("database unavailable"))
+        runtime._dequeue_next = AsyncMock()  # type: ignore[method-assign]
+
+        await runtime._cleanup_job_state(job_id)
+
+        runtime._artifact_finalizer.finalize.assert_awaited_once_with(job_id)
+        runtime._dequeue_next.assert_awaited_once_with()
+        assert job_id not in runtime._tasks
+        assert job_id not in runtime._last_activity
+
+    async def test_external_cleanup_continues_when_artifact_finalization_raises(
+        self,
+        runtime: RuntimeService,
+    ) -> None:
+        job_id = "external-finalizer-failure"
+        runtime._last_activity[job_id] = 1.0
+        runtime._active_tool[job_id] = ("powershell", "now", "{}")
+        runtime._artifact_finalizer.finalize = AsyncMock(side_effect=RuntimeError("event bus unavailable"))
+        runtime._finalize_naming = AsyncMock()  # type: ignore[method-assign]
+
+        await runtime.finalize_external_session(job_id)
+
+        runtime._artifact_finalizer.finalize.assert_awaited_once_with(job_id)
+        runtime._finalize_naming.assert_awaited_once_with(job_id)
+        assert job_id not in runtime._last_activity
+        assert job_id not in runtime._active_tool
+
     async def test_double_start_guard(
         self, runtime: RuntimeService, session_factory: async_sessionmaker[AsyncSession], config: CPLConfig
     ) -> None:

--- a/backend/tests/unit/test_runtime_service.py
+++ b/backend/tests/unit/test_runtime_service.py
@@ -207,9 +207,6 @@ async def runtime(
     all_tasks = list(service._tasks.values()) + list(service._heartbeat_tasks.values())
     if all_tasks:
         await asyncio.gather(*all_tasks, return_exceptions=True)
-    snapshot_tasks = list(service._snapshot_tasks.values())
-    if snapshot_tasks:
-        await asyncio.gather(*snapshot_tasks, return_exceptions=True)
     # Allow aiosqlite background threads to drain so they don't
     # encounter a closed event-loop after the engine is disposed.
     await asyncio.sleep(0.05)

--- a/backend/tests/unit/test_sse_manager.py
+++ b/backend/tests/unit/test_sse_manager.py
@@ -18,6 +18,7 @@ import pytest
 from backend.models.api_schemas import SnapshotPayload
 from backend.models.domain import Job
 from backend.models.events import EventKind, SessionEvent, new_event
+from backend.persistence.event_repo import StoredEvent
 from backend.services.events.sse_manager import (
     MAX_REPLAY_AGE,
     MAX_REPLAY_EVENTS,
@@ -33,7 +34,7 @@ def _make_event(
     job_id: str = "job-1",
     event_id: str = "evt-1",
     payload: dict[str, object] | None = None,
-    db_id: int | None = None,
+    sequence: int | None = None,
 ) -> SessionEvent:
     return new_event(
         event_id=event_id,
@@ -41,7 +42,7 @@ def _make_event(
         timestamp=datetime.now(UTC),
         kind=kind,
         payload=payload or {"test": True},
-        sequence=db_id,
+        sequence=sequence,
     )
 
 
@@ -66,6 +67,13 @@ def _frames(conn: SSEConnection) -> list[str]:
     while not conn.queue.empty():
         out.append(conn.queue.get_nowait())
     return out
+
+
+def _stored(events: list[SessionEvent]) -> list[StoredEvent]:
+    return [
+        StoredEvent(storage_cursor=index, event=event)
+        for index, event in enumerate(events, start=1)
+    ]
 
 
 # --- Unit tests for helper functions ---
@@ -104,7 +112,7 @@ class TestSerializeTFEvent:
         assert parsed["payload"]["level"] == "info"
 
     def test_carries_metadata_sequence(self) -> None:
-        event = _make_event(kind=EventKind.job_created, db_id=7)
+        event = _make_event(kind=EventKind.job_created, sequence=7)
         parsed = json.loads(_serialize_tf_event(event))
         assert parsed["metadata"]["sequence"] == 7
 
@@ -185,13 +193,14 @@ class TestSSEManager:
         conn = SSEConnection()
         mgr.register(conn)
 
-        event = _make_event(kind=EventKind.job_created, db_id=42)
-        await mgr.broadcast_domain_event(event)
+        event = _make_event(kind=EventKind.job_created, sequence=9001)
+        await mgr.broadcast_domain_event(event, storage_cursor=42)
 
         data = conn.queue.get_nowait()
-        # Wire event type is the dotted kind; id is the metadata.sequence cursor.
+        # The SSE replay cursor is storage-local; canonical sequence is unchanged.
         assert "event: job.created" in data
         assert "id: 42\n" in data
+        assert json.loads(data.split("data: ", maxsplit=1)[1])["metadata"]["sequence"] == 9001
 
     @pytest.mark.asyncio
     async def test_broadcast_emits_single_frame(self) -> None:
@@ -203,9 +212,9 @@ class TestSSEManager:
         event = _make_event(
             kind=EventKind.approval_requested,
             payload={"approval_id": "apr-1", "description": "approve?"},
-            db_id=5,
+            sequence=9001,
         )
-        await mgr.broadcast_domain_event(event)
+        await mgr.broadcast_domain_event(event, storage_cursor=5)
 
         frames = _frames(conn)
         assert len(frames) == 1
@@ -220,8 +229,8 @@ class TestSSEManager:
         mgr.register(conn1)
         mgr.register(conn2)
 
-        event = _make_event(kind=EventKind.job_created, job_id="job-1", db_id=10)
-        await mgr.broadcast_domain_event(event)
+        event = _make_event(kind=EventKind.job_created, job_id="job-1", sequence=9001)
+        await mgr.broadcast_domain_event(event, storage_cursor=10)
 
         assert not conn1.queue.empty()
         assert conn2.queue.empty()
@@ -376,7 +385,7 @@ class TestSSEManager:
                 timestamp=now,
                 kind=EventKind.job_created,
                 payload={"state": "running"},
-                sequence=1,
+                sequence=9001,
             ),
             new_event(
                 event_id="evt-2",
@@ -384,12 +393,12 @@ class TestSSEManager:
                 timestamp=now,
                 kind=EventKind.log_line_emitted,
                 payload={"seq": 1, "message": "hello"},
-                sequence=2,
+                sequence=9002,
             ),
         ]
 
         event_repo = AsyncMock()
-        event_repo.list_after.return_value = events
+        event_repo.list_after.return_value = _stored(events)
 
         job_repo = AsyncMock()
 
@@ -400,8 +409,10 @@ class TestSSEManager:
         assert len(frames) == 2
         assert "id: 1\n" in frames[0]
         assert "event: job.created" in frames[0]
+        assert '"sequence":9001' in frames[0]
         assert "id: 2\n" in frames[1]
         assert "event: log" in frames[1]
+        assert '"sequence":9002' in frames[1]
 
     @pytest.mark.asyncio
     async def test_replay_events_sends_snapshot_on_overflow(self) -> None:
@@ -423,7 +434,7 @@ class TestSSEManager:
         ]
 
         event_repo = AsyncMock()
-        event_repo.list_after.return_value = events
+        event_repo.list_after.return_value = _stored(events)
         event_repo.list_latest_progress_previews.return_value = {}
 
         job_repo = AsyncMock()
@@ -450,7 +461,7 @@ class TestSSEManager:
         ]
 
         event_repo = AsyncMock()
-        event_repo.list_after.return_value = events
+        event_repo.list_after.return_value = _stored(events)
         event_repo.list_latest_progress_previews.return_value = {}
 
         job_repo = AsyncMock()
@@ -476,7 +487,7 @@ class TestSSEManager:
         ]
 
         event_repo = AsyncMock()
-        event_repo.list_after.return_value = events
+        event_repo.list_after.return_value = _stored(events)
         job_repo = AsyncMock()
 
         await mgr.replay_events(conn, event_repo, job_repo, last_event_id=0)
@@ -532,7 +543,7 @@ class TestSSEManager:
         ]
 
         event_repo = AsyncMock()
-        event_repo.list_after.return_value = events
+        event_repo.list_after.return_value = _stored(events)
         event_repo.list_latest_progress_previews.return_value = {}
 
         job_repo = AsyncMock()
@@ -568,7 +579,7 @@ class TestSSEManager:
         ]
 
         event_repo = AsyncMock()
-        event_repo.list_after.return_value = events
+        event_repo.list_after.return_value = _stored(events)
         event_repo.list_latest_progress_previews.return_value = {}
 
         job_repo = AsyncMock()
@@ -602,7 +613,7 @@ class TestSSEManager:
         ]
 
         event_repo = AsyncMock()
-        event_repo.list_after.return_value = events
+        event_repo.list_after.return_value = _stored(events)
         event_repo.list_latest_progress_previews.return_value = {}
 
         job_repo = AsyncMock()

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -2132,33 +2132,33 @@ export interface paths {
          * Preview Proxy
          * @description Reverse-proxy a request to a local development server.
          */
-        get: operations["preview_proxy_api_preview__port___path__get"];
+        get: operations["preview_proxy_api_preview__port___path__delete"];
         /**
          * Preview Proxy
          * @description Reverse-proxy a request to a local development server.
          */
-        put: operations["preview_proxy_api_preview__port___path__get"];
+        put: operations["preview_proxy_api_preview__port___path__delete"];
         /**
          * Preview Proxy
          * @description Reverse-proxy a request to a local development server.
          */
-        post: operations["preview_proxy_api_preview__port___path__get"];
+        post: operations["preview_proxy_api_preview__port___path__delete"];
         /**
          * Preview Proxy
          * @description Reverse-proxy a request to a local development server.
          */
-        delete: operations["preview_proxy_api_preview__port___path__get"];
+        delete: operations["preview_proxy_api_preview__port___path__delete"];
         options?: never;
         /**
          * Preview Proxy
          * @description Reverse-proxy a request to a local development server.
          */
-        head: operations["preview_proxy_api_preview__port___path__get"];
+        head: operations["preview_proxy_api_preview__port___path__delete"];
         /**
          * Preview Proxy
          * @description Reverse-proxy a request to a local development server.
          */
-        patch: operations["preview_proxy_api_preview__port___path__get"];
+        patch: operations["preview_proxy_api_preview__port___path__delete"];
         trace?: never;
     };
     "/api/jobs/{job_id}/share": {
@@ -2928,6 +2928,16 @@ export interface components {
         ArtifactListResponse: {
             /** Items */
             items: components["schemas"]["ArtifactResponse"][];
+            /**
+             * Collectionstatus
+             * @default pending
+             * @enum {string}
+             */
+            collectionStatus: "pending" | "collecting" | "completed" | "failed";
+            /** Collectionerror */
+            collectionError?: string | null;
+            /** Collectionupdatedat */
+            collectionUpdatedAt?: string | null;
         };
         /** ArtifactResponse */
         ArtifactResponse: {
@@ -5345,14 +5355,15 @@ export interface components {
         };
         /**
          * Preset
-         * @description Action policy preset — controls how the policy router classifies agent actions.
+         * @description Action policy preset — selects the ``traceforge.governance`` profile the
+         *     router enforces (see ``action_policy/preset_profiles.py``).
          *
-         *     autonomous — Contained actions auto-approved. Non-contained actions gated.
-         *                  Monitor handles gate-tier decisions.
-         *     supervised — Reversible + contained auto-approved. Irreversible or
-         *                  non-contained actions gated. Monitor handles gate-tier decisions.
-         *     locked     — Reversible + contained get checkpointed. Everything else gated.
-         *                  Monitor disabled — all gates go directly to human.
+         *     autonomous — Generous budget; protected-path writes escalate; no USD ceiling.
+         *                  Escalations handled by the monitor sidecar.
+         *     supervised — Moderate budget and USD ceiling; cost pressure and protected-path
+         *                  writes escalate; monitor handles escalations.
+         *     locked     — Tight budget and USD ceiling; protected-path writes denied; hard
+         *                  tool-call ceiling; monitor disabled — escalations go to the human.
          * @enum {string}
          */
         Preset: "autonomous" | "supervised" | "locked";
@@ -7238,8 +7249,10 @@ export interface components {
         TranscriptPayload: {
             /** Jobid */
             jobId: string;
-            /** Seq */
-            seq: number;
+            /** Eventid */
+            eventId: string;
+            /** Sequence */
+            sequence?: number | null;
             /**
              * Timestamp
              * Format: date-time
@@ -7253,6 +7266,8 @@ export interface components {
             title?: string | null;
             /** Turnid */
             turnId?: string | null;
+            /** Toolcallid */
+            toolCallId?: string | null;
             /** Toolname */
             toolName?: string | null;
             /** Arguments */
@@ -10872,7 +10887,7 @@ export interface operations {
             };
         };
     };
-    preview_proxy_api_preview__port___path__get: {
+    preview_proxy_api_preview__port___path__delete: {
         parameters: {
             query?: never;
             header?: never;
@@ -10902,7 +10917,7 @@ export interface operations {
             };
         };
     };
-    preview_proxy_api_preview__port___path__get: {
+    preview_proxy_api_preview__port___path__delete: {
         parameters: {
             query?: never;
             header?: never;
@@ -10932,7 +10947,7 @@ export interface operations {
             };
         };
     };
-    preview_proxy_api_preview__port___path__get: {
+    preview_proxy_api_preview__port___path__delete: {
         parameters: {
             query?: never;
             header?: never;
@@ -10962,7 +10977,7 @@ export interface operations {
             };
         };
     };
-    preview_proxy_api_preview__port___path__get: {
+    preview_proxy_api_preview__port___path__delete: {
         parameters: {
             query?: never;
             header?: never;
@@ -10992,7 +11007,7 @@ export interface operations {
             };
         };
     };
-    preview_proxy_api_preview__port___path__get: {
+    preview_proxy_api_preview__port___path__delete: {
         parameters: {
             query?: never;
             header?: never;
@@ -11022,7 +11037,7 @@ export interface operations {
             };
         };
     };
-    preview_proxy_api_preview__port___path__get: {
+    preview_proxy_api_preview__port___path__delete: {
         parameters: {
             query?: never;
             header?: never;

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -269,20 +269,8 @@ export type ArtifactType = components["schemas"]["ArtifactType"];
 export type ExecutionPhase = components["schemas"]["ExecutionPhase"];
 export type GitMergeOutcome = components["schemas"]["GitMergeOutcome"];
 
-export interface ArtifactResponse {
-  id: string;
-  jobId: string;
-  name: string;
-  type: ArtifactType;
-  mimeType: string;
-  sizeBytes: number;
-  phase: ExecutionPhase;
-  createdAt: string;
-}
-
-export interface ArtifactListResponse {
-  items: ArtifactResponse[];
-}
+export type ArtifactResponse = components["schemas"]["ArtifactResponse"];
+export type ArtifactListResponse = components["schemas"]["ArtifactListResponse"];
 
 // --- Workspace types ---
 

--- a/frontend/src/components/ArtifactViewer.tsx
+++ b/frontend/src/components/ArtifactViewer.tsx
@@ -40,6 +40,8 @@ interface Artifact {
   createdAt: string;
 }
 
+type CollectionStatus = "pending" | "collecting" | "completed" | "failed";
+
 /** Display key — the actual group a given artifact is rendered under.
  *  This may differ from the raw `type` (e.g. legacy `document`-typed
  *  agent.log files are reclassified to `agent_log`). */
@@ -533,26 +535,53 @@ interface Props {
 export default function ArtifactViewer({ jobId, onCountChange }: Props) {
   const [artifacts, setArtifacts] = useState<Artifact[]>([]);
   const [loading, setLoading] = useState(true);
+  const [collectionStatus, setCollectionStatus] = useState<CollectionStatus>("pending");
+  const [collectionError, setCollectionError] = useState<string | null>(null);
 
   // Subscribe to job state changes so artifacts refresh when job reaches
   // review/completed/failed states (when post-completion artifacts are created).
   const jobState = useStore((s) => s.jobs[jobId]?.state);
+  const artifactVersion = useStore((s) => s.artifactVersions[jobId] ?? 0);
 
-  const loadArtifacts = useCallback(() => {
-    fetchArtifacts(jobId)
+  const loadArtifacts = useCallback(async () => {
+    return fetchArtifacts(jobId)
       .then((res) => {
         const items = res.items as Artifact[];
         setArtifacts(items);
+        setCollectionStatus(res.collectionStatus);
+        setCollectionError(res.collectionError ?? null);
         onCountChange?.(items.length);
+        return res.collectionStatus;
       })
-      .catch((err) => console.error("Failed to fetch artifacts", err))
+      .catch((err) => {
+        console.error("Failed to fetch artifacts", err);
+        throw err;
+      })
       .finally(() => setLoading(false));
   }, [jobId, onCountChange]);
 
   // Load on mount + whenever job state changes (covers session end + completion)
   useEffect(() => {
-    loadArtifacts();
-  }, [loadArtifacts, jobState]);
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const refresh = () => {
+      loadArtifacts()
+        .then((status) => {
+          const terminal = ["review", "completed", "failed", "canceled"].includes(jobState ?? "");
+          if (!cancelled && terminal && (status === "pending" || status === "collecting")) {
+            timer = setTimeout(refresh, 1000);
+          }
+        })
+        .catch(() => {
+          // The error is surfaced in the console; a later state/SSE update retries.
+        });
+    };
+    refresh();
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [loadArtifacts, jobState, artifactVersion]);
 
   // Classify and group
   const sortedGroups = useMemo(() => {
@@ -569,10 +598,18 @@ export default function ArtifactViewer({ jobId, onCountChange }: Props) {
   if (loading) return <div className="flex justify-center py-10"><Spinner /></div>;
 
   if (artifacts.length === 0) {
+    const collecting = collectionStatus === "pending" || collectionStatus === "collecting";
     return (
       <div className="rounded-lg border border-border bg-card p-8 text-center">
-        <p className="text-sm text-muted-foreground">No artifacts collected yet</p>
-        <p className="text-xs text-muted-foreground mt-1">Artifacts appear when a session ends or the job completes.</p>
+        {collecting && <div className="flex justify-center mb-3"><Spinner /></div>}
+        <p className="text-sm text-muted-foreground">
+          {collectionStatus === "failed" ? "Artifact collection failed" : collecting ? "Collecting artifacts…" : "No artifacts collected"}
+        </p>
+        {collectionError ? (
+          <p className="text-xs text-destructive mt-2 break-words">{collectionError}</p>
+        ) : (
+          <p className="text-xs text-muted-foreground mt-1">Artifacts are finalized when the session ends.</p>
+        )}
       </div>
     );
   }
@@ -581,6 +618,11 @@ export default function ArtifactViewer({ jobId, onCountChange }: Props) {
 
   return (
     <div>
+      {collectionStatus === "failed" && (
+        <div className="mb-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+          Artifact refresh failed: {collectionError ?? "Unknown collection error"}
+        </div>
+      )}
       <div className="flex items-center justify-between mb-2 px-1">
         <p className="text-xs text-muted-foreground">
           {artifacts.length} artifact{artifacts.length !== 1 ? "s" : ""} · {formatSize(totalSize)} total

--- a/frontend/src/components/CuratedFeed.tsx
+++ b/frontend/src/components/CuratedFeed.tsx
@@ -562,7 +562,7 @@ export function CuratedFeed({
 
   const entries = useMemo<TranscriptEntry[]>(() => [
     ...(prompt
-      ? [{ jobId, seq: -1, timestamp: promptTimestamp ?? "", kind: "message.user", content: prompt }]
+      ? [{ jobId, timestamp: promptTimestamp ?? "", kind: "message.user", content: prompt }]
       : []),
     ...rawEntries.filter((e) => {
       if (!e.content?.trim() && e.kind !== "tool.call.completed" && e.kind !== "tool.call.started") return false;
@@ -659,10 +659,10 @@ export function CuratedFeed({
     if (handledSeqRef.current === scrollToSeq) return;
     const idx = feedItems.findIndex((item) => {
       if (item.type === "turn" || item.type === "condensed") {
-        return item.turn.toolCalls.some((tc) => tc.seq === scrollToSeq);
+        return item.turn.toolCalls.some((tc) => tc.sequence === scrollToSeq);
       }
       if (item.type === "operator" || item.type === "divider") {
-        return item.entry.seq === scrollToSeq;
+        return item.entry.sequence === scrollToSeq;
       }
       return false;
     });
@@ -756,7 +756,6 @@ export function CuratedFeed({
     // Optimistic update: show the operator message immediately in the transcript
     const optimisticEntry: TranscriptEntry = {
       jobId,
-      seq: 0,
       timestamp: new Date().toISOString(),
       kind: "message.user",
       content: text,

--- a/frontend/src/components/CuratedFeedLogic.ts
+++ b/frontend/src/components/CuratedFeedLogic.ts
@@ -11,6 +11,8 @@ import {
   stripMcpPrefix,
 } from "./ToolRenderers";
 import type { FileText } from "lucide-react";
+import { transcriptIdentity } from "../lib/transcriptIdentity";
+import { repositoryRelativePath } from "../lib/pathDisplay";
 
 // ---------------------------------------------------------------------------
 // Tool classification for clustering
@@ -139,10 +141,10 @@ export function extractFileKey(entry: TranscriptEntry): string {
     if (path) return path;
   }
   if (kind === "execute") {
-    return (args.command as string) ?? entry.toolDisplay ?? `cmd-${entry.seq}`;
+    return (args.command as string) ?? entry.toolDisplay ?? entry.toolName ?? transcriptIdentity(entry) ?? entry.timestamp;
   }
   if (kind === "search") {
-    return (args.query ?? args.pattern ?? "") as string || `search-${entry.seq}`;
+    return (args.query ?? args.pattern ?? "") as string || entry.toolName || transcriptIdentity(entry) || entry.timestamp;
   }
   // multi_replace: extract first file
   const name = stripMcpPrefix(entry.toolName ?? "");
@@ -151,7 +153,7 @@ export function extractFileKey(entry: TranscriptEntry): string {
     const firstPath = edits[0] && ((edits[0].filePath ?? edits[0].file_path ?? edits[0].path ?? "") as string);
     if (firstPath) return firstPath;
   }
-  return entry.toolDisplay ?? `entry-${entry.seq}`;
+  return entry.toolDisplay ?? entry.toolName ?? transcriptIdentity(entry) ?? entry.timestamp;
 }
 
 /** Extract just the filename from a path. */
@@ -161,16 +163,8 @@ export function fileNameOnly(path: string): string {
 }
 
 /** Path relative to worktree root (strips worktree prefix). */
-export function relativeToWorktree(path: string): string {
-  const MARKER = "/.codeplane-worktrees/";
-  const idx = path.indexOf(MARKER);
-  if (idx !== -1) {
-    const afterMarker = path.slice(idx + MARKER.length);
-    const slashIdx = afterMarker.indexOf("/");
-    return slashIdx !== -1 ? afterMarker.slice(slashIdx + 1) : afterMarker;
-  }
-  const parts = path.replace(/\\/g, "/").split("/").filter(Boolean);
-  return parts.length <= 3 ? path : parts.slice(-3).join("/");
+export function relativeToWorktree(path: string, worktreeRoot?: string | null): string {
+  return repositoryRelativePath(path, worktreeRoot) ?? "(outside workspace)";
 }
 
 /** True if the path is inside the job worktree (a repo file, not a temp/session artifact). */
@@ -184,7 +178,7 @@ export function isRepoFile(path: string): boolean {
   return true;
 }
 
-export function deduplicateByFile(entries: TranscriptEntry[]): PhaseFile[] {
+export function deduplicateByFile(entries: TranscriptEntry[], worktreeRoot?: string | null): PhaseFile[] {
   const map = new Map<string, PhaseFile>();
   for (const e of entries) {
     const key = extractFileKey(e);
@@ -207,7 +201,7 @@ export function deduplicateByFile(entries: TranscriptEntry[]): PhaseFile[] {
         relativePath = `"${q}"`;
       } else {
         fileName = fileNameOnly(key);
-        relativePath = relativeToWorktree(key);
+        relativePath = relativeToWorktree(key, worktreeRoot);
       }
       map.set(key, { key, fileName, relativePath, entries: [e] });
     }
@@ -309,7 +303,7 @@ export function buildFeedItems(
         flushTurn();
       }
       if (!currentTurn) {
-        currentTurn = { key: `t-${entry.seq}`, reasoning: entry, toolCalls: [], message: null, firstTimestamp: entry.timestamp, turnId: entry.turnId ?? null };
+        currentTurn = { key: transcriptIdentity(entry) ?? `turn:${entry.timestamp}`, reasoning: entry, toolCalls: [], message: null, firstTimestamp: entry.timestamp, turnId: entry.turnId ?? null };
       } else if (!currentTurn.reasoning) {
         currentTurn.reasoning = entry;
       }
@@ -321,7 +315,7 @@ export function buildFeedItems(
         flushTurn();
       }
       if (!currentTurn) {
-        currentTurn = { key: `t-${entry.seq}`, reasoning: null, toolCalls: [], message: null, firstTimestamp: entry.timestamp, turnId: entry.turnId ?? null };
+        currentTurn = { key: transcriptIdentity(entry) ?? `turn:${entry.timestamp}`, reasoning: null, toolCalls: [], message: null, firstTimestamp: entry.timestamp, turnId: entry.turnId ?? null };
       }
       currentTurn.toolCalls.push(entry);
       continue;
@@ -332,7 +326,7 @@ export function buildFeedItems(
         flushTurn();
       }
       if (!currentTurn) {
-        currentTurn = { key: `t-${entry.seq}`, reasoning: null, toolCalls: [], message: null, firstTimestamp: entry.timestamp, turnId: entry.turnId ?? null };
+        currentTurn = { key: transcriptIdentity(entry) ?? `turn:${entry.timestamp}`, reasoning: null, toolCalls: [], message: null, firstTimestamp: entry.timestamp, turnId: entry.turnId ?? null };
       }
       currentTurn.message = entry;
       flushTurn();

--- a/frontend/src/components/CuratedFeedPreviews.tsx
+++ b/frontend/src/components/CuratedFeedPreviews.tsx
@@ -82,12 +82,17 @@ export function PhaseBox({
   const setExpanded = setManualExpanded;
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
   const Icon = KIND_ICONS[cluster.kind];
-  const files = useMemo(() => deduplicateByFile(cluster.entries), [cluster.entries]);
+  const jobId = cluster.entries[0]?.jobId;
+  const worktreeRoot = useStore((state) => jobId ? state.jobs[jobId]?.worktreePath : null);
+  const files = useMemo(
+    () => deduplicateByFile(cluster.entries, worktreeRoot),
+    [cluster.entries, worktreeRoot],
+  );
   const totalDuration = cluster.entries.reduce((sum, e) => sum + (e.toolDurationMs ?? 0), 0);
   const hasEdits = cluster.kind === "write" || cluster.kind === "create";
   const hasFailure = cluster.entries.some((e) => e.success === false);
 
-  const firstSeq = cluster.entries[0]?.seq;
+  const firstSeq = cluster.entries[0]?.sequence;
   const turnId = cluster.entries[0]?.turnId;
 
   const handleViewChanges = useCallback(() => {
@@ -289,7 +294,7 @@ export function FileChip({
   return (
     <button
       onClick={onClick}
-      title={file.relativePath}
+      title={file.key}
       className={cn(
         "inline-flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-mono",
         "transition-colors cursor-pointer select-none",
@@ -314,7 +319,10 @@ function InlinePreview({ file, kind }: { file: PhaseFile; kind: ClusterKind }) {
   return (
     <div>
       {kind !== "execute" && kind !== "search" && (
-        <div className="px-3 py-1 text-[11px] font-mono text-muted-foreground/60 border-b border-border/10">
+        <div
+          className="px-3 py-1 text-[11px] font-mono text-muted-foreground/60 border-b border-border/10"
+          title={file.key}
+        >
           {file.relativePath}
         </div>
       )}

--- a/frontend/src/components/JobCard.tsx
+++ b/frontend/src/components/JobCard.tsx
@@ -56,7 +56,7 @@ export const JobCard = memo(function JobCard({ job }: { job: JobSummary }) {
   const repoName = job.repo.split("/").pop() ?? job.repo;
   const transcript = useStore(selectJobTranscript(job.id));
   const lastSeenSeq = useViewStateStore((s) => s.lastSeenSeq[job.id]);
-  const hasUnread = lastSeenSeq != null && transcript.some((e) => (e.seq ?? 0) > lastSeenSeq);
+  const hasUnread = lastSeenSeq != null && transcript.some((e) => (e.sequence ?? 0) > lastSeenSeq);
   const previewHeadline = job.progressHeadline ?? null;
   const previewSummary = job.progressSummary ?? "";
 

--- a/frontend/src/components/JobDetailScreen.tsx
+++ b/frontend/src/components/JobDetailScreen.tsx
@@ -23,6 +23,7 @@ import type { ReviewSubView } from "./review/ReviewSubTabs";
 import { ActivityPanel } from "./ActivityPanel";
 import { ViewTabBar } from "./ViewTabBar";
 import { StructuralWarningBanner } from "./StructuralWarningBanner";
+import { mergeTranscriptEntries } from "../lib/transcriptIdentity";
 
 import { JobHeaderCard } from "./JobHeaderCard";
 import { MobileBottomNav, MobileFooterActions } from "./JobDetailMobile";
@@ -96,8 +97,9 @@ export function JobDetailScreen() {
   const diffs = useStore(selectJobDiffs(jobId ?? ""));
   const hasChanges = diffs.length > 0;
   const hasWorktree = !!job?.worktreePath && !job?.archivedAt;
-  const [hasArtifacts, setHasArtifacts] = useState(false);
+  const hasArtifacts = true;
   const [artifactCount, setArtifactCount] = useState(0);
+  const artifactVersion = useStore((s) => jobId ? (s.artifactVersions[jobId] ?? 0) : 0);
 
   // Map a transcript turnId to the nearest activity-timeline step turnId.
   // Many transcript turns have no corresponding step in the activity timeline;
@@ -146,9 +148,9 @@ export function JobDetailScreen() {
     const tabs = ["live"];
     if (hasChanges) tabs.push("review");
     tabs.push("files", "metrics");
-    if (hasArtifacts) tabs.push("artifacts");
+    tabs.push("artifacts");
     return tabs;
-  }, [hasChanges, hasArtifacts]);
+  }, [hasChanges]);
   const touchRef = useRef<{ x: number; y: number; t: number; el: EventTarget | null } | null>(null);
   const [slideDir, setSlideDir] = useState<"left" | "right" | null>(null);
 
@@ -232,17 +234,28 @@ export function JobDetailScreen() {
 
   useEffect(() => {
     if (!jobId) return;
-    fetchArtifacts(jobId)
-      .then((res) => {
-        setHasArtifacts(res.items.length > 0);
-        setArtifactCount(res.items.length);
-      })
-      .catch(() => {});
-  }, [jobId, job?.state]);
-
-  useEffect(() => {
-    if (!hasArtifacts && tab === "artifacts") setTab("live");
-  }, [hasArtifacts, tab]);
+    let cancelled = false;
+    let retryTimer: ReturnType<typeof setTimeout> | undefined;
+    const load = () => {
+      fetchArtifacts(jobId)
+        .then((res) => {
+          if (cancelled) return;
+          setArtifactCount(res.items.length);
+          const terminal = ["review", "completed", "failed", "canceled"].includes(job?.state ?? "");
+          if (terminal && (res.collectionStatus === "pending" || res.collectionStatus === "collecting")) {
+            retryTimer = setTimeout(load, 1000);
+          }
+        })
+        .catch((err) => {
+          if (!cancelled) console.error("Failed to fetch artifacts", err);
+        });
+    };
+    load();
+    return () => {
+      cancelled = true;
+      if (retryTimer) clearTimeout(retryTimer);
+    };
+  }, [jobId, job?.state, artifactVersion]);
 
 
 
@@ -295,10 +308,7 @@ export function JobDetailScreen() {
     fetchJobTranscript(jobId).then((transcript) => {
         useStore.setState((s) => {
           const existingTranscript = s.transcript[jobId] ?? [];
-          const mergedTx = [
-            ...transcript,
-            ...existingTranscript.filter((e) => !transcript.some((ne) => ne.seq === e.seq)),
-          ].sort((a, b) => a.seq - b.seq);
+          const mergedTx = mergeTranscriptEntries(transcript, existingTranscript);
           return {
             transcript: { ...s.transcript, [jobId]: mergedTx },
           };
@@ -693,7 +703,7 @@ export function JobDetailScreen() {
       {tab === "artifacts" && (
         <TabErrorBoundary>
           <Suspense fallback={<div className="flex justify-center py-10"><Spinner /></div>}>
-            <ArtifactViewer jobId={jobId} onCountChange={(n) => { setArtifactCount(n); setHasArtifacts(n > 0); }} />
+            <ArtifactViewer jobId={jobId} onCountChange={setArtifactCount} />
           </Suspense>
         </TabErrorBoundary>
       )}

--- a/frontend/src/components/SecondarySessionCard.tsx
+++ b/frontend/src/components/SecondarySessionCard.tsx
@@ -35,7 +35,7 @@ function entriesToTranscript(entries: SecondarySessionEntry[]): TranscriptEntry[
     if (entry.kind === "reasoning") {
       return {
         jobId: "",
-        seq: entry.seq,
+        sequence: entry.seq,
         timestamp: "",
         kind: "llm.reasoning.chunk",
         content: entry.content,
@@ -44,7 +44,7 @@ function entriesToTranscript(entries: SecondarySessionEntry[]): TranscriptEntry[
     if (entry.kind === "tool_call") {
       return {
         jobId: "",
-        seq: entry.seq,
+        sequence: entry.seq,
         timestamp: "",
         kind: "tool.call.completed",
         content: entry.content,
@@ -62,7 +62,7 @@ function entriesToTranscript(entries: SecondarySessionEntry[]): TranscriptEntry[
     if (entry.kind === "output") {
       return {
         jobId: "",
-        seq: entry.seq,
+        sequence: entry.seq,
         timestamp: "",
         kind: "message.assistant",
         content: entry.content,
@@ -71,7 +71,7 @@ function entriesToTranscript(entries: SecondarySessionEntry[]): TranscriptEntry[
     // error
     return {
       jobId: "",
-      seq: entry.seq,
+      sequence: entry.seq,
       timestamp: "",
       kind: "message.assistant",
       content: entry.content,

--- a/frontend/src/components/ToolRenderers.tsx
+++ b/frontend/src/components/ToolRenderers.tsx
@@ -9,6 +9,9 @@ import { SyntaxBlock } from "./SyntaxBlock";
 import { stripAnsi } from "../lib/ansi";
 import { RunningToolIndicator } from "./RunningToolIndicator";
 import type { TranscriptEntry } from "../store";
+import { transcriptReactKey } from "../lib/transcriptIdentity";
+import { repositoryRelativePath, trimWorktreeRoot } from "../lib/pathDisplay";
+import { useStore } from "../store";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -47,17 +50,12 @@ export function countLines(text?: string): number | undefined {
   return text.split("\n").filter((l) => l.trim()).length;
 }
 
-const WORKTREE_MARKER = "/.codeplane-worktrees/";
-
-export function abbreviatePath(path: string): string {
-  const idx = path.indexOf(WORKTREE_MARKER);
-  if (idx !== -1) return "…/" + path.slice(idx + WORKTREE_MARKER.length);
-  const parts = path.replace(/\\/g, "/").split("/").filter(Boolean);
-  return parts.length <= 2 ? path : parts.slice(-2).join("/");
+export function abbreviatePath(path: string, worktreeRoot?: string | null): string {
+  return repositoryRelativePath(path, worktreeRoot) ?? "(outside workspace)";
 }
 
-export function trimWorktreePaths(text: string): string {
-  return text.replace(/\/[^\s]*\.codeplane-worktrees\//g, "…/");
+export function trimWorktreePaths(text: string, worktreeRoot?: string | null): string {
+  return trimWorktreeRoot(text, worktreeRoot);
 }
 
 // ---------------------------------------------------------------------------
@@ -117,12 +115,13 @@ export function ReasoningBlock({ entry }: { entry: TranscriptEntry }) {
 export function StructuredToolContent({ entry }: { entry: TranscriptEntry }) {
   const toolName = stripMcpPrefix(entry.toolName ?? "");
   const args = parseArgs(entry.arguments);
+  const worktreeRoot = useStore((state) => state.jobs[entry.jobId]?.worktreePath);
 
   switch (toolName) {
     case "Bash":
     case "bash":
     case "run_in_terminal": {
-      const command = trimWorktreePaths((args.command as string) ?? "");
+      const command = trimWorktreePaths((args.command as string) ?? "", worktreeRoot);
       return (
         <div className="font-mono text-xs">
           <div className={cn(
@@ -144,13 +143,13 @@ export function StructuredToolContent({ entry }: { entry: TranscriptEntry }) {
       const startLine = (args.startLine ?? args.start_line) as number | undefined;
       const endLine = (args.endLine ?? args.end_line) as number | undefined;
       const lines = countLines(entry.result);
-      const shortPath = abbreviatePath(filePath);
+      const shortPath = abbreviatePath(filePath, worktreeRoot);
       const range = startLine && endLine ? `lines ${startLine}–${endLine}` : null;
       return (
         <div className="font-mono text-xs">
           <div className={cn("px-3 py-1.5 flex items-center gap-2", entry.result && "border-b border-border/30")}>
             <Codicon name="file-code" size={11} className="text-blue-400 shrink-0" />
-            <span className="text-foreground/80">{shortPath}</span>
+            <span className="text-foreground/80" title={filePath}>{shortPath}</span>
             {range && <span className="text-muted-foreground">{range}</span>}
             {lines != null && <span className="text-muted-foreground/60">({lines} lines)</span>}
           </div>
@@ -169,14 +168,14 @@ export function StructuredToolContent({ entry }: { entry: TranscriptEntry }) {
     case "Edit":
     case "insert_edit_into_file": {
       const filePath = (args.filePath ?? args.file_path ?? args.path ?? "") as string;
-      const shortPath = abbreviatePath(filePath);
+      const shortPath = abbreviatePath(filePath, worktreeRoot);
       const oldStr = (args.old_str ?? args.old_string ?? args.oldString) as string | undefined;
       const newStr = (args.new_str ?? args.new_string ?? args.newString) as string | undefined;
       return (
         <div className="px-3 py-1.5 text-xs">
           <div className="flex items-center gap-2">
             <Codicon name="edit" size={11} className="text-amber-400 shrink-0" />
-            <span className="font-mono text-foreground/80">{shortPath}</span>
+            <span className="font-mono text-foreground/80" title={filePath}>{shortPath}</span>
             <span className="text-muted-foreground">
               {entry.success !== false ? "→ applied" : "→ failed"}
             </span>
@@ -197,7 +196,7 @@ export function StructuredToolContent({ entry }: { entry: TranscriptEntry }) {
         edits
           .map((e) => (e.filePath ?? e.file_path ?? e.path ?? "") as string)
           .filter(Boolean)
-          .map((p) => abbreviatePath(p)),
+          .map((p) => abbreviatePath(p, worktreeRoot)),
       )];
       const label = paths.length
         ? paths.slice(0, 3).join(", ") + (paths.length > 3 ? "…" : "")
@@ -212,12 +211,13 @@ export function StructuredToolContent({ entry }: { entry: TranscriptEntry }) {
             </span>
           </div>
           {edits.slice(0, 3).map((e, i) => {
-            const p = abbreviatePath((e.filePath ?? e.file_path ?? e.path ?? "") as string);
+            const rawPath = (e.filePath ?? e.file_path ?? e.path ?? "") as string;
+            const p = abbreviatePath(rawPath, worktreeRoot);
             const oldStr = (e.old_string ?? e.old_str ?? e.oldString) as string | undefined;
             const newStr = (e.new_string ?? e.new_str ?? e.newString) as string | undefined;
             return (
               <div key={i} className="mt-1.5 pl-5">
-                {paths.length > 1 && <div className="text-muted-foreground/60 font-mono text-[10px]">{p}</div>}
+                {paths.length > 1 && <div className="text-muted-foreground/60 font-mono text-[10px]" title={rawPath}>{p}</div>}
                 {typeof oldStr === "string" && typeof newStr === "string" && (
                   <div className="font-mono text-[11px] leading-relaxed">
                     <div className="text-red-400/80">- {oldStr.slice(0, 80)}{oldStr.length > 80 ? "…" : ""}</div>
@@ -260,7 +260,7 @@ export function StructuredToolContent({ entry }: { entry: TranscriptEntry }) {
       return (
         <div className="px-3 py-1.5 flex items-center gap-2 text-xs">
           <Codicon name="edit" size={11} className="text-green-400 shrink-0" />
-          <span className="font-mono text-foreground/80">{abbreviatePath(filePath)}</span>
+          <span className="font-mono text-foreground/80" title={filePath}>{abbreviatePath(filePath, worktreeRoot)}</span>
           <span className="text-muted-foreground">→ {toolName === "write" || toolName === "Write" ? "written" : "created"}</span>
         </div>
       );
@@ -277,7 +277,7 @@ export function StructuredToolContent({ entry }: { entry: TranscriptEntry }) {
         <div className="font-mono text-xs">
           <div className={cn("px-3 py-1.5 flex items-center gap-2", entry.result && "border-b border-border/30")}>
             <Codicon name="file-code" size={11} className="text-blue-400 shrink-0" />
-            <span className="text-foreground/80">{abbreviatePath(path)}</span>
+            <span className="text-foreground/80" title={path}>{abbreviatePath(path, worktreeRoot)}</span>
             {range && <span className="text-muted-foreground">{range}</span>}
             {lines != null && <span className="text-muted-foreground/60">({lines} lines)</span>}
           </div>
@@ -303,7 +303,7 @@ export function StructuredToolContent({ entry }: { entry: TranscriptEntry }) {
           <div className={cn("px-3 py-1.5 flex items-center gap-2", entry.result && "border-b border-border/30")}>
             <Codicon name="search" size={11} className="text-blue-400 shrink-0" />
             <span className="text-foreground/80">{pattern}</span>
-            {searchPath && <span className="text-muted-foreground/60">in {abbreviatePath(searchPath)}</span>}
+            {searchPath && <span className="text-muted-foreground/60" title={searchPath}>in {abbreviatePath(searchPath, worktreeRoot)}</span>}
             {lines != null && <span className="text-muted-foreground">→ {lines} files</span>}
           </div>
           {entry.result && (
@@ -324,7 +324,7 @@ export function StructuredToolContent({ entry }: { entry: TranscriptEntry }) {
             <Codicon name="search" size={11} className="text-blue-400 shrink-0" />
             <span className="text-foreground/80">&ldquo;{pattern}&rdquo;</span>
             {(globFilter || searchPath) && (
-              <span className="text-muted-foreground/60">in {globFilter || abbreviatePath(searchPath)}</span>
+              <span className="text-muted-foreground/60" title={globFilter ? undefined : searchPath}>in {globFilter || abbreviatePath(searchPath, worktreeRoot)}</span>
             )}
             {lines != null && <span className="text-muted-foreground">→ {lines} matches</span>}
           </div>
@@ -342,7 +342,7 @@ export function StructuredToolContent({ entry }: { entry: TranscriptEntry }) {
         <div className="font-mono text-xs">
           <div className={cn("px-3 py-1.5 flex items-center gap-2", entry.result && "border-b border-border/30")}>
             <Codicon name="file-code" size={11} className="text-blue-400 shrink-0" />
-            <span className="text-foreground/80">{abbreviatePath(path) || "."}</span>
+            <span className="text-foreground/80" title={path}>{abbreviatePath(path, worktreeRoot) || "."}</span>
             {lines != null && <span className="text-muted-foreground/60">({lines} entries)</span>}
           </div>
           {entry.result && (
@@ -609,14 +609,14 @@ export function SubAgentSection({
           {childCalls.map((child, i) =>
             isSubagentTool(child.toolName) ? (
               <SubAgentSection
-                key={child.seq}
+                key={transcriptReactKey(child, i)}
                 entry={child}
                 childCalls={[]}
                 isActive={isActive && i === childCalls.length - 1}
               />
             ) : (
               <ToolStep
-                key={child.seq}
+                key={transcriptReactKey(child, i)}
                 entry={child}
                 isActive={isActive && i === childCalls.length - 1}
               />
@@ -713,7 +713,7 @@ export function ToolStepList({ calls, isActive }: { calls: TranscriptEntry[]; is
           if (seg.type === "subagent-group") {
             return (
               <SubAgentSection
-                key={seg.entry.seq}
+                key={transcriptReactKey(seg.entry, i)}
                 entry={seg.entry}
                 childCalls={seg.children}
                 isActive={isActive && isLastSeg}
@@ -722,7 +722,7 @@ export function ToolStepList({ calls, isActive }: { calls: TranscriptEntry[]; is
           }
           return (
             <ToolStep
-              key={seg.entry.seq}
+              key={transcriptReactKey(seg.entry, i)}
               entry={seg.entry}
               isActive={isActive && isLastSeg}
             />

--- a/frontend/src/components/__tests__/ArtifactViewer.test.tsx
+++ b/frontend/src/components/__tests__/ArtifactViewer.test.tsx
@@ -1,0 +1,53 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchArtifacts } from "../../api/client";
+import { useStore } from "../../store";
+import ArtifactViewer from "../ArtifactViewer";
+
+vi.mock("../../api/client", () => ({
+  fetchArtifacts: vi.fn(),
+  downloadArtifactUrl: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.mocked(fetchArtifacts).mockReset();
+  useStore.setState({
+    jobs: {},
+    artifactVersions: {},
+  });
+});
+
+describe("ArtifactViewer", () => {
+  it("surfaces durable collection failures when no artifacts were produced", async () => {
+    vi.mocked(fetchArtifacts).mockResolvedValue({
+      items: [],
+      collectionStatus: "failed",
+      collectionError: "OSError: workspace disappeared",
+      collectionUpdatedAt: "2026-08-02T20:00:00Z",
+    });
+
+    render(<ArtifactViewer jobId="job-1" />);
+
+    expect(await screen.findByText("Artifact collection failed")).toBeInTheDocument();
+    expect(screen.getByText("OSError: workspace disappeared")).toBeInTheDocument();
+  });
+
+  it("refetches after artifacts.updated increments the job version", async () => {
+    vi.mocked(fetchArtifacts).mockResolvedValue({
+      items: [],
+      collectionStatus: "completed",
+      collectionError: null,
+      collectionUpdatedAt: "2026-08-02T20:00:00Z",
+    });
+
+    render(<ArtifactViewer jobId="job-1" />);
+    await waitFor(() => expect(fetchArtifacts).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      useStore.setState({ artifactVersions: { "job-1": 1 } });
+    });
+
+    await waitFor(() => expect(fetchArtifacts).toHaveBeenCalledTimes(2));
+    expect(screen.getByText("No artifacts collected")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/__tests__/JobDetailScreen.test.tsx
+++ b/frontend/src/components/__tests__/JobDetailScreen.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { useStore } from "../../store";
 import type { JobSummary } from "../../store";
@@ -16,7 +16,12 @@ vi.mock("../../api/client", () => ({
   fetchJobSteps: vi.fn().mockResolvedValue([]),
   fetchApprovals: vi.fn().mockResolvedValue([]),
   resolveJob: vi.fn(),
-  fetchArtifacts: vi.fn().mockResolvedValue({ items: [] }),
+  fetchArtifacts: vi.fn().mockResolvedValue({
+    items: [],
+    collectionStatus: "completed",
+    collectionError: null,
+    collectionUpdatedAt: null,
+  }),
   createTerminalSession: vi.fn(),
   archiveJob: vi.fn(),
   fetchMultiSession: vi.fn().mockResolvedValue(null),
@@ -65,7 +70,7 @@ vi.mock("../ui/confirm-dialog", () => ({
 }));
 
 import { toast } from "sonner";
-import { fetchJob, fetchJobDiff, resolveJob, rerunJob, resumeJob } from "../../api/client";
+import { fetchArtifacts, fetchJob, fetchJobDiff, resolveJob, rerunJob, resumeJob } from "../../api/client";
 import { JobDetailScreen } from "../JobDetailScreen";
 
 function makeJob(overrides: Partial<JobSummary> = {}): JobSummary {
@@ -94,6 +99,13 @@ beforeEach(() => {
   vi.mocked(fetchJob).mockReset();
   vi.mocked(fetchJobDiff).mockReset();
   vi.mocked(resolveJob).mockReset();
+  vi.mocked(fetchArtifacts).mockReset();
+  vi.mocked(fetchArtifacts).mockResolvedValue({
+    items: [],
+    collectionStatus: "completed",
+    collectionError: null,
+    collectionUpdatedAt: null,
+  });
   vi.mocked(fetchJobDiff).mockResolvedValue([]);
   useStore.setState({
     jobs: {},
@@ -104,6 +116,7 @@ beforeEach(() => {
     timelines: {},
     plans: {},
     telemetryVersions: {},
+    artifactVersions: {},
     terminalSessions: {},
     activeTerminalTab: null,
     terminalDrawerOpen: false,
@@ -121,6 +134,30 @@ beforeEach(() => {
 });
 
 describe("JobDetailScreen", () => {
+  it("keeps the Artifacts tab visible and refetches after artifacts.updated", async () => {
+    useStore.setState({ jobs: { "job-1": makeJob() } });
+    vi.mocked(fetchJob).mockResolvedValueOnce(makeJob() as any);
+
+    render(
+      <MemoryRouter initialEntries={["/jobs/job-1"]}>
+        <Routes>
+          <Route path="/jobs/:jobId" element={<JobDetailScreen />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByRole("button", { name: "Artifacts" })).toBeInTheDocument();
+    await waitFor(() => expect(fetchArtifacts).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      useStore.getState().dispatchSSEEvent("artifacts.updated", {
+        jobId: "job-1",
+        collectionStatus: "completed",
+      });
+    });
+    await waitFor(() => expect(fetchArtifacts).toHaveBeenCalledTimes(2));
+  });
+
   it("re-fetches the job even when a cached copy already exists", async () => {
     useStore.setState({
       jobs: {

--- a/frontend/src/hooks/useSSE.ts
+++ b/frontend/src/hooks/useSSE.ts
@@ -129,6 +129,7 @@ export function useSSE(jobId?: string): { reconnect: () => void } {
         "session.heartbeat",
         "session.resumed",
         "telemetry.updated",
+        "artifacts.updated",
         // Plan steps — the only step-level event the frontend handles
         "plan.step_updated",
         // Activity timeline

--- a/frontend/src/lib/pathDisplay.test.ts
+++ b/frontend/src/lib/pathDisplay.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { repositoryRelativePath, trimWorktreeRoot } from "./pathDisplay";
+
+describe("repositoryRelativePath", () => {
+  it("returns Windows repository-relative paths without a leading slash", () => {
+    expect(repositoryRelativePath(
+      String.raw`C:\Users\david\.codeplane-worktrees\codeplane\audit\backend\api\jobs.py`,
+      String.raw`C:\Users\david\.codeplane-worktrees\codeplane\audit`,
+    )).toBe("backend/api/jobs.py");
+  });
+
+  it("compares Windows roots case-insensitively and enforces a path boundary", () => {
+    expect(repositoryRelativePath(
+      String.raw`c:\REPO\src\main.ts`,
+      String.raw`C:\repo`,
+    )).toBe("src/main.ts");
+    expect(repositoryRelativePath(
+      String.raw`C:\repository\src\main.ts`,
+      String.raw`C:\repo`,
+    )).toBeNull();
+  });
+
+  it("handles POSIX paths and rejects paths outside the worktree", () => {
+    expect(repositoryRelativePath("/work/job/src/main.py", "/work/job")).toBe("src/main.py");
+    expect(repositoryRelativePath("/work/other/main.py", "/work/job")).toBeNull();
+  });
+
+  it("handles UNC paths case-insensitively without losing their boundary", () => {
+    expect(repositoryRelativePath(
+      String.raw`\\SERVER\Share\repo\src\main.ts`,
+      String.raw`\\server\share\repo`,
+    )).toBe("src/main.ts");
+    expect(repositoryRelativePath(
+      String.raw`\\server\share\repository\src\main.ts`,
+      String.raw`\\server\share\repo`,
+    )).toBeNull();
+  });
+
+  it("rejects traversal and absolute paths when no worktree root is known", () => {
+    expect(repositoryRelativePath("../secret.txt", "/work/job")).toBeNull();
+    expect(repositoryRelativePath("/work/job/src/main.py")).toBeNull();
+  });
+
+  it("keeps already-relative repository paths intact", () => {
+    expect(repositoryRelativePath("src/components/App.tsx", "/work/job")).toBe("src/components/App.tsx");
+  });
+});
+
+describe("trimWorktreeRoot", () => {
+  it("only replaces the exact Windows worktree root", () => {
+    expect(trimWorktreeRoot(
+      String.raw`Get-Content C:\repo\src\main.ts`,
+      String.raw`C:\repo`,
+    )).toBe(String.raw`Get-Content .\src\main.ts`);
+    expect(trimWorktreeRoot(
+      String.raw`Get-Content C:\repository\src\main.ts`,
+      String.raw`C:\repo`,
+    )).toBe(String.raw`Get-Content C:\repository\src\main.ts`);
+  });
+});

--- a/frontend/src/lib/pathDisplay.ts
+++ b/frontend/src/lib/pathDisplay.ts
@@ -1,0 +1,83 @@
+export interface RepositoryPathDisplay {
+  display: string;
+  raw: string;
+}
+
+interface NormalizedPath {
+  value: string;
+  absolute: boolean;
+  windows: boolean;
+  escaped: boolean;
+}
+
+function normalizePath(raw: string): NormalizedPath {
+  const slashed = raw.replace(/\\/g, "/");
+  const windowsDrive = /^[A-Za-z]:\//.test(slashed);
+  const windowsUnc = slashed.startsWith("//");
+  const windows = windowsDrive || windowsUnc;
+  const absolute = windows || slashed.startsWith("/");
+  const prefix = windowsDrive ? slashed.slice(0, 2).toUpperCase() : windowsUnc ? "//" : absolute ? "/" : "";
+  const remainder = windowsDrive ? slashed.slice(2) : windowsUnc ? slashed.slice(2) : absolute ? slashed.slice(1) : slashed;
+  const segments: string[] = [];
+  let escaped = false;
+
+  for (const segment of remainder.split("/")) {
+    if (!segment || segment === ".") continue;
+    if (segment === "..") {
+      if (segments.length === 0) {
+        escaped = true;
+      } else {
+        segments.pop();
+      }
+      continue;
+    }
+    segments.push(segment);
+  }
+
+  const joined = segments.join("/");
+  const value = windowsDrive ? `${prefix}/${joined}` : windowsUnc ? `${prefix}${joined}` : absolute ? `/${joined}` : joined;
+  return { value: value.replace(/\/$/, ""), absolute, windows, escaped };
+}
+
+export function repositoryRelativePath(rawPath: string, worktreeRoot?: string | null): string | null {
+  if (!rawPath) return null;
+  const candidate = normalizePath(rawPath);
+  if (candidate.escaped) return null;
+  if (!candidate.absolute) return candidate.value || ".";
+  if (!worktreeRoot) return null;
+
+  const root = normalizePath(worktreeRoot);
+  if (!root.absolute || root.escaped || root.windows !== candidate.windows) return null;
+  const candidateForCompare = candidate.windows ? candidate.value.toLowerCase() : candidate.value;
+  const rootForCompare = root.windows ? root.value.toLowerCase() : root.value;
+  if (candidateForCompare === rootForCompare) return ".";
+  const boundary = rootForCompare === "/" ? "/" : `${rootForCompare}/`;
+  if (!candidateForCompare.startsWith(boundary)) return null;
+  return candidate.value.slice(boundary.length) || ".";
+}
+
+export function repositoryPathDisplay(
+  rawPath: string,
+  worktreeRoot?: string | null,
+): RepositoryPathDisplay | null {
+  const relative = repositoryRelativePath(rawPath, worktreeRoot);
+  return relative == null ? null : { display: relative, raw: rawPath };
+}
+
+export function trimWorktreeRoot(text: string, worktreeRoot?: string | null): string {
+  if (!text || !worktreeRoot) return text;
+  const root = normalizePath(worktreeRoot);
+  if (!root.absolute || root.escaped) return text;
+  const variants = root.windows
+    ? [root.value, root.value.replace(/\//g, "\\")]
+    : [root.value];
+  let result = text;
+  for (const variant of variants) {
+    const escaped = variant.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    result = result.replace(
+      new RegExp(`(^|[\\s"'=(])${escaped}(?=[\\\\/])`, root.windows ? "gi" : "g"),
+      "$1.",
+    );
+  }
+  return result;
+}

--- a/frontend/src/lib/transcriptIdentity.test.ts
+++ b/frontend/src/lib/transcriptIdentity.test.ts
@@ -24,6 +24,13 @@ describe("transcript identity", () => {
     )).toBe(true);
   });
 
+  it("merges the live and persisted copy of one canonical event once", () => {
+    const persisted = entry({ eventId: "evt-shared", sequence: 9001, content: "persisted" });
+    const live = entry({ eventId: "evt-shared", sequence: 9001, content: "live" });
+
+    expect(mergeTranscriptEntries([persisted], [live])).toEqual([persisted]);
+  });
+
   it("does not collapse distinct events that share an invalid legacy sequence", () => {
     const merged = mergeTranscriptEntries(
       [entry({ eventId: "evt-1", sequence: 0, content: "first" })],

--- a/frontend/src/lib/transcriptIdentity.test.ts
+++ b/frontend/src/lib/transcriptIdentity.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import type { TranscriptEntry } from "../store";
+import {
+  mergeTranscriptEntries,
+  sameTranscriptEntry,
+  transcriptReactKey,
+} from "./transcriptIdentity";
+
+function entry(overrides: Partial<TranscriptEntry> = {}): TranscriptEntry {
+  return {
+    jobId: "job-1",
+    timestamp: "2026-01-01T00:00:00Z",
+    kind: "message.assistant",
+    content: "done",
+    ...overrides,
+  };
+}
+
+describe("transcript identity", () => {
+  it("deduplicates by TraceForge event id before canonical sequence", () => {
+    expect(sameTranscriptEntry(
+      entry({ eventId: "evt-1", sequence: 10 }),
+      entry({ eventId: "evt-1", sequence: 11 }),
+    )).toBe(true);
+  });
+
+  it("does not collapse distinct events that share an invalid legacy sequence", () => {
+    const merged = mergeTranscriptEntries(
+      [entry({ eventId: "evt-1", sequence: 0, content: "first" })],
+      [entry({ eventId: "evt-2", sequence: 0, content: "second" })],
+    );
+    expect(merged.map((item) => item.eventId)).toEqual(["evt-1", "evt-2"]);
+  });
+
+  it("does not use zero as identity when canonical event ids are missing", () => {
+    const merged = mergeTranscriptEntries(
+      [entry({ sequence: 0, timestamp: "2026-01-01T00:00:00Z", content: "first" })],
+      [entry({ sequence: 0, timestamp: "2026-01-01T00:00:01Z", content: "second" })],
+    );
+    expect(merged).toHaveLength(2);
+  });
+
+  it("orders only when every event has a canonical sequence", () => {
+    expect(mergeTranscriptEntries(
+      [entry({ eventId: "evt-2", sequence: 2 })],
+      [entry({ eventId: "evt-1", sequence: 1 })],
+    ).map((item) => item.eventId)).toEqual(["evt-1", "evt-2"]);
+
+    expect(mergeTranscriptEntries(
+      [entry({ eventId: "evt-2" })],
+      [entry({ eventId: "evt-1", sequence: 1 })],
+    ).map((item) => item.eventId)).toEqual(["evt-2", "evt-1"]);
+  });
+
+  it("produces unique React keys for entries without canonical identity", () => {
+    const item = entry({ eventId: undefined, sequence: undefined });
+    expect(transcriptReactKey(item, 0)).not.toBe(transcriptReactKey(item, 1));
+  });
+});

--- a/frontend/src/lib/transcriptIdentity.test.ts
+++ b/frontend/src/lib/transcriptIdentity.test.ts
@@ -17,46 +17,51 @@ function entry(overrides: Partial<TranscriptEntry> = {}): TranscriptEntry {
 }
 
 describe("transcript identity", () => {
-  it("deduplicates by TraceForge event id before canonical sequence", () => {
+  it("deduplicates by TraceForge event id regardless of producer sequence", () => {
     expect(sameTranscriptEntry(
       entry({ eventId: "evt-1", sequence: 10 }),
       entry({ eventId: "evt-1", sequence: 11 }),
     )).toBe(true);
   });
 
-  it("merges the live and persisted copy of one canonical event once", () => {
-    const persisted = entry({ eventId: "evt-shared", sequence: 9001, content: "persisted" });
-    const live = entry({ eventId: "evt-shared", sequence: 9001, content: "live" });
-
-    expect(mergeTranscriptEntries([persisted], [live])).toEqual([persisted]);
-  });
-
-  it("does not collapse distinct events that share an invalid legacy sequence", () => {
+  it("does not collapse distinct events that share a producer sequence", () => {
     const merged = mergeTranscriptEntries(
-      [entry({ eventId: "evt-1", sequence: 0, content: "first" })],
-      [entry({ eventId: "evt-2", sequence: 0, content: "second" })],
+      [entry({ eventId: "evt-1", sequence: 10, content: "first" })],
+      [entry({ eventId: "evt-2", sequence: 10, content: "second" })],
     );
     expect(merged.map((item) => item.eventId)).toEqual(["evt-1", "evt-2"]);
   });
 
-  it("does not use zero as identity when canonical event ids are missing", () => {
+  it("does not invent identity for entries without canonical event ids", () => {
     const merged = mergeTranscriptEntries(
-      [entry({ sequence: 0, timestamp: "2026-01-01T00:00:00Z", content: "first" })],
-      [entry({ sequence: 0, timestamp: "2026-01-01T00:00:01Z", content: "second" })],
+      [entry({ eventId: undefined, sequence: 10 })],
+      [entry({ eventId: undefined, sequence: 10 })],
     );
     expect(merged).toHaveLength(2);
   });
 
-  it("orders only when every event has a canonical sequence", () => {
+  it("replaces a live copy with its persisted event-id match", () => {
+    const persisted = entry({ eventId: "evt-1", content: "persisted", sequence: undefined });
+    const live = entry({ eventId: "evt-1", content: "live", sequence: 999 });
+
+    expect(mergeTranscriptEntries([persisted], [live])).toEqual([persisted]);
+  });
+
+  it("orders only when every event has a comparable producer sequence", () => {
     expect(mergeTranscriptEntries(
       [entry({ eventId: "evt-2", sequence: 2 })],
-      [entry({ eventId: "evt-1", sequence: 1 })],
-    ).map((item) => item.eventId)).toEqual(["evt-1", "evt-2"]);
+      [entry({ eventId: "evt-0", sequence: 0 })],
+    ).map((item) => item.eventId)).toEqual(["evt-0", "evt-2"]);
 
+    const withMissingSequence = mergeTranscriptEntries(
+      [entry({ eventId: "evt-2" })],
+      [entry({ eventId: "evt-1", sequence: 1 })],
+    );
+    expect(withMissingSequence.map((item) => item.eventId)).toEqual(["evt-2", "evt-1"]);
     expect(mergeTranscriptEntries(
       [entry({ eventId: "evt-2" })],
       [entry({ eventId: "evt-1", sequence: 1 })],
-    ).map((item) => item.eventId)).toEqual(["evt-2", "evt-1"]);
+    )).toEqual(withMissingSequence);
   });
 
   it("produces unique React keys for entries without canonical identity", () => {

--- a/frontend/src/lib/transcriptIdentity.ts
+++ b/frontend/src/lib/transcriptIdentity.ts
@@ -1,0 +1,52 @@
+import type { TranscriptEntry } from "../store";
+
+function hasCanonicalSequence(entry: TranscriptEntry): entry is TranscriptEntry & { sequence: number } {
+  return Number.isSafeInteger(entry.sequence) && entry.sequence! > 0;
+}
+
+export function transcriptIdentity(entry: TranscriptEntry): string | null {
+  if (entry.eventId) return `event:${entry.eventId}`;
+  if (hasCanonicalSequence(entry)) return `sequence:${entry.sequence}`;
+  return null;
+}
+
+function semanticIdentity(entry: TranscriptEntry): string {
+  return [
+    entry.kind,
+    entry.timestamp,
+    entry.turnId ?? "",
+    entry.toolCallId ?? "",
+    entry.toolName ?? "",
+    entry.content ?? "",
+    entry.arguments ?? "",
+    entry.result ?? "",
+  ].join("\u001f");
+}
+
+export function sameTranscriptEntry(left: TranscriptEntry, right: TranscriptEntry): boolean {
+  if (left.eventId && right.eventId) return left.eventId === right.eventId;
+  if (hasCanonicalSequence(left) && hasCanonicalSequence(right)) {
+    return left.sequence === right.sequence;
+  }
+  return semanticIdentity(left) === semanticIdentity(right);
+}
+
+export function mergeTranscriptEntries(
+  historical: TranscriptEntry[],
+  live: TranscriptEntry[],
+): TranscriptEntry[] {
+  const merged = [...historical];
+  for (const entry of live) {
+    if (!merged.some((candidate) => sameTranscriptEntry(candidate, entry))) {
+      merged.push(entry);
+    }
+  }
+  if (merged.every(hasCanonicalSequence)) {
+    return [...merged].sort((left, right) => left.sequence! - right.sequence!);
+  }
+  return merged;
+}
+
+export function transcriptReactKey(entry: TranscriptEntry, index: number): string {
+  return transcriptIdentity(entry) ?? `${semanticIdentity(entry)}\u001f${index}`;
+}

--- a/frontend/src/lib/transcriptIdentity.ts
+++ b/frontend/src/lib/transcriptIdentity.ts
@@ -1,34 +1,16 @@
 import type { TranscriptEntry } from "../store";
 
-function hasCanonicalSequence(entry: TranscriptEntry): entry is TranscriptEntry & { sequence: number } {
-  return Number.isSafeInteger(entry.sequence) && entry.sequence! > 0;
+function hasComparableSequence(entry: TranscriptEntry): entry is TranscriptEntry & { sequence: number } {
+  return Number.isSafeInteger(entry.sequence);
 }
 
 export function transcriptIdentity(entry: TranscriptEntry): string | null {
   if (entry.eventId) return `event:${entry.eventId}`;
-  if (hasCanonicalSequence(entry)) return `sequence:${entry.sequence}`;
   return null;
 }
 
-function semanticIdentity(entry: TranscriptEntry): string {
-  return [
-    entry.kind,
-    entry.timestamp,
-    entry.turnId ?? "",
-    entry.toolCallId ?? "",
-    entry.toolName ?? "",
-    entry.content ?? "",
-    entry.arguments ?? "",
-    entry.result ?? "",
-  ].join("\u001f");
-}
-
 export function sameTranscriptEntry(left: TranscriptEntry, right: TranscriptEntry): boolean {
-  if (left.eventId && right.eventId) return left.eventId === right.eventId;
-  if (hasCanonicalSequence(left) && hasCanonicalSequence(right)) {
-    return left.sequence === right.sequence;
-  }
-  return semanticIdentity(left) === semanticIdentity(right);
+  return Boolean(left.eventId && right.eventId && left.eventId === right.eventId);
 }
 
 export function mergeTranscriptEntries(
@@ -41,12 +23,12 @@ export function mergeTranscriptEntries(
       merged.push(entry);
     }
   }
-  if (merged.every(hasCanonicalSequence)) {
+  if (merged.every(hasComparableSequence)) {
     return [...merged].sort((left, right) => left.sequence! - right.sequence!);
   }
   return merged;
 }
 
 export function transcriptReactKey(entry: TranscriptEntry, index: number): string {
-  return transcriptIdentity(entry) ?? `${semanticIdentity(entry)}\u001f${index}`;
+  return transcriptIdentity(entry) ?? `transcript:${index}`;
 }

--- a/frontend/src/store/__tests__/sse-events.test.ts
+++ b/frontend/src/store/__tests__/sse-events.test.ts
@@ -250,19 +250,49 @@ describe("dispatchSSEEvent — additional events", () => {
   it("transcript_update deduplicates", () => {
     useStore.getState().dispatchSSEEvent("message.assistant", {
       jobId: "job-1",
-      seq: 1,
+      eventId: "evt-1",
+      sequence: 1,
       timestamp: "2025-01-01T00:00:00Z",
       kind: "message.assistant",
       content: "Hello",
     });
     useStore.getState().dispatchSSEEvent("message.assistant", {
       jobId: "job-1",
-      seq: 1,
+      eventId: "evt-1",
+      sequence: 1,
       timestamp: "2025-01-01T00:00:00Z",
       kind: "message.assistant",
       content: "Hello",
     });
     expect(selectJobTranscript("job-1")(useStore.getState())).toHaveLength(1);
+  });
+
+  it("keeps distinct events that share a legacy sequence value", () => {
+    useStore.getState().dispatchSSEEvent("message.assistant", {
+      jobId: "job-1",
+      eventId: "evt-1",
+      sequence: 0,
+      timestamp: "2025-01-01T00:00:00Z",
+      kind: "message.assistant",
+      content: "First",
+    });
+    useStore.getState().dispatchSSEEvent("message.assistant", {
+      jobId: "job-1",
+      eventId: "evt-2",
+      sequence: 0,
+      timestamp: "2025-01-01T00:00:01Z",
+      kind: "message.assistant",
+      content: "Second",
+    });
+    expect(selectJobTranscript("job-1")(useStore.getState())).toHaveLength(2);
+  });
+
+  it("bumps artifact versions after collection completes", () => {
+    useStore.getState().dispatchSSEEvent("artifacts.updated", {
+      jobId: "job-1",
+      collectionStatus: "completed",
+    });
+    expect(useStore.getState().artifactVersions["job-1"]).toBe(1);
   });
 });
 

--- a/frontend/src/store/handlers/miscHandlers.ts
+++ b/frontend/src/store/handlers/miscHandlers.ts
@@ -69,7 +69,8 @@ export function handleSessionResumed(state: AppState, payload: Record<string, un
   const timestamp = payload.timestamp as string;
   const divider: TranscriptEntry = {
     jobId,
-    seq: -99,
+    eventId: payload.eventId as string | undefined,
+    sequence: payload.sequence as number | undefined,
     timestamp,
     kind: "divider",
     content: "Session",
@@ -129,6 +130,17 @@ export function handleTelemetryUpdated(state: AppState, payload: Record<string, 
   };
 }
 
+export function handleArtifactsUpdated(state: AppState, payload: Record<string, unknown>): Partial<AppState> | null {
+  const jobId = payload.jobId as string | undefined;
+  if (!jobId) return null;
+  return {
+    artifactVersions: {
+      ...state.artifactVersions,
+      [jobId]: (state.artifactVersions[jobId] ?? 0) + 1,
+    },
+  };
+}
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function handlePolicySettingsChanged(_state: AppState): Partial<AppState> | null {
   return {
@@ -185,6 +197,7 @@ export const miscHandlers: Record<string, SSEHandler> = {
   "diff.updated": handleDiffUpdate,
   "session.resumed": handleSessionResumed,
   "telemetry.updated": handleTelemetryUpdated,
+  "artifacts.updated": handleArtifactsUpdated,
   "policy.settings_changed": handlePolicySettingsChanged,
   "repo.index_progress": handleRepoIndexProgress,
   "repo.index_complete": handleRepoIndexComplete,

--- a/frontend/src/store/handlers/transcriptHandlers.ts
+++ b/frontend/src/store/handlers/transcriptHandlers.ts
@@ -118,8 +118,7 @@ export function handleTranscriptUpdate(state: AppState, payload: Record<string, 
     }
   }
 
-  // Deduplicate: two SSE connections (global + job-scoped) may deliver
-  // the same event; skip if identical kind+content+timestamp already present.
+  // Deduplicate canonical events by their stable TraceForge event id.
   // For user messages, match on kind+content only (ignore timestamp) to
   // suppress the SSE echo when an optimistic entry was already inserted.
   if (entry.kind === "message.user"

--- a/frontend/src/store/handlers/transcriptHandlers.ts
+++ b/frontend/src/store/handlers/transcriptHandlers.ts
@@ -4,6 +4,7 @@
 
 import type { LogLine, SecondarySession, SecondarySessionEntry, TranscriptEntry } from "../types";
 import type { SSEHandler, AppState } from "./types";
+import { sameTranscriptEntry } from "../../lib/transcriptIdentity";
 
 // ---------------------------------------------------------------------------
 // Handlers
@@ -72,12 +73,14 @@ export function handleTranscriptUpdate(state: AppState, payload: Record<string, 
 
   const entry: TranscriptEntry = {
     jobId,
-    seq: payload.seq as number,
+    eventId: payload.eventId as string | undefined,
+    sequence: payload.sequence as number | undefined,
     timestamp: payload.timestamp as string,
     kind,
     content: payload.content as string,
     title: payload.title as string | undefined,
     turnId: payload.turnId as string | undefined,
+    toolCallId: payload.toolCallId as string | undefined,
     toolName: payload.toolName as string | undefined,
     arguments: payload.arguments as string | undefined,
     result: payload.result as string | undefined,
@@ -100,6 +103,7 @@ export function handleTranscriptUpdate(state: AppState, payload: Record<string, 
     const before = base.length;
     base = base.filter((e) => {
       if (e.kind !== "tool.call.started" || e.toolName !== entry.toolName) return true;
+      if (entry.toolCallId && e.toolCallId) return entry.toolCallId !== e.toolCallId;
       // If both entries have a turnId, they must match to be considered the same call.
       if (entry.turnId && e.turnId && entry.turnId !== e.turnId) return true;
       return false;
@@ -120,7 +124,7 @@ export function handleTranscriptUpdate(state: AppState, payload: Record<string, 
   // suppress the SSE echo when an optimistic entry was already inserted.
   if (entry.kind === "message.user"
     ? existing.some((e) => e.kind === "message.user" && e.content === entry.content)
-    : existing.some((e) => e.timestamp === entry.timestamp && e.kind === entry.kind && e.content === entry.content)) {
+    : existing.some((e) => sameTranscriptEntry(e, entry))) {
     return null;
   }
   const updated = [...existing, entry];

--- a/frontend/src/store/index.test.ts
+++ b/frontend/src/store/index.test.ts
@@ -363,7 +363,6 @@ describe("AppStore", () => {
           "job-1": [
             {
               jobId: "job-1",
-              seq: -99,
               timestamp: "2025-06-02T00:00:00Z",
               kind: "divider",
               content: "Session",

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -308,6 +308,7 @@ export const useStore = create<AppState>((set, get) => ({
   streamingToolOutput: {},
   streamingReasoning: {},
   telemetryVersions: {},
+  artifactVersions: {},
   repoIndexState: {},
   multiSessions: {},
   reviewStories: {},

--- a/frontend/src/store/sseNormalize.test.ts
+++ b/frontend/src/store/sseNormalize.test.ts
@@ -84,6 +84,13 @@ describe("normalizeTFEvent", () => {
     expect(out.turnId).toBe("turn-9");
   });
 
+  it("carries canonical event identity from the envelope and metadata", () => {
+    const out = normalizeTFEvent(ev({ id: "evt-9", metadata: { sequence: 42 } }));
+    expect(out.eventId).toBe("evt-9");
+    expect(out.sequence).toBe(42);
+    expect(out.seq).toBeUndefined();
+  });
+
   it("prefers a payload turnId over metadata", () => {
     const out = normalizeTFEvent(ev({ payload: { turn_id: "payload-turn" }, metadata: { turn_id: "meta-turn" } }));
     expect(out.turnId).toBe("payload-turn");

--- a/frontend/src/store/sseNormalize.test.ts
+++ b/frontend/src/store/sseNormalize.test.ts
@@ -85,10 +85,19 @@ describe("normalizeTFEvent", () => {
   });
 
   it("carries canonical event identity from the envelope and metadata", () => {
-    const out = normalizeTFEvent(ev({ id: "evt-9", metadata: { sequence: 42 } }));
+    const out = normalizeTFEvent(ev({
+      id: "evt-9",
+      payload: { sequence: 9000 },
+      metadata: { sequence: 42 },
+    }));
     expect(out.eventId).toBe("evt-9");
     expect(out.sequence).toBe(42);
     expect(out.seq).toBeUndefined();
+  });
+
+  it("does not use payload sequence as producer-stream order", () => {
+    const out = normalizeTFEvent(ev({ payload: { sequence: 9000 }, metadata: {} }));
+    expect(out.sequence).toBeUndefined();
   });
 
   it("prefers a payload turnId over metadata", () => {

--- a/frontend/src/store/sseNormalize.ts
+++ b/frontend/src/store/sseNormalize.ts
@@ -69,6 +69,9 @@ export function normalizeTFEvent(ev: TFSessionEvent): Record<string, unknown> {
 
   // `jobId` is authoritative from the envelope session id.
   payload.jobId = ev.session_id;
+  if (ev.id !== undefined) {
+    payload.eventId = ev.id;
+  }
 
   if (payload.timestamp === undefined && ev.timestamp !== undefined) {
     payload.timestamp = ev.timestamp;
@@ -84,6 +87,9 @@ export function normalizeTFEvent(ev: TFSessionEvent): Record<string, unknown> {
   // payload view unless the payload already provides the field.
   const meta = ev.metadata;
   const metadata = meta == null ? undefined : (meta as Record<string, unknown>);
+  if (typeof metadata?.sequence === "number") {
+    payload.sequence = metadata.sequence;
+  }
   const metaTurnId = metadata?.turn_id;
   if (payload.turnId === undefined && metaTurnId != null) {
     payload.turnId = metaTurnId;

--- a/frontend/src/store/sseNormalize.ts
+++ b/frontend/src/store/sseNormalize.ts
@@ -83,10 +83,11 @@ export function normalizeTFEvent(ev: TFSessionEvent): Record<string, unknown> {
     payload.kind = ev.kind;
   }
 
-  // Metadata enrichment lives on EventMetadata; carry it into the camelCase
-  // payload view unless the payload already provides the field.
+  // Metadata enrichment lives on EventMetadata; canonical sequence never comes
+  // from payload data.
   const meta = ev.metadata;
   const metadata = meta == null ? undefined : (meta as Record<string, unknown>);
+  delete payload.sequence;
   if (typeof metadata?.sequence === "number") {
     payload.sequence = metadata.sequence;
   }

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -102,13 +102,15 @@ export interface LogLine {
 
 export interface TranscriptEntry {
   jobId: string;
-  seq: number;
+  eventId?: string;
+  sequence?: number;
   timestamp: string;
   kind: string;
   content: string;
   // Rich fields — only present for specific transcript kinds
   title?: string;        // agent messages: optional annotation title
   turnId?: string;       // groups reasoning + tool_calls + message into one turn
+  toolCallId?: string;   // pairs tool.call.started/completed
   toolName?: string;     // tool_call: identifier
   arguments?: string;    // tool_call: JSON-serialised arguments
   result?: string;       // tool_call: text output
@@ -267,6 +269,8 @@ export interface AppState {
   /** Monotonically-increasing counter per job, bumped on each telemetry_updated
    * SSE event. Components watching this trigger a telemetry re-fetch. */
   telemetryVersions: Record<string, number>; // keyed by jobId
+  /** Bumped after terminal artifact collection finishes so panels re-fetch. */
+  artifactVersions: Record<string, number>; // keyed by jobId
 
   // Repo index progress (keyed by repo name)
   repoIndexState: Record<string, RepoIndexProgress>;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     # traceforge-title-model ONNX weights transitively. A git+ install is avoided
     # on purpose — it force-checks-out the LFS monorepo and trips a missing LFS
     # object on the remote (tracked as an upstream defect).
-    "traceforge-toolkit>=0.1.1,<0.2",
+    "traceforge-toolkit>=0.1.3,<0.2",
     "psutil>=7.2.2",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -644,7 +644,7 @@ requires-dist = [
     { name = "sqlalchemy", specifier = ">=2.0,<3" },
     { name = "structlog", specifier = ">=24.0,<26" },
     { name = "tiktoken", marker = "extra == 'tokenizer'", specifier = ">=0.12.0,<1" },
-    { name = "traceforge-toolkit", specifier = ">=0.1.1,<0.2" },
+    { name = "traceforge-toolkit", specifier = ">=0.1.3,<0.2" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32,<1" },
 ]
 provides-extras = ["voice", "push", "telemetry", "tokenizer", "all"]
@@ -3904,7 +3904,7 @@ wheels = [
 
 [[package]]
 name = "traceforge-toolkit"
-version = "0.1.2"
+version = "0.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "alembic" },
@@ -3930,9 +3930,9 @@ dependencies = [
     { name = "tzdata", marker = "sys_platform == 'win32'" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2c/22/f4180493645ed2da791ed34ea8eeda995029491302742b0bcfcea9b4db10/traceforge_toolkit-0.1.2.tar.gz", hash = "sha256:f2a255298508b229bc3813fdfefd949e7189945e9febedf8e34c3ce611ea8af2", size = 28830372, upload-time = "2026-07-30T18:12:24.814Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/c1/9afa301a555bc8635813f1af01e4c8370bfbc838e63ed0fce63792fc38c8/traceforge_toolkit-0.1.3.tar.gz", hash = "sha256:d582ffad11c180918ad59eeb6990bf97c875af6b5d0cc1391227ab9053b1bd85", size = 28835020, upload-time = "2026-08-03T03:34:33.775Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/81/6004682910e63d60f84d603e44a18df972d994cfbbbaa5a5a603c3763f1c/traceforge_toolkit-0.1.2-py3-none-any.whl", hash = "sha256:481f17558d411bb04fe6a30c10cbe8e1ae5383023ce5f512dd8bbae1bab31e82", size = 28937409, upload-time = "2026-07-30T18:12:22.025Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f3/765f3c7209ec12da686527213a2557ba695a87793659ae41a580d833d70a/traceforge_toolkit-0.1.3-py3-none-any.whl", hash = "sha256:1d43d26b43a8e58b04145cfc8f6d282db294a0a9428fe20cff731a650da35423", size = 28944655, upload-time = "2026-08-03T03:34:30.215Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -3904,7 +3904,7 @@ wheels = [
 
 [[package]]
 name = "traceforge-toolkit"
-version = "0.1.3"
+version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "alembic" },
@@ -3930,9 +3930,9 @@ dependencies = [
     { name = "tzdata", marker = "sys_platform == 'win32'" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/c1/9afa301a555bc8635813f1af01e4c8370bfbc838e63ed0fce63792fc38c8/traceforge_toolkit-0.1.3.tar.gz", hash = "sha256:d582ffad11c180918ad59eeb6990bf97c875af6b5d0cc1391227ab9053b1bd85", size = 28835020, upload-time = "2026-08-03T03:34:33.775Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/b0/667eae52510b06729aa3ed1a39395651e44263c9899c15a7fcfafcc15973/traceforge_toolkit-0.1.4.tar.gz", hash = "sha256:7a4415962f138a5ea7a46b4ddcba44ec056a591b78eb14bb98ea5968bfc6d342", size = 28834947, upload-time = "2026-08-03T04:14:24.825Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/f3/765f3c7209ec12da686527213a2557ba695a87793659ae41a580d833d70a/traceforge_toolkit-0.1.3-py3-none-any.whl", hash = "sha256:1d43d26b43a8e58b04145cfc8f6d282db294a0a9428fe20cff731a650da35423", size = 28944655, upload-time = "2026-08-03T03:34:30.215Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/47/50ef7263163e6e0ba4ccc89a18656bcf9a2741d27a09577fac817c379c6c/traceforge_toolkit-0.1.4-py3-none-any.whl", hash = "sha256:059803600d23cc3a69ce4c2f56d5c7505d2f966cea3ca567cbfe2546c3f48c93", size = 28944570, upload-time = "2026-08-03T04:14:21.841Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add one awaited, idempotent terminal artifact finalizer with durable pending/collecting/completed/failed status, startup backfill, and post-completion `artifacts.updated`
- collect session logs, workspace/session-storage files, telemetry, plan, approval, and log artifacts from durable sources before volatile cleanup
- keep the Artifacts tab visible, poll/refetch while collection is active, and surface empty/failure states
- consume TraceForge envelope IDs and `metadata.sequence` directly for transcript merge/key identity without a payload sequence fallback
- render Windows/POSIX/UNC paths repository-relative only when they are contained by the worktree, while retaining raw paths in hover metadata

## Validation
- `uv run pytest backend/tests/unit/test_artifact_finalization_service.py backend/tests/integration/test_api_artifacts.py backend/tests/unit/test_sse_fidelity.py backend/tests/unit/test_runtime_service.py backend/tests/unit/test_plan_mode_flow.py -q` (83 passed)
- focused canonical transcript/artifact integration tests (14 passed)
- focused frontend Vitest suites (98 passed, 1 skipped)
- frontend TypeScript typecheck and ESLint
- changed backend Ruff and mypy checks
- Alembic upgrade through revision 0057 on a fresh SQLite database
- GitHub Frontend CI passed; Backend CI was blocked before tests because `uv sync` could not authenticate to the private `dfinson/coderecon` dependency commit

## Upstream dependencies
This PR intentionally does not synthesize activity summaries, add PowerShell/tool-name aliases, produce normalized TraceForge targets, or copy canonical sequence into payloads.

- Activity/step TOC hydration remains blocked on TraceForge deterministic `turnSummaries`/live-structuring output.
- Canonical PowerShell/tool classification remains TraceForge-owned.
- Normalized target plus raw-target production remains TraceForge-owned; CodePlane only applies containment-safe presentation to currently available raw paths.
- Transcript identity consumes the existing TraceForge envelope `id` and `metadata.sequence`. Any change to those producer semantics should land in TraceForge rather than adding a CodePlane compatibility source.