### PR TITLE
feat(sidecar): widen Task Recipe vocabulary for chaining (Story 4.1, CAP-8)

### DIFF
--- a/_bmad-output/implementation-artifacts/4-1-widen-the-task-recipe-vocabulary.md
+++ b/_bmad-output/implementation-artifacts/4-1-widen-the-task-recipe-vocabulary.md
@@ -1,0 +1,78 @@
+---
+baseline_commit: bbf31746
+---
+
+# Story 4.1: Widen the Task Recipe vocabulary
+
+Status: review
+
+## Story
+
+As a CodePlane user relying on existing sidecar templates,
+I want the recipe schema to support chained, tracker-aware task recipes,
+so that new chaining capability is additive and never breaks my existing sidecars.
+
+## Acceptance Criteria
+
+1. **Given** an existing `SidecarTemplateRow` with a pre-existing `lifetime`/`outputRoutes`/`contextSources` value, **when** the schema validation function is updated, **then** `chained`, `spawn_task`, `tracker_write`, `story_node`, and `tracker_ticket` are accepted as new valid values, and every existing template continues to validate and run unchanged.
+2. **And** no new schema table, version flag, or migration is introduced — the same `definition_json` column is reused.
+
+## Tasks / Subtasks
+
+- [x] Add `chained` to `_ALLOWED_LIFETIMES`, `spawn_task`/`tracker_write` to `_ALLOWED_OUTPUT_ROUTES`, and `story_node`/`tracker_ticket` to `_ALLOWED_CONTEXT_SOURCES` in `backend/services/sidecar/template_service.py`.
+- [x] Verify no schema table/migration/version flag is introduced — `definition_json` column reused as-is.
+- [x] Add/extend tests proving new values validate and existing values still validate unchanged.
+- [x] Run targeted test suite and lint.
+
+## Dev Notes
+
+- CAP-8 (SPEC.md) / AD-8 (ARCHITECTURE-SPINE.md): widen `_ALLOWED_LIFETIMES`/`_ALLOWED_OUTPUT_ROUTES`/`_ALLOWED_CONTEXT_SOURCES` in the existing `_validate_definition` function in `template_service.py`. No new schema table, version flag, or migration — `SidecarTemplateRow.definition_json` is reused unchanged.
+- Scope is strictly the schema/validation widening. Do NOT implement TaskLink, ingestion (Story 4.2), ticket assignment (4.3), board rendering (4.4), auto-spawn (4.5), or tracker-write routing (4.6) — those are separate, dependent stories.
+- Existing constants: `_ALLOWED_CONTEXT_SOURCES`, `_ALLOWED_OUTPUT_ROUTES`, `_ALLOWED_LIFETIMES` in `backend/services/sidecar/template_service.py`.
+- Existing tests: `backend/tests/unit/test_sidecar_template_service.py`.
+
+### References
+
+- [Source: `_bmad-output/planning-artifacts/epics.md#Story-41-Widen-the-Task-Recipe-vocabulary`]
+- [Source: `_bmad-output/specs/spec-project-boards/SPEC.md#CAP-8`]
+- [Source: `_bmad-output/planning-artifacts/architecture/architecture-codeplane 2026-08-10/ARCHITECTURE-SPINE.md#AD-8`]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Claude Sonnet 5 (GitHub Copilot CLI).
+
+### Debug Log References
+
+- `python -m pytest backend/tests/unit/test_sidecar_template_service.py -q` -> 38 passed
+- `python -m ruff check backend/services/sidecar/template_service.py backend/tests/unit/test_sidecar_template_service.py` -> All checks passed
+- `python -m pytest backend/tests/unit -k "sidecar" -q` -> 130 passed, 3080 deselected (no regressions)
+
+### Completion Notes
+
+Widened the existing `_validate_definition` vocabulary in `backend/services/sidecar/template_service.py`
+per CAP-8/AD-8, purely additively:
+- `_ALLOWED_LIFETIMES` gained `chained`.
+- `_ALLOWED_OUTPUT_ROUTES` gained `spawn_task`, `tracker_write`.
+- `_ALLOWED_CONTEXT_SOURCES` gained `story_node`, `tracker_ticket`.
+
+No new schema table, version flag, or migration was introduced; `SidecarTemplateRow.definition_json`
+is unchanged and reused as-is. No TaskLink, ingestion, board rendering, auto-spawn, or tracker-write
+routing logic was touched — those remain scoped to Stories 4.2–4.6. Extended
+`test_sidecar_template_service.py`'s `TestConstants` with explicit assertions for the new values;
+the existing parametrized `test_valid_lifetimes`/`test_valid_output_routes`/`test_valid_context_sources`
+tests already iterate these constants so they automatically cover the new values end-to-end through
+`_validate_definition`.
+
+## File List
+
+- `backend/services/sidecar/template_service.py` (modified)
+- `backend/tests/unit/test_sidecar_template_service.py` (modified)
+- `_bmad-output/implementation-artifacts/4-1-widen-the-task-recipe-vocabulary.md` (added)
+- `_bmad-output/implementation-artifacts/sprint-status.yaml` (modified)
+
+## Change Log
+
+- Story created.
+- Implemented CAP-8/AD-8 vocabulary widening; all targeted tests and lint pass; story marked for review.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -74,8 +74,8 @@ development_status:
   3-5-see-per-provider-pat-scope-guidance: backlog
   epic-3-retrospective: optional
 
