### PR TITLE
fix: preserve snapshot transcript identity

### DIFF
--- a/backend/services/artifacts/snapshot_helpers.py
+++ b/backend/services/artifacts/snapshot_helpers.py
@@ -137,7 +137,8 @@ def _build_transcript(
     result = [
         TranscriptPayload(
             job_id=e.session_id,
-            seq=e.payload.get("seq", 0),
+            event_id=e.id,
+            sequence=e.metadata.sequence,
             timestamp=e.payload.get("timestamp", e.timestamp),
             kind=str(e.kind),
             content=e.payload.get("content", ""),
@@ -161,6 +162,8 @@ def _build_transcript(
         for e in transcript_events
         if (not filter_deltas or e.kind not in TRANSCRIPT_STREAMING_KINDS) and not _is_hidden_tool_event(e)
     ]
+    if all(item.sequence is not None for item in result):
+        result.sort(key=lambda item: item.sequence or 0)
     return result
 
 

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -42,6 +42,7 @@ from backend.services.git.git_service import GitService
 from backend.services.job.approval_service import ApprovalService
 from backend.services.merge_service import MergeService
 from backend.services.runtime import RuntimeService
+from backend.services.sharing.share_service import ShareService
 from backend.services.sidecar.session import SidecarSessionManager
 from backend.services.terminal.terminal_service import TerminalService
 
@@ -206,6 +207,7 @@ async def app(
         job_telemetry,
         jobs,
         settings,
+        share,
         terminal,
         voice,
         workspace,
@@ -226,6 +228,7 @@ async def app(
     application.include_router(workspace.router, prefix="/api")
     application.include_router(voice.router, prefix="/api")
     application.include_router(settings.router, prefix="/api")
+    application.include_router(share.router, prefix="/api")
     application.include_router(terminal.router, prefix="/api")
 
     # -- dishka DI container (replaces app.state) --------------------------
@@ -239,6 +242,7 @@ async def app(
             SSEManager: sse_manager,
             ApprovalService: approval_service,
             RuntimeService: mock_runtime_service,
+            ShareService: ShareService(),
             MergeService: mock_merge_service,
             GitService: mock_git_service,
             PlatformRegistry: mock_platform_registry,

--- a/backend/tests/integration/test_api_jobs.py
+++ b/backend/tests/integration/test_api_jobs.py
@@ -614,6 +614,53 @@ class TestJobData:
         ]
         assert all("seq" not in item for item in items)
 
+    async def test_snapshots_preserve_persisted_transcript_identity_for_job_and_share_paths(
+        self,
+        client: AsyncClient,
+        seed_job: SeedJobFn,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        jid = await seed_job(state="completed", job_id="snapshot-identity")
+        producer_sequence = 10_000
+        payload_sequence = 77_777
+        async with session_factory() as session:
+            sequenced_row = EventRow(
+                event_id="evt-snapshot-sequenced",
+                job_id=jid,
+                kind=EventKind.message_assistant.value,
+                timestamp=datetime.now(UTC),
+                payload=f'{{"content":"Sequenced","seq":{payload_sequence}}}',
+                event_metadata=f'{{"sequence":{producer_sequence}}}',
+            )
+            unsequenced_row = EventRow(
+                event_id="evt-snapshot-unsequenced",
+                job_id=jid,
+                kind=EventKind.message_assistant.value,
+                timestamp=datetime.now(UTC),
+                payload=f'{{"content":"Unsequenced","seq":{payload_sequence + 1}}}',
+                event_metadata="{}",
+            )
+            session.add_all([sequenced_row, unsequenced_row])
+            await session.flush()
+            storage_cursors = {sequenced_row.id, unsequenced_row.id}
+            assert producer_sequence not in storage_cursors
+            assert payload_sequence not in storage_cursors
+            await session.commit()
+
+        job_snapshot = await client.get(f"/api/jobs/{jid}/snapshot")
+        share_link = await client.post(f"/api/jobs/{jid}/share")
+        shared_snapshot = await client.get(f"/api/share/{share_link.json()['token']}/snapshot")
+
+        for response in (job_snapshot, shared_snapshot):
+            assert response.status_code == 200
+            transcript = response.json()["transcript"]
+            assert [(item["eventId"], item["sequence"]) for item in transcript] == [
+                ("evt-snapshot-sequenced", producer_sequence),
+                ("evt-snapshot-unsequenced", None),
+            ]
+            assert all("seq" not in item for item in transcript)
+            assert all(item["eventId"] not in {str(cursor) for cursor in storage_cursors} for item in transcript)
+
     # ── Timeline ──
 
     async def test_timeline_empty(self, client: AsyncClient, seed_job: SeedJobFn) -> None:

--- a/backend/tests/unit/test_snapshot_helpers.py
+++ b/backend/tests/unit/test_snapshot_helpers.py
@@ -19,12 +19,14 @@ from backend.services.artifacts.snapshot_helpers import (
 
 def _event(
     job_id: str = "j1",
+    event_id: str = "evt-1",
     timestamp: str = "2025-01-01T00:00:00Z",
     kind: EventKind = EventKind.log_line_emitted,
     metadata: EventMetadata | None = None,
     **payload: Any,
 ) -> SimpleNamespace:
     return SimpleNamespace(
+        id=event_id,
         session_id=job_id,
         timestamp=timestamp,
         kind=kind,
@@ -71,6 +73,65 @@ class TestBuildLogs:
 
 
 class TestBuildTranscript:
+    def test_preserves_canonical_event_identity_and_optional_sequence(self) -> None:
+        sequenced = _event(
+            event_id="evt-sequenced",
+            kind=EventKind.message_assistant,
+            metadata=EventMetadata(sequence=10_000),
+            seq=41,
+            content="Sequenced",
+        )
+        unsequenced = _event(
+            event_id="evt-unsequenced",
+            kind=EventKind.message_assistant,
+            metadata=EventMetadata(),
+            seq=42,
+            content="Unsequenced",
+        )
+
+        transcript = _build_transcript(
+            [sequenced, unsequenced],
+            [],
+            None,
+            None,
+            filter_deltas=True,
+        )
+
+        assert [(item.event_id, item.sequence) for item in transcript] == [
+            ("evt-sequenced", 10_000),
+            ("evt-unsequenced", None),
+        ]
+        assert all("seq" not in item.model_fields_set for item in transcript)
+
+    def test_orders_by_canonical_sequence_when_every_event_has_one(self) -> None:
+        later_storage_event = _event(
+            event_id="evt-first-row",
+            kind=EventKind.message_assistant,
+            metadata=EventMetadata(sequence=20),
+            seq=1,
+            content="Later producer event",
+        )
+        earlier_storage_event = _event(
+            event_id="evt-second-row",
+            kind=EventKind.message_assistant,
+            metadata=EventMetadata(sequence=10),
+            seq=2,
+            content="Earlier producer event",
+        )
+
+        transcript = _build_transcript(
+            [later_storage_event, earlier_storage_event],
+            [],
+            None,
+            None,
+            filter_deltas=True,
+        )
+
+        assert [item.event_id for item in transcript] == [
+            "evt-second-row",
+            "evt-first-row",
+        ]
+
     def test_builds_tool_call_from_tf_fields_and_metadata(self) -> None:
         ev = _event(
             kind=EventKind.tool_call_completed,
@@ -269,7 +330,8 @@ class TestApplyReassignments:
 
         entry = TranscriptPayload(
             job_id="j1",
-            seq=1,
+            event_id="evt-1",
+            sequence=1,
             timestamp="2025-01-01T00:00:00Z",
             kind=EventKind.message_assistant,
             content="hi",
@@ -287,7 +349,8 @@ class TestApplyReassignments:
 
         entry = TranscriptPayload(
             job_id="j1",
-            seq=1,
+            event_id="evt-1",
+            sequence=1,
             timestamp="2025-01-01T00:00:00Z",
             kind=EventKind.message_assistant,
             content="hi",


### PR DESCRIPTION
## Summary
- project canonical TraceForge `event.id` and optional `event.metadata.sequence` into snapshot transcript entries
- order fully sequenced snapshots by producer sequence without synthesizing from payload `seq` or the database replay cursor
- cover both authenticated and shared snapshot paths with persisted-event regression tests

## Checks
- `uv run pytest backend/tests/unit/test_snapshot_helpers.py backend/tests/integration/test_api_jobs.py::TestJobData::test_transcript_exposes_event_identity_and_optional_producer_sequence backend/tests/integration/test_api_jobs.py::TestJobData::test_snapshots_preserve_persisted_transcript_identity_for_job_and_share_paths -q` (22 passed)
- `uv run ruff check backend/services/artifacts/snapshot_helpers.py backend/tests/unit/test_snapshot_helpers.py backend/tests/integration/conftest.py backend/tests/integration/test_api_jobs.py`
- `uv run mypy --no-incremental backend/services/artifacts/snapshot_helpers.py backend/tests/unit/test_snapshot_helpers.py backend/tests/integration/conftest.py backend/tests/integration/test_api_jobs.py`