### PR TITLE
fix: preserve native activity labels

### DIFF
--- a/backend/lifespan.py
+++ b/backend/lifespan.py
@@ -387,6 +387,32 @@ def _is_sqlite_lock_error(exc: OperationalError) -> bool:
     return "database is locked" in str(exc).lower()
 
 
+def build_turn_summary_payload(update: Any) -> dict[str, Any] | None:
+    """Map a TraceForge ``TitleUpdate`` to a ``turn_summary`` payload.
+
+    Returns ``None`` for session-level titles, which are handled by
+    auto-naming rather than the turn timeline.
+
+    Only fields TF natively provides are mapped — nothing is inferred. For
+    activity-kind updates TF's ``title`` *is* the activity label, so it is
+    carried through as ``activity_label``; without it the frontend timeline
+    renders a blank activity heading. Step-kind updates carry no label (they
+    belong to the activity named by ``activity_id``).
+    """
+    if update.kind == "session":
+        return None
+    is_new_activity = update.kind == "activity"
+    payload: dict[str, Any] = {
+        "turn_id": update.segment_id,
+        "title": update.title,
+        "activity_id": update.parent_id or update.segment_id,
+        "is_new_activity": is_new_activity,
+    }
+    if is_new_activity:
+        payload["activity_label"] = update.title
+    return payload
+
+
 async def _persist_event_with_retry(
     *,
     event: SessionEvent,
@@ -831,25 +857,16 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     )
 
     async def _on_title_update(update) -> None:  # noqa: ANN001  (TitleUpdate at runtime)
-        """Convert a TraceForge TitleUpdate to a CodePlane turn_summary event.
-
-        Only maps fields that TF natively provides. Does not invent values
-        for fields TF does not supply (plan_item_id, activity_status).
-        """
-        if update.kind == "session":
-            # Session-level titles are handled by auto-naming, not turn summaries
+        """Convert a TraceForge TitleUpdate to a CodePlane turn_summary event."""
+        payload = build_turn_summary_payload(update)
+        if payload is None:
             return
         await event_bus.publish(
             new_event(
                 session_id=update.session_id,
                 timestamp=datetime.now(UTC),
                 kind=EventKind.turn_summary,
-                payload={
-                    "turn_id": update.segment_id,
-                    "title": update.title,
-                    "activity_id": update.parent_id or update.segment_id,
-                    "is_new_activity": update.kind == "activity",
-                },
+                payload=payload,
             )
         )
 

--- a/backend/services/events/reenrich.py
+++ b/backend/services/events/reenrich.py
@@ -16,6 +16,7 @@ force deletes then re-inserts the marker).
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
@@ -46,6 +47,43 @@ def _get_job_lock(job_id: str) -> asyncio.Lock:
     if job_id not in _job_locks:
         _job_locks[job_id] = asyncio.Lock()
     return _job_locks[job_id]