-  epic-4: backlog
-  4-1-widen-the-task-recipe-vocabulary: backlog
+  epic-4: in-progress
+  4-1-widen-the-task-recipe-vocabulary: review
   4-2-ingest-a-task-graph-into-a-project: backlog
   4-3-manually-assign-a-task-to-an-existing-ticket: backlog
   4-4-see-tasklink-cards-on-the-board: backlog

--- a/backend/services/sidecar/template_service.py
+++ b/backend/services/sidecar/template_service.py
@@ -18,17 +18,31 @@ from backend.models.domain import SidecarTemplate
 log = structlog.get_logger()
 
 # Context sources available to custom sidecars (safe subset).
-_ALLOWED_CONTEXT_SOURCES = ["trigger_event", "job_diff", "job_prompt", "recent_messages"]
+# `story_node` and `tracker_ticket` (CAP-8/AD-8) support Task Recipe chaining —
+# a `chained` recipe's context may come from an ingested/assigned story node or a
+# paired tracker ticket, in addition to the original job-scoped sources.
+_ALLOWED_CONTEXT_SOURCES = [
+    "trigger_event",
+    "job_diff",
+    "job_prompt",
+    "recent_messages",
+    "story_node",
+    "tracker_ticket",
+]
 
 # Output routes available to custom sidecars.
-_ALLOWED_OUTPUT_ROUTES = ["event_bus", "job_metadata", "agent_message", "gate"]
+# `spawn_task` and `tracker_write` (CAP-8/AD-8) let a `chained` recipe spawn the next
+# dependent TaskLink's job or route a completion write to a paired tracker ticket.
+_ALLOWED_OUTPUT_ROUTES = ["event_bus", "job_metadata", "agent_message", "gate", "spawn_task", "tracker_write"]
 
 # Trigger conditions available to custom sidecars.
 _ALLOWED_CONDITIONS = ["event", "timer", "threshold", "manual", "regex", "file_pattern", "content_match"]
 
 # Allowed phases, lifetimes, and scopes.
 _ALLOWED_PHASES = ["preflight", "midflight", "postflight"]
-_ALLOWED_LIFETIMES = ["ephemeral", "windowed", "persistent"]
+# `chained` (CAP-8/AD-8) is a Task Recipe lifetime that spans multiple jobs, rather
+# than being scoped to one job's lifetime like the original three values.
+_ALLOWED_LIFETIMES = ["ephemeral", "windowed", "persistent", "chained"]
 _ALLOWED_SCOPES = ["global", "repo", "job"]
 
 # Tool access levels and category names.

--- a/backend/tests/unit/test_sidecar_template_service.py
+++ b/backend/tests/unit/test_sidecar_template_service.py
@@ -206,6 +206,15 @@ class TestConstants:
         assert "ephemeral" in _ALLOWED_LIFETIMES
         assert "windowed" in _ALLOWED_LIFETIMES
         assert "persistent" in _ALLOWED_LIFETIMES
+        assert "chained" in _ALLOWED_LIFETIMES
+
+    def test_allowed_output_routes_include_task_recipe_chaining(self):
+        assert "spawn_task" in _ALLOWED_OUTPUT_ROUTES
+        assert "tracker_write" in _ALLOWED_OUTPUT_ROUTES
+
+    def test_allowed_context_sources_include_task_recipe_chaining(self):
+        assert "story_node" in _ALLOWED_CONTEXT_SOURCES
+        assert "tracker_ticket" in _ALLOWED_CONTEXT_SOURCES
 
     def test_allowed_scopes(self):
         assert "global" in _ALLOWED_SCOPES


### PR DESCRIPTION
## Summary

Implements Story 4.1 (Widen the Task Recipe vocabulary) from `_bmad-output/planning-artifacts/epics.md`, per CAP-8 (`_bmad-output/specs/spec-project-boards/SPEC.md`) and AD-8 (`_bmad-output/planning-artifacts/architecture/.../ARCHITECTURE-SPINE.md`).

Widens the existing sidecar-template recipe vocabulary in `backend/services/sidecar/template_service.py`'s `_validate_definition` so it can express Task Recipe chaining, additively and backward-compatibly:

- `_ALLOWED_LIFETIMES` gains `chained`
- `_ALLOWED_OUTPUT_ROUTES` gains `spawn_task`, `tracker_write`
- `_ALLOWED_CONTEXT_SOURCES` gains `story_node`, `tracker_ticket`

No new schema table, version flag, or migration — `SidecarTemplateRow.definition_json` is reused unchanged, and every existing template continues to validate/run unchanged.

## Scope

Strictly limited to this story's schema/validation widening. **Not** included (separate, dependent stories):
- Story 4.2 — ingestion into `TaskLink`
- Story 4.3 — manual ticket assignment
- Story 4.4 — TaskLink board cards
- Story 4.5 — auto-spawn
- Story 4.6 — tracker-write routing

## Testing

- `pytest backend/tests/unit/test_sidecar_template_service.py -q` → 38 passed
- `pytest backend/tests/unit -k "sidecar" -q` → 130 passed, 3080 deselected (no regressions)
- `ruff check backend/services/sidecar/template_service.py backend/tests/unit/test_sidecar_template_service.py` → all checks passed

## Story tracking

- `_bmad-output/implementation-artifacts/4-1-widen-the-task-recipe-vocabulary.md` — status `review`
- `sprint-status.yaml` updated: `4-1-widen-the-task-recipe-vocabulary: review`

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>