### PR TITLE
chore: ignore BMAD generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,10 @@ scorecard.png
 *.tsbuildinfo
 site/
 .playwright-mcp/
+
+# BMAD generated method and runtime files
+/_bmad/
+/.agents/skills/bmad-*/
+/.github/agents/bmad-*.agent.md
+/_bmad-output/planning-artifacts/
+/_bmad-output/implementation-artifacts/


### PR DESCRIPTION
## Summary

- ignore installer-managed BMAD method files and Copilot skill pointers
- ignore transient BMAD planning and implementation artifacts
- keep durable project knowledge trackable

The BMAD installation remains local and reproducible from the machine-global patched installer recorded in session handoff.