+
+
+def _metadata_fingerprint(event: SessionEvent) -> str | None:
+    """Stable content hash of an event's canonical metadata, or ``None``.
+
+    Taken *before* the enricher runs so that enrichers which mutate metadata
+    in place (rather than returning a new object) are still detected: after
+    ``process()`` the live object and the event object are the same instance,
+    so an identity/equality comparison against the post-process value would
+    always report "unchanged" and silently drop the update.
+
+    A hash (not the serialized blob) keeps the per-job snapshot map small
+    across large replays.
+    """
+    if event.metadata is None:
+        return None
+    canonical = json.dumps(
+        event.metadata.model_dump(mode="json"),
+        ensure_ascii=False,
+        default=str,
+        sort_keys=True,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _persist_if_changed(event: SessionEvent, fingerprints: dict[str, str | None]) -> bool:
+    """True when *event*'s metadata differs from its pre-enrichment snapshot.
+
+    Consumes the snapshot when the event is emitted. The map therefore retains
+    only events currently buffered by TraceForge rather than the full replay
+    history. An event emitted twice is ignored after its snapshot is consumed.
+    """
+    if event.metadata is None or event.id not in fingerprints:
+        return False
+    before = fingerprints.pop(event.id)
+    after = _metadata_fingerprint(event)
+    return after != before
 
 
 async def reenrich_job_events(
@@ -104,6 +142,10 @@ async def _reenrich_locked(
         enricher = TFEnricher(flush_on_session_end=True)
         updated = 0
         offset = 0
+        # event_id → pre-enrichment metadata fingerprint for events currently
+        # buffered by TF. Entries are consumed as events are emitted, keeping
+        # memory proportional to pending events rather than total history.
+        pre_fingerprints: dict[str, str | None] = {}
 
         while True:
             batch = await repo.list_all_events_by_job(job_id, limit=_BATCH_SIZE, offset=offset)
@@ -115,9 +157,13 @@ async def _reenrich_locked(
                 if event.kind == _REENRICH_MARKER_KIND:
                     continue
 
+                # Snapshot BEFORE process() — the enricher may mutate in place.
+                pre_fingerprints[event.id] = _metadata_fingerprint(event)
+
                 try:
                     enriched = enricher.process(event)
                 except Exception:
+                    pre_fingerprints.pop(event.id, None)
                     log.warning(
                         "reenrich_event_failed",
                         job_id=job_id,
@@ -131,7 +177,7 @@ async def _reenrich_locked(
 
                 events_to_update = enriched if isinstance(enriched, list) else [enriched]
                 for e in events_to_update:
-                    if e.metadata and e.metadata != event.metadata:
+                    if e.metadata is not None and _persist_if_changed(e, pre_fingerprints):
                         await repo.update_metadata(event_id=e.id, metadata=e.metadata)
                         updated += 1
 
@@ -141,7 +187,7 @@ async def _reenrich_locked(
 
         # Flush any remaining buffered events
         for orphan in enricher.flush():
-            if orphan.metadata:
+            if orphan.metadata is not None and _persist_if_changed(orphan, pre_fingerprints):
                 await repo.update_metadata(event_id=orphan.id, metadata=orphan.metadata)
                 updated += 1
 

--- a/backend/tests/unit/test_reenrich.py
+++ b/backend/tests/unit/test_reenrich.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from backend.models.events import EventKind, new_event
+from backend.models.events import EventKind, EventMetadata, new_event
 from backend.services.events.reenrich import (
     _REENRICH_MARKER_KIND,
     _job_locks,
@@ -192,3 +192,79 @@ class TestReenrichBatching:
                 assert call_count >= 2
                 # Enricher.process should have been called for all events
                 assert enricher.process.call_count == _BATCH_SIZE + 10
+
+
+class TestReenrichMutationInPlace:
+    """Metadata is compared against a pre-``process()`` snapshot.
+
+    An enricher that mutates the event's metadata in place returns the *same*
+    object, so comparing post-process metadata against ``event.metadata``
+    always looks unchanged and the update is silently dropped.
+    """
+
+    @pytest.mark.asyncio
+    async def test_in_place_mutation_is_persisted(self, mock_session_factory):
+        from traceforge.types import Visibility
+
+        event = new_event(
+            session_id="j1",
+            kind=EventKind.tool_call_completed,
+            payload={"tool_name": "bash"},
+            metadata=EventMetadata(),
+        )
+
+        def _mutating_process(ev):
+            # Mutate metadata in place and hand back the same event object.
+            object.__setattr__(ev.metadata, "visibility", Visibility.COLLAPSED)
+            return ev
+
+        with patch("backend.persistence.event_repo.EventRepository") as mock_repo_cls:
+            repo = mock_repo_cls.return_value
+            repo.list_by_job = AsyncMock(return_value=[])
+            repo.list_all_events_by_job = AsyncMock(side_effect=[[event], []])
+            repo.update_metadata = AsyncMock()
+
+            with patch("backend.services.events.reenrich.TFEnricher") as mock_enricher_cls:
+                enricher = mock_enricher_cls.return_value
+                enricher.process = MagicMock(side_effect=_mutating_process)
+                enricher.flush = MagicMock(return_value=[])
+
+                with patch(
+                    "backend.services.events.reenrich._append_marker",
+                    new_callable=AsyncMock,
+                ) as mock_append:
+                    updated = await reenrich_job_events("j1", mock_session_factory)
+
+        assert updated == 1
+        repo.update_metadata.assert_awaited_once()
+        assert repo.update_metadata.await_args.kwargs["event_id"] == event.id
+        marker = mock_append.await_args.args[2]
+        assert marker.payload["updated_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_unchanged_metadata_is_not_rewritten(self, mock_session_factory):
+        """An enricher that changes nothing produces no writes."""
+        event = new_event(
+            session_id="j1",
+            kind=EventKind.tool_call_completed,
+            payload={"tool_name": "bash"},
+            metadata=EventMetadata(),
+        )
+
+        with patch("backend.persistence.event_repo.EventRepository") as mock_repo_cls:
+            repo = mock_repo_cls.return_value
+            repo.list_by_job = AsyncMock(return_value=[])
+            repo.list_all_events_by_job = AsyncMock(side_effect=[[event], []])
+            repo.update_metadata = AsyncMock()
+
+            with patch("backend.services.events.reenrich.TFEnricher") as mock_enricher_cls:
+                enricher = mock_enricher_cls.return_value
+                enricher.process = MagicMock(side_effect=lambda ev: ev)
+                # The same event is also returned by flush() — it must not be
+                # counted or written twice.
+                enricher.flush = MagicMock(return_value=[event])
+
+                updated = await reenrich_job_events("j1", mock_session_factory)
+
+        assert updated == 0
+        repo.update_metadata.assert_not_awaited()

--- a/backend/tests/unit/test_traceforge_enrichment.py
+++ b/backend/tests/unit/test_traceforge_enrichment.py
@@ -16,6 +16,7 @@ import pytest
 from traceforge.enricher import Enricher as TFEnricher
 from traceforge.types import Classification, EventMetadata, TitleUpdate
 
+from backend.lifespan import build_turn_summary_payload
 from backend.models.events import EventKind, SessionEvent, new_event
 from backend.services.events.event_bus import EventBus
 from backend.services.events.event_processor import EventProcessor
@@ -272,7 +273,7 @@ class TestPowerShellRegression:
 
 
 class TestTitlePipelineCallback:
-    """The title pipeline callback in lifespan.py converts TitleUpdate → turn_summary."""
+    """``build_turn_summary_payload`` converts a TF TitleUpdate → turn_summary payload."""
 
     @pytest.mark.asyncio
     async def test_activity_title_update_emits_turn_summary(self):
@@ -285,21 +286,16 @@ class TestTitlePipelineCallback:
 
         bus.subscribe(_handler)
 
-        # Simulate the callback that lifespan.py wires
         async def _on_title_update(update: TitleUpdate) -> None:
-            if update.kind == "session":
+            payload = build_turn_summary_payload(update)
+            if payload is None:
                 return
             await bus.publish(
                 new_event(
                     session_id=update.session_id,
                     timestamp=datetime.now(UTC),
                     kind=EventKind.turn_summary,
-                    payload={
-                        "turn_id": update.segment_id,
-                        "title": update.title,
-                        "activity_id": update.parent_id or update.segment_id,
-                        "is_new_activity": update.kind == "activity",
-                    },
+                    payload=payload,
                 )
             )
 
@@ -319,29 +315,44 @@ class TestTitlePipelineCallback:
         assert ev.payload["title"] == "Setting up environment"
         assert ev.payload["is_new_activity"] is True
 
+    def test_activity_update_carries_native_activity_label(self):
+        """Regression: activity updates must carry activity_label (TF's own title).
+
+        Without it the frontend activity timeline renders a blank group heading.
+        """
+        payload = build_turn_summary_payload(
+            TitleUpdate(
+                session_id="j1",
+                segment_id="act-1",
+                kind="activity",
+                title="Setting up environment",
+                version=1,
+                parent_id=None,
+            )
+        )
+        assert payload is not None
+        assert payload["activity_label"] == "Setting up environment"
+        assert payload["activity_id"] == "act-1"
+        assert payload["is_new_activity"] is True
+
+    def test_step_update_carries_no_activity_label(self):
+        """Step updates name the step, not the activity — no label is invented."""
+        payload = build_turn_summary_payload(
+            TitleUpdate(
+                session_id="j1",
+                segment_id="step-1",
+                kind="step",
+                title="Reading config file",
+                version=1,
+                parent_id="activity-1",
+            )
+        )
+        assert payload is not None
+        assert "activity_label" not in payload
+
     @pytest.mark.asyncio
     async def test_session_title_update_skipped(self):
         """Session-kind TitleUpdates are not emitted as turn_summaries."""
-        bus = EventBus()
-        published: list[SessionEvent] = []
-
-        async def _handler(e: SessionEvent) -> None:
-            published.append(e)
-
-        bus.subscribe(_handler)
-
-        async def _on_title_update(update: TitleUpdate) -> None:
-            if update.kind == "session":
-                return
-            await bus.publish(
-                new_event(
-                    session_id=update.session_id,
-                    timestamp=datetime.now(UTC),
-                    kind=EventKind.turn_summary,
-                    payload={},
-                )
-            )
-
         update = TitleUpdate(
             session_id="j1",
             segment_id="seg-1",
@@ -350,52 +361,24 @@ class TestTitlePipelineCallback:
             version=1,
             parent_id=None,
         )
-        await _on_title_update(update)
-
-        assert len(published) == 0
+        assert build_turn_summary_payload(update) is None
 
     @pytest.mark.asyncio
     async def test_step_title_update_uses_parent_as_activity_id(self):
         """Step-kind TitleUpdate uses parent_id as activity_id."""
-        bus = EventBus()
-        published: list[SessionEvent] = []
-
-        async def _handler(e: SessionEvent) -> None:
-            published.append(e)
-
-        bus.subscribe(_handler)
-
-        async def _on_title_update(update: TitleUpdate) -> None:
-            if update.kind == "session":
-                return
-            await bus.publish(
-                new_event(
-                    session_id=update.session_id,
-                    timestamp=datetime.now(UTC),
-                    kind=EventKind.turn_summary,
-                    payload={
-                        "turn_id": update.segment_id,
-                        "title": update.title,
-                        "activity_id": update.parent_id or update.segment_id,
-                        "is_new_activity": update.kind == "activity",
-                    },
-                )
+        payload = build_turn_summary_payload(
+            TitleUpdate(
+                session_id="j1",
+                segment_id="step-1",
+                kind="step",
+                title="Reading config file",
+                version=1,
+                parent_id="activity-1",
             )
-
-        update = TitleUpdate(
-            session_id="j1",
-            segment_id="step-1",
-            kind="step",
-            title="Reading config file",
-            version=1,
-            parent_id="activity-1",
         )
-        await _on_title_update(update)
-
-        assert len(published) == 1
-        ev = published[0]
-        assert ev.payload["activity_id"] == "activity-1"
-        assert ev.payload["is_new_activity"] is False
+        assert payload is not None
+        assert payload["activity_id"] == "activity-1"
+        assert payload["is_new_activity"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/store/__tests__/activity-timeline.test.ts
+++ b/frontend/src/store/__tests__/activity-timeline.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useStore } from "../index";
+import { normalizeTFEvent } from "../sseNormalize";
+
+/**
+ * Regression coverage for the activity-timeline group heading.
+ *
+ * The backend emits `turn.summary` from TraceForge's native `TitleUpdate`.
+ * Activity-kind updates carry `activity_label` (TF's own title); step-kind
+ * updates carry none. If the label is dropped anywhere along that path the
+ * timeline renders a blank activity heading.
+ */
+
+/** Feed a raw TF wire frame through the same adapter `useSSE` uses. */
+function dispatchTF(payload: Record<string, unknown>) {
+  const normalized = normalizeTFEvent({
+    kind: "turn.summary",
+    session_id: "job-1",
+    timestamp: "2025-01-01T00:00:00Z",
+    payload,
+  });
+  useStore.getState().dispatchSSEEvent("turn.summary", normalized);
+}
+
+beforeEach(() => {
+  useStore.setState({ activityTimelines: {} });
+});
+
+describe("turn.summary → activity timeline", () => {
+  it("gives the activity group a nonblank label from a native activity update", () => {
+    dispatchTF({
+      turn_id: "act-1",
+      title: "Setting up environment",
+      activity_id: "act-1",
+      activity_label: "Setting up environment",
+      is_new_activity: true,
+    });
+
+    const timeline = useStore.getState().activityTimelines["job-1"]!;
+    expect(timeline.activities).toHaveLength(1);
+    expect(timeline.activities[0]!.label).toBe("Setting up environment");
+    expect(timeline.activities[0]!.label).not.toBe("");
+  });
+
+  it("keeps the activity label when a labelless step update follows", () => {
+    dispatchTF({
+      turn_id: "act-1",
+      title: "Setting up environment",
+      activity_id: "act-1",
+      activity_label: "Setting up environment",
+      is_new_activity: true,
+    });
+    // Step-kind updates carry no activity_label — they must not erase it.
+    dispatchTF({
+      turn_id: "step-1",
+      title: "Reading config file",
+      activity_id: "act-1",
+      is_new_activity: false,
+    });
+
+    const timeline = useStore.getState().activityTimelines["job-1"]!;
+    expect(timeline.activities).toHaveLength(1);
+    expect(timeline.activities[0]!.label).toBe("Setting up environment");
+    expect(timeline.activities[0]!.steps.map((s) => s.title)).toEqual([
+      "Setting up environment",
+      "Reading config file",
+    ]);
+  });
+});

--- a/frontend/src/store/__tests__/sse-events.test.ts
+++ b/frontend/src/store/__tests__/sse-events.test.ts
@@ -10,6 +10,7 @@ import {
   selectAttentionJobs,
   selectArchivedJobs,
   selectArchivedCount,
+  selectActivityTimeline,
 } from "../index";
 import type { JobSummary } from "../index";
 
@@ -54,6 +55,29 @@ beforeEach(() => {
 // ---- Additional SSE event types -------------------------------------------
 
 describe("dispatchSSEEvent — additional events", () => {
+  it("preserves a native activity label when a step summary omits it", () => {
+    useStore.getState().dispatchSSEEvent("turn.summary", {
+      jobId: "job-1",
+      turnId: "activity-1",
+      title: "Inspect authentication flow",
+      activityId: "activity-1",
+      activityLabel: "Inspect authentication flow",
+      isNewActivity: true,
+    });
+    useStore.getState().dispatchSSEEvent("turn.summary", {
+      jobId: "job-1",
+      turnId: "step-1",
+      title: "Read middleware",
+      activityId: "activity-1",
+      isNewActivity: false,
+    });
+
+    const timeline = selectActivityTimeline("job-1")(useStore.getState());
+    expect(timeline.activities).toHaveLength(1);
+    expect(timeline.activities[0]!.label).toBe("Inspect authentication flow");
+    expect(timeline.activities[0]!.steps).toHaveLength(2);
+  });
+
   it("handles job_review with prUrl and resolution", () => {
     useStore.setState({ jobs: { "job-1": makeJob({ progressHeadline: "Audit", progressSummary: "Reviewing shortcuts" }) } });
     useStore.getState().dispatchSSEEvent("job.review", {

--- a/frontend/src/store/handlers/timelineHandlers.ts
+++ b/frontend/src/store/handlers/timelineHandlers.ts
@@ -112,7 +112,10 @@ export function handleTurnSummary(state: AppState, payload: Record<string, unkno
   const turnId = payload.turnId as string;
   const title = payload.title as string;
   const activityId = payload.activityId as string;
-  const activityLabel = payload.activityLabel as string;
+  // TF only supplies `activityLabel` on activity-kind updates; step updates
+  // omit it. Treat a missing/blank label as "no opinion" so a step never
+  // erases the label its parent activity already established.
+  const activityLabel = (payload.activityLabel as string | undefined) || undefined;
   const activityStatus = (payload.activityStatus as "active" | "done") || "active";
   const isNewActivity = payload.isNewActivity as boolean;
   const planItemId = (payload.planItemId as string | null) ?? null;
@@ -186,7 +189,7 @@ export function handleTurnSummary(state: AppState, payload: Record<string, unkno
     }
     activities.push({
       activityId,
-      label: activityLabel,
+      label: activityLabel ?? "",
       status: activityStatus,
       steps: [step],
       planItemId,
@@ -197,7 +200,7 @@ export function handleTurnSummary(state: AppState, payload: Record<string, unkno
     if (last) {
       activities[activities.length - 1] = {
         ...last,
-        label: activityLabel,
+        label: activityLabel ?? last.label,
         status: activityStatus,
         steps: [...last.steps, step],
       };

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -251,7 +251,9 @@ function _rebuildActivityTimeline(
     const existingById = activities.find((a) => a.activityId === (s.activityId ?? ""));
     if (existingById && !isNew) {
       existingById.steps.push(step);
-      existingById.label = s.activityLabel ?? existingById.label;
+      // Blank label = "no opinion" (step-kind summaries carry none) — keep
+      // the activity's established label rather than erasing it.
+      existingById.label = (s.activityLabel as string | undefined) || existingById.label;
       existingById.status = (s.activityStatus as "active" | "done") ?? existingById.status;
     } else if (existingById && isNew) {
       // isNewActivity was set but this activityId already exists — resume it
@@ -271,7 +273,7 @@ function _rebuildActivityTimeline(
       const last = activities[activities.length - 1];
       if (last) {
         last.steps.push(step);
-        last.label = s.activityLabel ?? last.label;
+        last.label = (s.activityLabel as string | undefined) || last.label;
         last.status = (s.activityStatus as "active" | "done") ?? last.status;
       }
     }


### PR DESCRIPTION
## Summary
- map TraceForge activity `TitleUpdate` titles to native `activity_label` on `turn_summary` payloads (no synthetic inference; step behavior preserved)
- preserve an established activity label when later step summaries omit it (live reducer + snapshot hydration)
- snapshot canonical metadata *before* `TFEnricher.process()` in `reenrich.py` and compare against that snapshot, so mutation-in-place still persists

## Tests
- `backend/tests/unit/test_traceforge_enrichment.py` — `build_turn_summary_payload` carries `activity_label` on activity updates and omits it on step updates
- `backend/tests/unit/test_reenrich.py` — mutating enricher regression: asserts `update_metadata` is written and the marker's `updated_count` is 1; plus a no-write case for unchanged metadata
- `frontend/src/store/__tests__/activity-timeline.test.ts` — a native (snake_case wire) `turn.summary` activity update yields a nonblank activity group label, and a labelless step update does not erase it
- `frontend/src/store/__tests__/sse-events.test.ts` — label preservation across step summaries

## Validation
- backend focused tests: 26 passed (`test_reenrich.py`, `test_traceforge_enrichment.py`); related: `test_snapshot_helpers.py`, `test_event_processor.py` 39 passed
- frontend store tests: 80 passed; typecheck (`tsc --noEmit`) clean; eslint clean on changed files
- `ruff check backend` clean; `ruff format --check` clean on changed files

## CI
CI Backend job fails at **Install dependencies** — `uv` cannot fetch the pinned `coderecon-ai` git commit. This is a pre-existing infrastructure failure: the same step fails identically on `main` (98f12d35) and on the two commits before it. Frontend job is green. No merge requested.