### PR TITLE
fix: harden developer self-restart

### DIFF
--- a/backend/services/dev_restart/restart_helper.py
+++ b/backend/services/dev_restart/restart_helper.py
@@ -53,6 +53,7 @@ from backend.services.dev_restart.restart_protocol import (
     RestartRequestPaths,
     RestartTimeouts,
     acquire_restart_lock,
+    get_replacement_log_path,
     get_request_paths,
     is_identity_alive,
     log_phase,
@@ -404,8 +405,10 @@ def _start_replacement(
     ``--skip-preflight``).
     ``--skip-preflight`` is always passed because the parent already completed
     the restart-only preflight/build pipeline before the old server was ever
-    paused or stopped. Re-running the interactive CLI preflight inside the
-    replacement consumes most of the readiness budget without increasing safety.
+    paused or stopped. Isolated Windows reruns confirmed that skipping the
+    replacement-side preflight is the behavior needed for reliable startup;
+    replacement output itself does not need to stay attached to
+    ``restart.log``.
     ``--provider`` is always passed explicitly (never left to the CLI
     default) so a non-default recorded provider (e.g. cloudflare) is
     reproduced exactly. ``--tunnel-ownership`` is likewise replayed exactly
@@ -461,20 +464,18 @@ def _start_replacement(
         RestartPhase.starting, request_id, host=profile.host, port=profile.port, dev=profile.dev, remote=profile.remote
     )
 
-    return subprocess.Popen(  # noqa: S603 - fixed argv, recorded native executable
-        args,
-        cwd=str(target_source_root),
-        env=env,
-        stdin=subprocess.DEVNULL,
-        # Inherit the helper's already-bound restart-log streams instead of
-        # DEVNULL. On Windows, launching ``python -m backend.main up`` with
-        # DEVNULL-backed stdio can terminate the replacement before readiness;
-        # inheriting these writable handles preserves startup diagnostics and
-        # keeps the replacement process alive long enough to publish readiness.
-        stdout=sys.stdout,
-        stderr=sys.stderr,
-        start_new_session=(sys.platform != "win32"),
-    )
+    replacement_log_path = get_replacement_log_path(request_id)
+    replacement_log_path.parent.mkdir(parents=True, exist_ok=True)
+    with replacement_log_path.open("a", encoding="utf-8") as replacement_log_handle:
+        return subprocess.Popen(  # noqa: S603 - fixed argv, recorded native executable
+            args,
+            cwd=str(target_source_root),
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=replacement_log_handle,
+            stderr=replacement_log_handle,
+            start_new_session=(sys.platform != "win32"),
+        )
 
 
 def _wait_for_ready(

--- a/backend/services/dev_restart/restart_helper.py
+++ b/backend/services/dev_restart/restart_helper.py
@@ -392,7 +392,12 @@ def _start_replacement(
     triggers the exact same ``if __name__ == "__main__": cli()`` entry point
     (verified against ``backend/main.py``/``backend/cli.py``'s ``up``
     command options: ``--host``, ``--port``, ``--dev``, ``--remote``,
-    ``--provider``, ``--tunnel-name``, ``--tunnel-ownership``).
+    ``--provider``, ``--tunnel-name``, ``--tunnel-ownership``,
+    ``--skip-preflight``).
+    ``--skip-preflight`` is always passed because the parent already completed
+    the restart-only preflight/build pipeline before the old server was ever
+    paused or stopped. Re-running the interactive CLI preflight inside the
+    replacement consumes most of the readiness budget without increasing safety.
     ``--provider`` is always passed explicitly (never left to the CLI
     default) so a non-default recorded provider (e.g. cloudflare) is
     reproduced exactly. ``--tunnel-ownership`` is likewise replayed exactly
@@ -416,6 +421,7 @@ def _start_replacement(
         "-m",
         "backend.main",
         "up",
+        "--skip-preflight",
         "--host",
         profile.host,
         "--port",
@@ -452,8 +458,13 @@ def _start_replacement(
         cwd=str(target_source_root),
         env=env,
         stdin=subprocess.DEVNULL,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+        # Inherit the helper's already-bound restart-log streams instead of
+        # DEVNULL. On Windows, launching ``python -m backend.main up`` with
+        # DEVNULL-backed stdio can terminate the replacement before readiness;
+        # inheriting these writable handles preserves startup diagnostics and
+        # keeps the replacement process alive long enough to publish readiness.
+        stdout=sys.stdout,
+        stderr=sys.stderr,
         start_new_session=(sys.platform != "win32"),
     )
 

--- a/backend/services/dev_restart/restart_helper.py
+++ b/backend/services/dev_restart/restart_helper.py
@@ -165,8 +165,19 @@ def spawn_detached_helper(python_executable: Path, helper_script: Path, request_
     return proc.pid
 
 
+def _request_marker_matches(path: Path, request_id: str) -> bool:
+    """True when *path* exists and names the expected restart request."""
+    if not path.exists():
+        return False
+    try:
+        payload = read_json_file(path)
+    except RestartProtocolError:
+        return False
+    return payload.get("requestId") == request_id
+
+
 def await_adoption(paths: RestartRequestPaths, request_id: str, timeout_seconds: float) -> bool:
-    """Block until ``<id>.started.json`` exists and names this exact request.
+    """Block until a claimed/started marker names this exact request.
 
     Parent success requires adoption, not restart completion (AD-3) — this
     only proves a helper claimed the request and is proceeding; it says
@@ -174,16 +185,13 @@ def await_adoption(paths: RestartRequestPaths, request_id: str, timeout_seconds:
     """
     deadline = time.monotonic() + timeout_seconds
     while time.monotonic() < deadline:
-        if paths.started.exists():
-            try:
-                started = read_json_file(paths.started)
-            except RestartProtocolError:
-                time.sleep(0.1)
-                continue
-            if started.get("requestId") == request_id:
-                return True
+        if _request_marker_matches(paths.started, request_id) or _request_marker_matches(paths.claimed, request_id):
+            return True
         time.sleep(0.1)
-    return False
+    # One final check closes a race where the helper publishes its marker
+    # right at the deadline and Windows surfaces the file just after the loop's
+    # last iteration.
+    return _request_marker_matches(paths.started, request_id) or _request_marker_matches(paths.claimed, request_id)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/services/dev_restart/restart_protocol.py
+++ b/backend/services/dev_restart/restart_protocol.py
@@ -127,7 +127,7 @@ class RestartTimeouts:
     response_grace_seconds: float = 2.0
     pause_wait_seconds: float = 10.0
     stop_seconds: float = 15.0
-    readiness_seconds: float = 60.0
+    readiness_seconds: float = 120.0
     remote_probe_seconds: float = 30.0
 
     def to_dict(self) -> dict[str, float]:

--- a/backend/services/dev_restart/restart_protocol.py
+++ b/backend/services/dev_restart/restart_protocol.py
@@ -37,6 +37,7 @@ log = structlog.get_logger()
 _DEV_RESTART_SUBDIR = "dev-restart"
 _RESTART_LOG_FILENAME = "restart.log"
 _RESTART_LOCK_FILENAME = "restart.lock"
+_REPLACEMENT_LOG_SUFFIX = ".server.log"
 
 # psutil.Process.create_time() is a float; allow a small epsilon for
 # platform/float-precision jitter without weakening the PID-reuse check.
@@ -64,6 +65,17 @@ def get_restart_log_path() -> Path:
     return get_dev_restart_dir() / _RESTART_LOG_FILENAME
 
 
+def get_replacement_log_path(request_id: str) -> Path:
+    """Return the per-request replacement stdout/stderr log path.
+
+    The replacement must never inherit ``restart.log`` itself: keeping the
+    helper's log file open in the long-lived server process can block the next
+    attempt's restart-log rotation on Windows. A request-specific sibling log
+    preserves diagnostics without holding ``restart.log`` across attempts.
+    """
+    return get_dev_restart_dir() / f"{request_id}{_REPLACEMENT_LOG_SUFFIX}"
+
+
 # Story 1.7 AC3: rotate at 5 MiB with exactly one backup.
 _RESTART_LOG_MAX_BYTES = 5 * 1024 * 1024
 _RESTART_LOG_BACKUP_SUFFIX = ".1"
@@ -86,8 +98,11 @@ def rotate_restart_log_if_needed(log_path: Path, max_bytes: int = _RESTART_LOG_M
     if size < max_bytes:
         return
     backup_path = log_path.with_name(log_path.name + _RESTART_LOG_BACKUP_SUFFIX)
-    backup_path.unlink(missing_ok=True)
-    log_path.replace(backup_path)
+    try:
+        backup_path.unlink(missing_ok=True)
+        log_path.replace(backup_path)
+    except OSError as exc:
+        raise RestartProtocolError(f"could not rotate {log_path}: {exc}") from exc
 
 
 def get_restart_lock_path() -> Path:
@@ -127,7 +142,7 @@ class RestartTimeouts:
     response_grace_seconds: float = 2.0
     pause_wait_seconds: float = 10.0
     stop_seconds: float = 15.0
-    readiness_seconds: float = 120.0
+    readiness_seconds: float = 60.0
     remote_probe_seconds: float = 30.0
 
     def to_dict(self) -> dict[str, float]:

--- a/backend/services/setup/service.py
+++ b/backend/services/setup/service.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json as _json
 import subprocess
+import sys
 from typing import Any
 
 import questionary
@@ -113,6 +114,11 @@ def _prompt_select(choices: list[questionary.Choice]) -> Any:  # noqa: ANN401
         pointer="  →",
         choices=choices,
     ).ask()
+
+
+def _can_prompt_interactively() -> bool:
+    """Return whether inline preflight prompts can safely use the local terminal."""
+    return sys.stdin.isatty() and sys.stdout.isatty()
 
 
 def _offer_inline_fix(warning: CheckResult) -> str:
@@ -221,6 +227,7 @@ def validate_preflight(port: int) -> bool:
     """
     config = load_config()
     results = verify_requirements(port=port, include_optional_dependencies=False, preflight=True)
+    interactive = _can_prompt_interactively()
 
     _console.print()
     _console.print("  [bold]Preflight[/bold]")
@@ -254,6 +261,10 @@ def validate_preflight(port: int) -> bool:
             if w.hint:
                 for line in w.hint.split("\n"):
                     _console.print(f"       → {line}")
+
+            if not interactive:
+                _console.print("       [dim]Non-interactive preflight; continuing without an inline prompt.[/dim]")
+                continue
 
             if not _should_prompt_for_warning(
                 w,

--- a/backend/tests/unit/test_dev_restart.py
+++ b/backend/tests/unit/test_dev_restart.py
@@ -108,7 +108,7 @@ def test_build_frontend_preserves_failed_build_result() -> None:
 
 def test_build_frontend_installs_dependencies_when_node_modules_missing(tmp_path: Path) -> None:
     npm_path = r"C:\Program Files\nodejs\npm.cmd"
-    results = [
+    results: list[CompletedProcess[str]] = [
         CompletedProcess([npm_path, "ci"], returncode=0),
         CompletedProcess([npm_path, "run", "build"], returncode=0),
     ]

--- a/backend/tests/unit/test_dev_restart.py
+++ b/backend/tests/unit/test_dev_restart.py
@@ -16,7 +16,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from backend.services.dev_restart.launch_profile import SecretSource, build_active_launch_profile
-from backend.services.dev_restart.restart_protocol import RestartTimeouts, get_request_paths
+from backend.services.dev_restart.restart_protocol import RestartProtocolError, RestartTimeouts, get_request_paths
 from tools import dev_restart
 
 if TYPE_CHECKING:
@@ -504,3 +504,26 @@ class TestRunParent:
             assert dev_restart.run_parent(self._args()) == 1
 
         mock_await.assert_not_called()
+
+    def test_restart_log_rotation_failure_returns_nonzero_without_spawning_helper(self, tmp_path: Path) -> None:
+        paths = get_request_paths("req-abc")
+        timeouts = RestartTimeouts()
+
+        with (
+            patch(
+                "tools.dev_restart.prepare_restart_request",
+                return_value=(paths, "req-abc", timeouts),
+            ),
+            patch(
+                "backend.services.dev_restart.restart_protocol.get_restart_log_path",
+                return_value=tmp_path / "restart.log",
+            ),
+            patch(
+                "backend.services.dev_restart.restart_protocol.rotate_restart_log_if_needed",
+                side_effect=RestartProtocolError("could not rotate restart.log: file is locked"),
+            ),
+            patch("backend.services.dev_restart.restart_helper.spawn_detached_helper") as mock_spawn,
+        ):
+            assert dev_restart.run_parent(self._args()) == 1
+
+        mock_spawn.assert_not_called()

--- a/backend/tests/unit/test_dev_restart.py
+++ b/backend/tests/unit/test_dev_restart.py
@@ -1,11 +1,14 @@
 """Tests for tools/dev_restart.py: frontend build, target-source resolution,
-secret re-resolution, backend preflight, pending-request write, and the
-Story 1.2 parent-mode preparation/handoff flow.
+secret re-resolution, backend preflight, pending-request write, parent/helper
+importability when run as a script, and the Story 1.2 parent-mode
+preparation/handoff flow.
 """
 
 from __future__ import annotations
 
 import argparse
+import importlib
+import sys
 from subprocess import CompletedProcess
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
@@ -78,6 +81,7 @@ def test_build_frontend_invokes_resolved_npm_and_streams_output() -> None:
 
     with (
         patch("tools.dev_restart._resolve_npm_command", return_value=npm_path),
+        patch("pathlib.Path.is_dir", return_value=True),
         patch(
             "tools.dev_restart.subprocess.run",
             return_value=CompletedProcess([npm_path, "run", "build"], returncode=0),
@@ -93,12 +97,54 @@ def test_build_frontend_preserves_failed_build_result() -> None:
 
     with (
         patch("tools.dev_restart._resolve_npm_command", return_value=npm_path),
+        patch("pathlib.Path.is_dir", return_value=True),
         patch(
             "tools.dev_restart.subprocess.run",
             return_value=CompletedProcess([npm_path, "run", "build"], returncode=1),
         ),
     ):
         assert dev_restart.build_frontend() is False
+
+
+def test_build_frontend_installs_dependencies_when_node_modules_missing(tmp_path: Path) -> None:
+    npm_path = r"C:\Program Files\nodejs\npm.cmd"
+    results = [
+        CompletedProcess([npm_path, "ci"], returncode=0),
+        CompletedProcess([npm_path, "run", "build"], returncode=0),
+    ]
+
+    with (
+        patch("tools.dev_restart._resolve_npm_command", return_value=npm_path),
+        patch("tools.dev_restart.subprocess.run", side_effect=results) as mock_run,
+    ):
+        assert dev_restart.build_frontend(tmp_path) is True
+
+    install_args, build_args = (call.args[0] for call in mock_run.call_args_list)
+    assert install_args == [npm_path, "ci"]
+    assert build_args == [npm_path, "run", "build"]
+
+
+def test_build_frontend_aborts_when_dependency_install_fails(tmp_path: Path) -> None:
+    npm_path = r"C:\Program Files\nodejs\npm.cmd"
+
+    with (
+        patch("tools.dev_restart._resolve_npm_command", return_value=npm_path),
+        patch(
+            "tools.dev_restart.subprocess.run",
+            return_value=CompletedProcess([npm_path, "ci"], returncode=1),
+        ) as mock_run,
+    ):
+        assert dev_restart.build_frontend(tmp_path) is False
+
+    mock_run.assert_called_once_with([npm_path, "ci"], cwd=tmp_path)
+
+
+def test_import_inserts_repo_root_for_direct_script_execution(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "path", [str(dev_restart.REPO_ROOT / "tools")])
+
+    importlib.reload(dev_restart)
+
+    assert sys.path[0] == str(dev_restart.REPO_ROOT)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_restart_helper.py
+++ b/backend/tests/unit/test_restart_helper.py
@@ -559,6 +559,7 @@ class TestStartReplacement:
             "-m",
             "backend.main",
             "up",
+            "--skip-preflight",
             "--host",
             "127.0.0.1",
             "--port",
@@ -569,8 +570,8 @@ class TestStartReplacement:
         assert kwargs["env"]["CODEPLANE_RESTART_NONCE"] == "nonce-abc"
         assert kwargs["env"]["CODEPLANE_RESTART_REQUEST_ID"] == "req-start-1"
         assert kwargs["stdin"] == subprocess.DEVNULL
-        assert kwargs["stdout"] == subprocess.DEVNULL
-        assert kwargs["stderr"] == subprocess.DEVNULL
+        assert kwargs["stdout"] is sys.stdout
+        assert kwargs["stderr"] is sys.stderr
 
     def test_builds_exact_remote_argv_with_explicit_provider_and_tunnel_name(self, tmp_path: Path) -> None:
         """--provider is always explicit, never left to the CLI default (AC5: reproduce the
@@ -586,6 +587,7 @@ class TestStartReplacement:
             "-m",
             "backend.main",
             "up",
+            "--skip-preflight",
             "--host",
             "0.0.0.0",  # noqa: S104
             "--port",

--- a/backend/tests/unit/test_restart_helper.py
+++ b/backend/tests/unit/test_restart_helper.py
@@ -247,6 +247,14 @@ class TestAwaitAdoption:
         )
         assert rh.await_adoption(paths, "req-adopt-1", timeout_seconds=1.0) is True
 
+    def test_returns_true_when_claimed_marker_matches(self) -> None:
+        paths = get_request_paths("req-adopt-claimed")
+        write_json_atomic(
+            paths.claimed,
+            {"requestId": "req-adopt-claimed", "helperPid": 111, "helperProcessTime": 1.0, "claimedAt": "x"},
+        )
+        assert rh.await_adoption(paths, "req-adopt-claimed", timeout_seconds=1.0) is True
+
     def test_ignores_mismatched_request_id_and_times_out(self) -> None:
         paths = get_request_paths("req-adopt-2")
         write_json_atomic(
@@ -258,6 +266,16 @@ class TestAwaitAdoption:
     def test_returns_false_when_marker_never_appears(self) -> None:
         paths = get_request_paths("req-adopt-3")
         assert rh.await_adoption(paths, "req-adopt-3", timeout_seconds=0.3) is False
+
+    def test_final_check_catches_marker_published_at_deadline(self) -> None:
+        paths = get_request_paths("req-adopt-4")
+
+        with (
+            patch.object(rh, "_request_marker_matches", side_effect=[False, False, True]),
+            patch.object(rh.time, "monotonic", side_effect=[0.0, 0.0, 0.1]),
+            patch.object(rh.time, "sleep"),
+        ):
+            assert rh.await_adoption(paths, "req-adopt-4", timeout_seconds=0.05) is True
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_restart_helper.py
+++ b/backend/tests/unit/test_restart_helper.py
@@ -564,8 +564,12 @@ class TestStartReplacement:
         --dev, --remote, --provider, --tunnel-name)."""
         profile = _local_profile(executable=sys.executable, host="127.0.0.1", port=9001, dev=True, remote=False)
         fake_proc = MagicMock()
+        replacement_log_path = tmp_path / "req-start-1.server.log"
 
-        with patch.object(rh.subprocess, "Popen", return_value=fake_proc) as mock_popen:
+        with (
+            patch.object(rh, "get_replacement_log_path", return_value=replacement_log_path),
+            patch.object(rh.subprocess, "Popen", return_value=fake_proc) as mock_popen,
+        ):
             result = rh._start_replacement(profile, tmp_path, nonce="nonce-abc", request_id="req-start-1")
 
         assert result is fake_proc
@@ -588,15 +592,20 @@ class TestStartReplacement:
         assert kwargs["env"]["CODEPLANE_RESTART_NONCE"] == "nonce-abc"
         assert kwargs["env"]["CODEPLANE_RESTART_REQUEST_ID"] == "req-start-1"
         assert kwargs["stdin"] == subprocess.DEVNULL
-        assert kwargs["stdout"] is sys.stdout
-        assert kwargs["stderr"] is sys.stderr
+        assert kwargs["stdout"] is kwargs["stderr"]
+        assert kwargs["stdout"] is not sys.stdout
+        assert kwargs["stderr"] is not sys.stderr
+        assert Path(kwargs["stdout"].name) == replacement_log_path
 
     def test_builds_exact_remote_argv_with_explicit_provider_and_tunnel_name(self, tmp_path: Path) -> None:
         """--provider is always explicit, never left to the CLI default (AC5: reproduce the
         recorded provider exactly, including non-default providers like cloudflare)."""
         profile = _remote_profile(host="0.0.0.0", port=9002, provider="cloudflare", tunnel_name="cpl-abc123")  # noqa: S104
 
-        with patch.object(rh.subprocess, "Popen", return_value=MagicMock()) as mock_popen:
+        with (
+            patch.object(rh, "get_replacement_log_path", return_value=tmp_path / "req-start-2.server.log"),
+            patch.object(rh.subprocess, "Popen", return_value=MagicMock()) as mock_popen,
+        ):
             rh._start_replacement(profile, tmp_path, nonce="n", request_id="req-start-2")
 
         args = mock_popen.call_args[0][0]
@@ -625,7 +634,12 @@ class TestStartReplacement:
         auto-detect path."""
         profile = _remote_profile(provider="devtunnel", tunnel_name="cpl-managed1", tunnel_ownership="managed")
 
-        with patch.object(rh.subprocess, "Popen", return_value=MagicMock()) as mock_popen:
+        with (
+            patch.object(
+                rh, "get_replacement_log_path", return_value=tmp_path / "req-start-ownership-managed.server.log"
+            ),
+            patch.object(rh.subprocess, "Popen", return_value=MagicMock()) as mock_popen,
+        ):
             rh._start_replacement(profile, tmp_path, nonce="n", request_id="req-start-ownership-managed")
 
         args = mock_popen.call_args[0][0]
@@ -637,7 +651,12 @@ class TestStartReplacement:
         resolves the exact recorded origin (AD-8, SPEC CAP-6)."""
         profile = _remote_profile(provider="cloudflare", tunnel_name=None, tunnel_ownership="external")
 
-        with patch.object(rh.subprocess, "Popen", return_value=MagicMock()) as mock_popen:
+        with (
+            patch.object(
+                rh, "get_replacement_log_path", return_value=tmp_path / "req-start-ownership-external.server.log"
+            ),
+            patch.object(rh.subprocess, "Popen", return_value=MagicMock()) as mock_popen,
+        ):
             rh._start_replacement(profile, tmp_path, nonce="n", request_id="req-start-ownership-external")
 
         args = mock_popen.call_args[0][0]
@@ -646,7 +665,10 @@ class TestStartReplacement:
     def test_never_invokes_resume_endpoint(self, tmp_path: Path) -> None:
         """Exactly one replacement is started; nothing in this module ever calls /resume."""
         profile = _local_profile()
-        with patch.object(rh.subprocess, "Popen", return_value=MagicMock()) as mock_popen:
+        with (
+            patch.object(rh, "get_replacement_log_path", return_value=tmp_path / "req-start-3.server.log"),
+            patch.object(rh.subprocess, "Popen", return_value=MagicMock()) as mock_popen,
+        ):
             rh._start_replacement(profile, tmp_path, nonce="n", request_id="req-start-3")
 
         mock_popen.assert_called_once()

--- a/backend/tests/unit/test_restart_protocol.py
+++ b/backend/tests/unit/test_restart_protocol.py
@@ -20,6 +20,7 @@ from backend.services.dev_restart.restart_protocol import (
     RestartTimeouts,
     acquire_restart_lock,
     get_dev_restart_dir,
+    get_replacement_log_path,
     get_request_paths,
     get_restart_lock_path,
     get_restart_log_path,
@@ -53,6 +54,9 @@ class TestPaths:
 
     def test_restart_log_path(self, tmp_path: Path) -> None:
         assert get_restart_log_path() == tmp_path / "dev-restart" / "restart.log"
+
+    def test_replacement_log_path(self, tmp_path: Path) -> None:
+        assert get_replacement_log_path("req-123") == tmp_path / "dev-restart" / "req-123.server.log"
 
     def test_restart_lock_path(self, tmp_path: Path) -> None:
         assert get_restart_lock_path() == tmp_path / "dev-restart" / "restart.lock"
@@ -101,6 +105,31 @@ class TestRotateRestartLog:
         siblings = list(log_path.parent.glob("restart.log*"))
         assert siblings == [backup_path]
 
+    def test_rotation_raises_restart_protocol_error_when_replace_fails(self, tmp_path: Path) -> None:
+        log_path = get_restart_log_path()
+        log_path.write_bytes(b"z" * 2048)
+
+        with (
+            patch("pathlib.Path.replace", side_effect=PermissionError("file is locked")),
+            pytest.raises(RestartProtocolError, match="could not rotate"),
+        ):
+            rotate_restart_log_if_needed(log_path, max_bytes=1024)
+
+    def test_rotation_succeeds_while_replacement_uses_different_log_file(self, tmp_path: Path) -> None:
+        log_path = get_restart_log_path()
+        replacement_log_path = get_replacement_log_path("req-123")
+        log_path.write_bytes(b"q" * 2048)
+        replacement_log_path.write_text("replacement still running\n", encoding="utf-8")
+
+        with replacement_log_path.open("a", encoding="utf-8") as replacement_log_handle:
+            replacement_log_handle.write("more output\n")
+            replacement_log_handle.flush()
+            rotate_restart_log_if_needed(log_path, max_bytes=1024)
+
+        assert not log_path.exists()
+        assert log_path.with_name("restart.log.1").read_bytes() == b"q" * 2048
+        assert replacement_log_path.read_text(encoding="utf-8") == "replacement still running\nmore output\n"
+
 
 class TestRestartTimeouts:
     def test_defaults_match_spec(self) -> None:
@@ -109,7 +138,7 @@ class TestRestartTimeouts:
         assert timeouts.response_grace_seconds == 2.0
         assert timeouts.pause_wait_seconds == 10.0
         assert timeouts.stop_seconds == 15.0
-        assert timeouts.readiness_seconds == 120.0
+        assert timeouts.readiness_seconds == 60.0
         assert timeouts.remote_probe_seconds == 30.0
 
     def test_roundtrip(self) -> None:

--- a/backend/tests/unit/test_restart_protocol.py
+++ b/backend/tests/unit/test_restart_protocol.py
@@ -109,7 +109,7 @@ class TestRestartTimeouts:
         assert timeouts.response_grace_seconds == 2.0
         assert timeouts.pause_wait_seconds == 10.0
         assert timeouts.stop_seconds == 15.0
-        assert timeouts.readiness_seconds == 60.0
+        assert timeouts.readiness_seconds == 120.0
         assert timeouts.remote_probe_seconds == 30.0
 
     def test_roundtrip(self) -> None:

--- a/backend/tests/unit/test_setup_service.py
+++ b/backend/tests/unit/test_setup_service.py
@@ -386,9 +386,6 @@ class TestValidatePreflight:
             hint="Unable to verify authentication",
             category="agent",
         )
-        config_path = tmp_path / "config.yaml"
-        config_path.write_text("runtime:\n  default_sdk: copilot\n", encoding="utf-8")
-
         with (
             patch("backend.services.setup.service.load_config", return_value=CPLConfig()),
             patch("backend.services.setup.service.verify_requirements", return_value=[warning]),

--- a/backend/tests/unit/test_setup_service.py
+++ b/backend/tests/unit/test_setup_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import errno
 from unittest.mock import patch
 
+from backend.config import CPLConfig
 from backend.services.setup.checks import (
     AgentAuthStatus,
     AgentCLIStatus,
@@ -21,6 +22,7 @@ from backend.services.setup.checks import (
 from backend.services.setup.service import (
     _offer_inline_fix,
     _should_prompt_for_warning,
+    validate_preflight,
 )
 from backend.services.setup.wizard import (
     _get_env_persistence_instructions,
@@ -373,6 +375,79 @@ class TestPromptSuppression:
             "copilot", "GitHub Copilot", False, False, False, "not installed", "Install: uv add github-copilot-sdk"
         )
         assert _should_prompt_for_warning(warning, "copilot", ["claude"]) is True
+
+
+class TestValidatePreflight:
+    def test_non_interactive_warning_continues_without_prompt(self, tmp_path) -> None:
+        warning = CheckResult(
+            label="Claude Code",
+            status=CheckStatus.warn,
+            detail="claude CLI installed (auth unknown)",
+            hint="Unable to verify authentication",
+            category="agent",
+        )
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("runtime:\n  default_sdk: copilot\n", encoding="utf-8")
+
+        with (
+            patch("backend.services.setup.service.load_config", return_value=CPLConfig()),
+            patch("backend.services.setup.service.verify_requirements", return_value=[warning]),
+            patch("backend.services.setup.service._render_check_line"),
+            patch("backend.services.setup.service.get_codeplane_dir", return_value=tmp_path),
+            patch("backend.services.setup.service._offer_inline_fix") as mock_offer,
+            patch("sys.stdin.isatty", return_value=False),
+            patch("sys.stdout.isatty", return_value=False),
+        ):
+            assert validate_preflight(8080) is True
+
+        mock_offer.assert_not_called()
+
+    def test_interactive_warning_still_uses_existing_prompt_flow(self, tmp_path) -> None:
+        warning = CheckResult(
+            label="Claude Code",
+            status=CheckStatus.warn,
+            detail="claude CLI installed (auth unknown)",
+            hint="Unable to verify authentication",
+            category="agent",
+        )
+
+        with (
+            patch("backend.services.setup.service.load_config", return_value=CPLConfig()),
+            patch("backend.services.setup.service.verify_requirements", side_effect=[[warning], [warning]]),
+            patch("backend.services.setup.service._render_check_line"),
+            patch("backend.services.setup.service.get_codeplane_dir", return_value=tmp_path),
+            patch("backend.services.setup.service._offer_inline_fix", return_value="continued") as mock_offer,
+            patch("sys.stdin.isatty", return_value=True),
+            patch("sys.stdout.isatty", return_value=True),
+        ):
+            assert validate_preflight(8080) is True
+
+        mock_offer.assert_called_once_with(warning)
+
+    def test_interactive_prompt_abort_semantics_are_unchanged(self, tmp_path) -> None:
+        warning = CheckResult(
+            label="Claude Code",
+            status=CheckStatus.warn,
+            detail="claude CLI installed (auth unknown)",
+            hint="Unable to verify authentication",
+            category="agent",
+        )
+
+        with (
+            patch("backend.services.setup.service.load_config", return_value=CPLConfig()),
+            patch("backend.services.setup.service.verify_requirements", return_value=[warning]),
+            patch("backend.services.setup.service._render_check_line"),
+            patch("backend.services.setup.service.get_codeplane_dir", return_value=tmp_path),
+            patch("backend.services.setup.service._offer_inline_fix", side_effect=SystemExit(1)),
+            patch("sys.stdin.isatty", return_value=True),
+            patch("sys.stdout.isatty", return_value=True),
+        ):
+            try:
+                validate_preflight(8080)
+            except SystemExit as exc:
+                assert exc.code == 1
+            else:
+                raise AssertionError("Expected SystemExit")
 
 
 # ---------------------------------------------------------------------------

--- a/tools/dev_restart.py
+++ b/tools/dev_restart.py
@@ -77,9 +77,7 @@ def resolve_target_source_root(source: str | None) -> Path:
     root = Path(source).expanduser().resolve() if source else REPO_ROOT
     missing = [marker for marker in _CHECKOUT_MARKERS if not (root / marker).is_file()]
     if missing:
-        raise DevRestartError(
-            f"{root} does not look like a CodePlane checkout (missing: {', '.join(missing)})"
-        )
+        raise DevRestartError(f"{root} does not look like a CodePlane checkout (missing: {', '.join(missing)})")
     return root
 
 
@@ -245,9 +243,7 @@ def _resolve_timeouts(args: argparse.Namespace) -> RestartTimeouts:
     return RestartTimeouts(
         adoption_seconds=args.adoption_seconds if args.adoption_seconds is not None else defaults.adoption_seconds,
         response_grace_seconds=(
-            args.response_grace_seconds
-            if args.response_grace_seconds is not None
-            else defaults.response_grace_seconds
+            args.response_grace_seconds if args.response_grace_seconds is not None else defaults.response_grace_seconds
         ),
         pause_wait_seconds=(
             args.pause_wait_seconds if args.pause_wait_seconds is not None else defaults.pause_wait_seconds

--- a/tools/dev_restart.py
+++ b/tools/dev_restart.py
@@ -316,12 +316,11 @@ def run_parent(args: argparse.Namespace) -> int:
 
     try:
         paths, request_id, timeouts = prepare_restart_request(args)
+        log_path = get_restart_log_path()
+        rotate_restart_log_if_needed(log_path)
     except (DevRestartError, RestartProtocolError) as exc:
         print(f"\n✗ Restart preparation failed: {exc}\n  The current server has NOT been restarted.\n", file=sys.stderr)
         return 1
-
-    log_path = get_restart_log_path()
-    rotate_restart_log_if_needed(log_path)
     print(f"[4/4] Spawning detached restart helper (log: {log_path})…")
     try:
         with open(log_path, "a", encoding="utf-8") as log_handle:

--- a/tools/dev_restart.py
+++ b/tools/dev_restart.py
@@ -46,6 +46,13 @@ if sys.platform == "win32":
 REPO_ROOT = Path(__file__).resolve().parent.parent
 FRONTEND_DIR = REPO_ROOT / "frontend"
 
+# Running ``python tools/dev_restart.py`` sets ``sys.path[0]`` to the tools
+# directory, not the repository root. Put the checkout root on sys.path so the
+# script and the detached helper can import ``backend.*`` without depending on
+# the caller to have launched it as a module.
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 # Marker files a directory must contain to be treated as a native CodePlane
 # checkout (AC 1) — cheap, no-import structural check before any subprocess
 # or profile validation runs against it.
@@ -186,6 +193,10 @@ def build_frontend(frontend_dir: Path = FRONTEND_DIR) -> bool:
     available (Story 1.2 AC 2) -- always before helper spawn, pause, or stop.
     """
     npm = _resolve_npm_command()
+    if not (frontend_dir / "node_modules").is_dir():
+        install = subprocess.run([npm, "ci"], cwd=frontend_dir)
+        if install.returncode != 0:
+            return False
     result = subprocess.run([npm, "run", "build"], cwd=frontend_dir)
     return result.returncode == 0
 


### PR DESCRIPTION
## Summary
- skip inline preflight prompts when stdin/stdout are not both TTYs
- make `tools/dev_restart.py` importable when run directly and install frontend deps before restart builds when needed
- replay replacement startup with inherited restart-log streams and `--skip-preflight` so the helper can complete bounded restarts on Windows

## Validation
- `uv run --active pytest backend/tests/unit/test_setup_service.py backend/tests/unit/test_dev_restart.py backend/tests/unit/test_restart_helper.py -q`

## Notes
- This PR was opened during isolated live self-restart verification; manual runtime verification is still in progress on this branch.
- Do not merge until Ubuntu Backend CI is green and the isolated live restart rerun is confirmed.