### PR TITLE
feat: Story 3.1 - Register a Credential (Settings > Integrations)

### DIFF
--- a/_bmad-output/implementation-artifacts/3-1-register-a-credential.md
+++ b/_bmad-output/implementation-artifacts/3-1-register-a-credential.md
@@ -1,0 +1,118 @@
+---
+baseline_commit: bbf31746
+---
+
+# Story 3.1: Register a Credential
+
+Status: review
+
+## Story
+
+As a CodePlane user,
+I want to register a provider account (Jira, Azure DevOps, or GitHub Projects) once,
+So that I don't have to re-enter credentials for every Project that needs it.
+
+## Acceptance Criteria
+
+1. **Given** the Settings > Integrations screen, **when** I enter a provider, label, base URL, and PAT, **then** a `CredentialRow` is created with the PAT encrypted at rest, **and** the PAT is never rendered in plaintext after save, never logged, and never included in any agent-facing job prompt/context (NFR1).
+2. **Given** an existing Credential is referenced by one or more TrackerLinks, **when** I attempt to delete it, **then** the deletion is blocked until all referencing TrackerLinks are removed.
+
+## Tasks / Subtasks
+
+- [x] Task 1: Add the `Credential` persistence contract (AC: 1, 2)
+  - [x] Add `CredentialRow` ORM model (`backend/models/db.py`): id, provider, label, base_url, encrypted_secret, created_at.
+  - [x] Add a minimal `TrackerLinkRow` ORM model (project_id as a plain, non-FK string column — deliberately decoupled from a `Project` entity, which does not exist yet) so AC2's referential-integrity rule has something real to enforce. No attach/detach endpoints for TrackerLink are added; that is Story 3.2 scope.
+  - [x] Add Alembic migration `alembic/versions/0058_add_credentials.py` creating `credentials` and `tracker_links` tables on top of `0057`.
+- [x] Task 2: Implement PAT encryption at rest (AC: 1, NFR1/NFR9)
+  - [x] Add `backend/services/credentials/encryption.py` using `cryptography.fernet.Fernet` (already a locked dependency; no new package added).
+  - [x] Auto-generate and persist a Fernet key at `get_codeplane_dir() / "credential.key"` on first use; best-effort `chmod 0600` wrapped in `contextlib.suppress(OSError)` for platforms without POSIX permission bits.
+  - [x] Provide `encrypt_secret`/`decrypt_secret` plus a `CredentialDecryptionError` for corrupt/foreign-key ciphertext.
+- [x] Task 3: Implement `CredentialRepository` (AC: 1, 2)
+  - [x] `backend/persistence/credential_repo.py` following the existing `PolicyRepository` shared-session pattern (`BaseRepository`, `async_sessionmaker[AsyncSession]` via `FromDishka`).
+  - [x] `list_all()`/`get()` never include `encrypted_secret` in returned dicts (not just omitted from the response schema) — the plaintext PAT never leaves the encryption boundary except via `resolve_secret()`, which no Story 3.1 route calls.
+  - [x] `create()` encrypts the PAT before persisting.
+  - [x] `delete()` raises `CredentialReferencedError` when any `TrackerLinkRow` still references the credential; the API translates this to `409 Conflict`.
+- [x] Task 4: Implement the `/settings/credentials` API (AC: 1, 2)
+  - [x] `backend/api/credentials.py`: thin `DishkaRoute`-style router — `GET` (list, secret-free), `GET /guidance` (static per-provider NFR9 guidance text for github/jira/azure_devops), `POST` (create, 201), `DELETE /{id}` (204, 409 if referenced, 404 if missing).
+  - [x] `CamelModel`-based schemas: `CredentialResponse`, `CredentialListResponse`, `CreateCredentialRequest`, `ProviderGuidanceResponse`. Provider is constrained by regex `^(github|jira|azure_devops)$`.
+  - [x] Mount the router in `backend/app_factory.py` (production) and `backend/tests/integration/conftest.py` (test app fixture).
+  - [x] Structured log events (`credential.created`, `credential.deleted`, etc.) never include the PAT/secret field.
+- [x] Task 5: Author comprehensive tests (AC: 1, 2)
+  - [x] `backend/tests/unit/test_credential_encryption.py` — round-trip encrypt/decrypt, key persistence/reuse, corrupt-ciphertext error.
+  - [x] `backend/tests/unit/test_credential_repo.py` — create/list/get/resolve_secret, delete blocked while a `TrackerLinkRow` references the credential, delete succeeds after the link is removed.
+  - [x] `backend/tests/integration/test_api_credentials.py` — list/guidance/create/delete endpoint contracts, including the 409 blocked-delete path via a `TrackerLinkRow` fixture, and asserting list/get responses never contain the secret.
+- [x] Task 6: Build the Settings > Integrations UI (AC: 1, 2)
+  - [x] `frontend/src/api/client.ts` — add `Credential`, `CreateCredentialRequest`, `CredentialProvider` types and `fetchCredentials`/`fetchCredentialGuidance`/`createCredential`/`deleteCredential` functions, following the existing hand-written-interface precedent already used for `PolicyState`/`UsdCeiling` in this file (rather than OpenAPI-schema generation, which requires a running backend).
+  - [x] `frontend/src/components/IntegrationsSettings.tsx` — provider picker with live NFR9 guidance text, register form (label/base URL/PAT), credential list (never renders the secret), delete flow gated by `ConfirmDialog`.
+  - [x] Wire `IntegrationsSettings` into `frontend/src/components/SettingsScreen.tsx` after `PolicySettingsPanel`.
+  - [x] `frontend/src/components/__tests__/IntegrationsSettings.test.tsx` — empty state, list rendering without ever showing a secret, guidance display + create submission, missing-field validation toast, delete confirm-dialog flow. Uses `fireEvent` per project test convention (not `@testing-library/user-event`, which is not a project dependency).
+
+## Dev Notes
+
+### Implementation Boundary
+
+This story implements only the global, Project-independent `Credential` entity and its registration/deletion UI and API. It explicitly does **not** implement:
+
+- The `Project` entity (Epic 2/elsewhere) — Credential registration must not block on Project existing.
+- Story 3.2 (attaching a `TrackerLink` to a Project) — no attach/create/list endpoints for `TrackerLink` exist yet. `TrackerLinkRow` is schema-only in this story, added solely so AC2's delete-blocked-while-referenced rule has a real referential check to enforce.
+- Tracker polling/sync, write-back approval flows, or any use of `CredentialRepository.resolve_secret()` by a tracker adapter (out of scope; NFR2/NFR3/FR7 belong to later stories in Epic 3).
+
+### Architecture Compliance
+
+- Thin routes: `backend/api/credentials.py` validates input and delegates to `CredentialRepository`; no orchestration logic lives in the route handlers.
+- All database access goes through `CredentialRepository` in `backend/persistence/`; no direct SQLAlchemy session usage in the API layer.
+- Response models use the `CamelModel` base class for camelCase serialization, matching the rest of the API contract.
+- `CredentialRow.encrypted_secret` is never included in any repository read path that could reach a response model; `resolve_secret()` is a separate, unused-by-this-story method reserved for a future tracker adapter (AD-6/CAP-6/CAP-7).
+- Encryption uses the already-locked `cryptography` dependency (Fernet symmetric encryption); no new dependency was added.
+
+### References
+
+- [Source: `_bmad-output/planning-artifacts/epics.md#Story-31-Register-a-Credential`]
+- [Source: `_bmad-output/specs/spec-project-boards/SPEC.md` CAP-6, CAP-7, NFR1, NFR9]
+- [Source: `_bmad-output/planning-artifacts/architecture/*/ARCHITECTURE-SPINE.md` AD-6 (Credential/TrackerLink separation, encrypted-at-rest PAT storage)]
+- [Source: `backend/services/policy_settings.py`, `backend/persistence/` `PolicyRepository` — repository/route pattern precedent]
+- [Source: `frontend/src/api/client.ts` `PolicyState`/`UsdCeiling` — hand-written settings-adjacent type precedent]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Claude Sonnet 5 (GitHub Copilot CLI).
+
+### Debug Log References
+
+- Backend: `uv run pytest` could not be used in this worktree because `uv sync` fails to fetch `traceforge-toolkit==0.1.5` from PyPI (TLS handshake failure in this sandbox). Ran tests/lint instead via the main checkout's pre-built venv: `C:\Users\davidfinson\.copilot\repos\codeplane\.venv\Scripts\python.exe -m pytest ...` / `... -m ruff check ...`, invoked from within this worktree so the tests exercise this branch's code.
+- `pytest backend/tests/unit/test_credential_encryption.py backend/tests/unit/test_credential_repo.py backend/tests/integration/test_api_credentials.py -q` → 24 passed.
+- `ruff check` on all new/modified backend files → all checks passed (8 pre-existing lint issues found and fixed during development: UP037, SIM105, TC003 x-several, E501).
+- A full-repository `pytest backend/tests -q` run could not be completed to 100% in this sandbox: it consistently hangs partway through (observed at ~46-48%, in modules unrelated to this change, e.g. `test_persistence_repos.py`/job-service-adjacent async mocks) due to a pre-existing Windows/asyncio event-loop interaction in this environment, reproducible even with `pytest-timeout` (`--timeout`, thread method) and independent of this story's changes. Confirmed pre-existing and unrelated by: (a) reproducing one scattered pre-existing failure (`test_api_settings.py::TestGetRepoDetail::test_registered_repo`) on a `git stash`-clean tree without any Story 3.1 changes; (b) running the new credential tests together with the immediately-surrounding alphabetical test modules (`test_persistence_repos.py`, `test_permission_policy.py`) in isolation — `68 passed` with no hang. Regression risk from this story's `CredentialRow`/`TrackerLinkRow` additions to `Base.metadata` is assessed as low: both are new, disconnected tables (no FKs to existing entities) and every touched/adjacent module was verified to pass directly.
+- Frontend: `npx vitest run IntegrationsSettings` → 5 passed. `npx vitest run SettingsScreen` (regression check for the new component wired into the existing screen) → 5 passed, no regressions. `npx tsc --noEmit` → clean. `npx eslint` on all touched frontend files → clean.
+
+### Completion Notes List
+
+- Implemented the global `Credential` entity (provider/label/base_url/encrypted PAT) exactly as scoped: independent of `Project`, which does not exist in the codebase yet, per explicit story guidance.
+- PAT is encrypted at rest with Fernet; plaintext never returned by any list/get read path, never logged (structured log events explicitly omit the secret field), and never included in agent-facing job context (no code path connects `CredentialRepository.resolve_secret()` to job/prompt construction in this story).
+- Added a minimal, FK-decoupled `TrackerLinkRow` purely to give AC2's "delete blocked while referenced" rule a real referential check; no TrackerLink attach/list/detach API exists yet (Story 3.2).
+- Followed existing repository/route/schema conventions (`PolicyRepository`, `CamelModel`, thin `DishkaRoute`-style handlers) and existing frontend hand-written-type precedent (`PolicyState`/`UsdCeiling` in `client.ts`) rather than introducing new patterns.
+- Full backend regression suite could not be run to completion in this sandbox due to a pre-existing, unrelated environment hang (see Debug Log References); targeted and adjacent-module test runs show no regressions from this change.
+
+### File List
+
+- `backend/models/db.py` (modified — added `CredentialRow`, `TrackerLinkRow`)
+- `backend/services/credentials/__init__.py` (new)
+- `backend/services/credentials/encryption.py` (new)
+- `backend/persistence/credential_repo.py` (new)
+- `backend/api/credentials.py` (new)
+- `backend/app_factory.py` (modified — mounted `credentials` router)
+- `backend/tests/integration/conftest.py` (modified — mounted `credentials` router in test app fixture)
+- `alembic/versions/0058_add_credentials.py` (new)
+- `backend/tests/unit/test_credential_encryption.py` (new)
+- `backend/tests/unit/test_credential_repo.py` (new)
+- `backend/tests/integration/test_api_credentials.py` (new)
+- `frontend/src/api/client.ts` (modified — added Credential types/functions)
+- `frontend/src/components/IntegrationsSettings.tsx` (new)
+- `frontend/src/components/SettingsScreen.tsx` (modified — wired in `IntegrationsSettings`)
+- `frontend/src/components/__tests__/IntegrationsSettings.test.tsx` (new)
+
+## Change Log
+
+- 2026-08-10: Implemented Story 3.1 (Register a Credential) end-to-end: backend `CredentialRow`/`TrackerLinkRow` models, migration, Fernet-based encryption service, `CredentialRepository`, `/settings/credentials` API, and the Settings > Integrations frontend panel with full test coverage. Status set to `review`.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -67,7 +67,7 @@ development_status:
   epic-2-retrospective: optional
 
   epic-3: backlog
-  3-1-register-a-credential: backlog
+  3-1-register-a-credential: review
   3-2-attach-a-trackerlink-to-a-project: backlog
   3-3-view-synced-ticket-state: backlog
   3-4-approve-a-tracker-write-back: backlog

--- a/alembic/versions/0058_add_credentials.py
+++ b/alembic/versions/0058_add_credentials.py
@@ -1,0 +1,49 @@
+"""Add credentials and tracker_links tables (Story 3.1, AD-6).
+
+``credentials`` is a global, Project-independent table for registered
+integration accounts (provider, label, base_url, PAT encrypted at rest by the
+application, never in this migration or in plaintext). ``tracker_links`` is
+added as the referential-integrity anchor Story 3.1's delete-blocked-while-
+referenced rule needs (AC2); ``project_id`` is a plain string column, not a
+foreign key, since the Project entity does not exist yet. No data is attached
+to ``tracker_links`` by this story — that is Story 3.2's scope.
+
+Revision ID: 0058
+Revises: 0057
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0058"
+down_revision = "0057"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "credentials",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("provider", sa.String(32), nullable=False),
+        sa.Column("label", sa.String(), nullable=False),
+        sa.Column("base_url", sa.String(), nullable=False),
+        sa.Column("encrypted_secret", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.Text(), nullable=False),
+    )
+    op.create_table(
+        "tracker_links",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("project_id", sa.String(), nullable=False),
+        sa.Column("credential_id", sa.String(), sa.ForeignKey("credentials.id"), nullable=False),
+        sa.Column("external_ref", sa.String(), nullable=False),
+        sa.Column("created_at", sa.Text(), nullable=False),
+    )
+    op.create_index("ix_tracker_links_credential_id", "tracker_links", ["credential_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_tracker_links_credential_id", table_name="tracker_links")
+    op.drop_table("tracker_links")
+    op.drop_table("credentials")

--- a/alembic/versions/0059_add_credentials.py
+++ b/alembic/versions/0059_add_credentials.py
@@ -8,16 +8,16 @@ referenced rule needs (AC2); ``project_id`` is a plain string column, not a
 foreign key, since the Project entity does not exist yet. No data is attached
 to ``tracker_links`` by this story — that is Story 3.2's scope.
 
-Revision ID: 0058
-Revises: 0057
+Revision ID: 0059
+Revises: 0058
 """
 
 import sqlalchemy as sa
 
 from alembic import op
 
-revision = "0058"
-down_revision = "0057"
+revision = "0059"
+down_revision = "0058"
 branch_labels = None
 depends_on = None
 

--- a/backend/api/credentials.py
+++ b/backend/api/credentials.py
@@ -1,0 +1,128 @@
+"""Global integration Credential API (Story 3.1, CAP-6/CAP-7).
+
+Register once, in Settings > Integrations, independent of any Project
+(AD-6). No route in this module ever returns a decrypted or encrypted
+secret — list/get/create responses expose only provider/label/base_url/id/
+created_at.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import structlog
+from dishka.integrations.fastapi import DishkaRoute, FromDishka
+from fastapi import APIRouter, HTTPException
+from pydantic import Field
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from backend.models.schemas.base import CamelModel
+from backend.persistence.credential_repo import CredentialReferencedError, CredentialRepository
+
+router = APIRouter(prefix="/settings/credentials", tags=["credentials"], route_class=DishkaRoute)
+log = structlog.get_logger()
+
+_PROVIDER_PATTERN = r"^(github|jira|azure_devops)$"
+
+# NFR9: per-provider PAT scope guidance, copy-paste only — never validated/enforced
+# against TrackerLinks, since a Credential is deliberately global and reusable.
+_PROVIDER_GUIDANCE: dict[str, str] = {
+    "github": (
+        "Use a fine-grained personal access token. Scope it to the repos you need: "
+        "'Issues: Read & write' for tracker writes; add 'Contents: Read & write' + "
+        "'Pull requests: Read & write' if PR creation will also be used. A scope broader "
+        "than any single TrackerLink is expected, since this Credential may be attached "
+        "to multiple Projects over time."
+    ),
+    "jira": (
+        "Jira API tokens cannot be scoped down further than the full account — the token "
+        "inherits every permission the account has. The codeplane_approval write-back gate, "
+        "not token scope, is the real security boundary here."
+    ),
+    "azure_devops": (
+        "Azure DevOps personal access tokens are organization-scoped, not project-scoped: "
+        "scope to 'Work Items: Read & write' for tracker writes and 'Code: Read & write' for "
+        "PR creation. One token covers every project in that org regardless of which project "
+        "a TrackerLink references — again, the approval gate is the actual security boundary."
+    ),
+}
+
+
+class CredentialResponse(CamelModel):
+    id: str
+    provider: str
+    label: str
+    base_url: str
+    created_at: str
+
+
+class CredentialListResponse(CamelModel):
+    credentials: list[CredentialResponse] = Field(default_factory=list)
+
+
+class CreateCredentialRequest(CamelModel):
+    provider: str = Field(pattern=_PROVIDER_PATTERN)
+    label: str = Field(min_length=1)
+    base_url: str = Field(min_length=1)
+    pat: str = Field(min_length=1)
+
+
+class ProviderGuidanceResponse(CamelModel):
+    guidance: dict[str, str] = Field(default_factory=dict)
+
+
+def _to_response(data: dict[str, Any]) -> CredentialResponse:
+    return CredentialResponse(**data)
+
+
+@router.get("", response_model=CredentialListResponse)
+async def list_credentials(sf: FromDishka[async_sessionmaker[AsyncSession]]) -> CredentialListResponse:
+    async with sf() as session:
+        repo = CredentialRepository(session)
+        rows = await repo.list_all()
+    return CredentialListResponse(credentials=[_to_response(r) for r in rows])
+
+
+@router.get("/guidance", response_model=ProviderGuidanceResponse)
+async def get_provider_guidance() -> ProviderGuidanceResponse:
+    """Return per-provider PAT scope guidance (NFR9). Static, no DB access."""
+    return ProviderGuidanceResponse(guidance=_PROVIDER_GUIDANCE)
+
+
+@router.post("", response_model=CredentialResponse, status_code=201)
+async def create_credential(
+    body: CreateCredentialRequest,
+    sf: FromDishka[async_sessionmaker[AsyncSession]],
+) -> CredentialResponse:
+    credential_id = str(uuid.uuid4())
+    async with sf() as session:
+        repo = CredentialRepository(session)
+        result = await repo.create(
+            credential_id=credential_id,
+            provider=body.provider,
+            label=body.label,
+            base_url=body.base_url,
+            pat=body.pat,
+        )
+        await session.commit()
+    # Never log the PAT itself — only non-secret identifying fields (NFR1).
+    log.info("credential.created", credential_id=credential_id, provider=body.provider, label=body.label)
+    return _to_response(result)
+
+
+@router.delete("/{credential_id}", status_code=204)
+async def delete_credential(
+    credential_id: str,
+    sf: FromDishka[async_sessionmaker[AsyncSession]],
+) -> None:
+    async with sf() as session:
+        repo = CredentialRepository(session)
+        try:
+            deleted = await repo.delete(credential_id)
+        except CredentialReferencedError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        if not deleted:
+            raise HTTPException(status_code=404, detail="Credential not found")
+        await session.commit()
+    log.info("credential.deleted", credential_id=credential_id)

--- a/backend/app_factory.py
+++ b/backend/app_factory.py
@@ -30,6 +30,7 @@ from backend.api import (
     approvals,
     artifacts,
     chats,
+    credentials,
     events,
     health,
     hooks,
@@ -220,6 +221,7 @@ def _register_routes(app: FastAPI) -> None:
     app.include_router(trail.router, prefix="/api")
     # Action policy settings
     app.include_router(policy_settings.router, prefix="/api")
+    app.include_router(credentials.router, prefix="/api")
     app.include_router(metrics.router, prefix="/api")
     app.include_router(sidecar_templates.router, prefix="/api")
     app.include_router(chats.router, prefix="/api")

--- a/backend/models/db.py
+++ b/backend/models/db.py
@@ -497,6 +497,52 @@ class MCPServerConfigRow(Base):
     created_at: Mapped[str] = mapped_column(Text, nullable=False)
 
 
+# ---------------------------------------------------------------------------
+# Tracker integration tables (CAP-6/CAP-7, AD-6)
+# ---------------------------------------------------------------------------
+
+
+class CredentialRow(Base):
+    """A global, Project-independent integration credential (Story 3.1, AD-6).
+
+    Registered once in Settings > Integrations and referenced by any number of
+    ``TrackerLinkRow``s. ``encrypted_secret`` holds the PAT encrypted at rest
+    via ``backend.services.credentials.encryption`` — never plaintext, never
+    returned by any API response, never logged.
+    """
+
+    __tablename__ = "credentials"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    provider: Mapped[str] = mapped_column(String(32), nullable=False)
+    label: Mapped[str] = mapped_column(String, nullable=False)
+    base_url: Mapped[str] = mapped_column(String, nullable=False)
+    encrypted_secret: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[str] = mapped_column(Text, nullable=False)
+
+
+class TrackerLinkRow(Base):
+    """Many-to-many join between a Project and a Credential (AD-6).
+
+    Only the referential-integrity anchor needed for Story 3.1's
+    delete-blocked-while-referenced rule (AC2) exists here. ``project_id`` is
+    a plain string, deliberately not a foreign key to a ``ProjectRow`` — that
+    entity does not exist yet, and Credential registration (this story) must
+    not depend on Project existing. Attach/create endpoints for this table
+    are out of scope for this story (Story 3.2).
+    """
+
+    __tablename__ = "tracker_links"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    project_id: Mapped[str] = mapped_column(String, nullable=False)
+    credential_id: Mapped[str] = mapped_column(
+        String, ForeignKey("credentials.id"), nullable=False, index=True
+    )
+    external_ref: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[str] = mapped_column(Text, nullable=False)
+
+
 class SidecarTemplateRow(Base):
     __tablename__ = "sidecar_templates"
 

--- a/backend/persistence/credential_repo.py
+++ b/backend/persistence/credential_repo.py
@@ -1,0 +1,78 @@
+"""Persistence for global integration Credentials (Story 3.1, AD-6).
+
+``CredentialRepository`` never returns a decrypted (or encrypted) secret from
+list/get calls used by API responses — only ``resolve_secret`` decrypts, and
+that method exists for future tracker-adapter use (Story 3.3+), not for any
+Story 3.1 route.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import delete, select
+
+from backend.models.db import CredentialRow, TrackerLinkRow
+from backend.persistence.repository import BaseRepository
+from backend.services.credentials.encryption import decrypt_secret, encrypt_secret
+
+
+class CredentialReferencedError(Exception):
+    """Raised when deleting a Credential still referenced by a TrackerLink (AC2)."""
+
+
+class CredentialRepository(BaseRepository):
+    """Database access for global integration Credentials."""
+
+    async def list_all(self) -> list[dict[str, Any]]:
+        result = await self._session.execute(select(CredentialRow).order_by(CredentialRow.created_at))
+        return [_row_to_dict(r) for r in result.scalars()]
+
+    async def get(self, credential_id: str) -> dict[str, Any] | None:
+        result = await self._session.execute(select(CredentialRow).where(CredentialRow.id == credential_id))
+        row = result.scalar_one_or_none()
+        return _row_to_dict(row) if row else None
+
+    async def create(self, *, credential_id: str, provider: str, label: str, base_url: str, pat: str) -> dict[str, Any]:
+        row = CredentialRow(
+            id=credential_id,
+            provider=provider,
+            label=label,
+            base_url=base_url,
+            encrypted_secret=encrypt_secret(pat),
+            created_at=datetime.now(UTC).isoformat(),
+        )
+        self._session.add(row)
+        await self._session.flush()
+        return _row_to_dict(row)
+
+    async def delete(self, credential_id: str) -> bool:
+        """Delete a Credential, blocked while any TrackerLink still references it (AC2)."""
+        ref_result = await self._session.execute(
+            select(TrackerLinkRow.id).where(TrackerLinkRow.credential_id == credential_id).limit(1)
+        )
+        if ref_result.scalar_one_or_none() is not None:
+            raise CredentialReferencedError(
+                f"Credential {credential_id} is still referenced by one or more TrackerLinks"
+            )
+        result = await self._session.execute(delete(CredentialRow).where(CredentialRow.id == credential_id))
+        return result.rowcount > 0
+
+    async def resolve_secret(self, credential_id: str) -> str | None:
+        """Decrypt and return the PAT for server-side use only (never for API responses)."""
+        result = await self._session.execute(select(CredentialRow).where(CredentialRow.id == credential_id))
+        row = result.scalar_one_or_none()
+        if row is None:
+            return None
+        return decrypt_secret(row.encrypted_secret)
+
+
+def _row_to_dict(row: CredentialRow) -> dict[str, Any]:
+    return {
+        "id": row.id,
+        "provider": row.provider,
+        "label": row.label,
+        "base_url": row.base_url,
+        "created_at": row.created_at,
+    }

--- a/backend/services/credentials/__init__.py
+++ b/backend/services/credentials/__init__.py
@@ -1,0 +1,1 @@
+"""Global integration credential services (Story 3.1, CAP-6/CAP-7, AD-6)."""

--- a/backend/services/credentials/encryption.py
+++ b/backend/services/credentials/encryption.py
@@ -1,0 +1,54 @@
+"""PAT encryption-at-rest for global integration Credentials (Story 3.1, NFR1).
+
+A single app-level symmetric key is generated on first use and persisted at
+``get_codeplane_dir() / "credential.key"`` with owner-only permissions where
+supported. Every ``CredentialRow.encrypted_secret`` is a Fernet token produced
+with that key. The key file is developer-machine-local, file-backed
+diagnostic-adjacent state — the same posture as ``run.json`` — and is never
+logged or transmitted.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import stat
+
+from cryptography.fernet import Fernet, InvalidToken
+
+from backend.config import get_codeplane_dir
+
+_KEY_FILENAME = "credential.key"
+
+
+class CredentialDecryptionError(Exception):
+    """Raised when a stored secret cannot be decrypted with the current key."""
+
+
+def _load_or_create_key() -> bytes:
+    path = get_codeplane_dir() / _KEY_FILENAME
+    if path.exists():
+        return path.read_bytes()
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    key = Fernet.generate_key()
+    path.write_bytes(key)
+    with contextlib.suppress(OSError):
+        # Best-effort on platforms without POSIX permission bits (e.g. Windows).
+        os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
+    return key
+
+
+def encrypt_secret(plaintext: str) -> str:
+    """Encrypt a PAT for storage. Returns an opaque token, never the plaintext."""
+    fernet = Fernet(_load_or_create_key())
+    return fernet.encrypt(plaintext.encode("utf-8")).decode("ascii")
+
+
+def decrypt_secret(token: str) -> str:
+    """Decrypt a stored token back to the PAT. Only call this at point of use."""
+    fernet = Fernet(_load_or_create_key())
+    try:
+        return fernet.decrypt(token.encode("ascii")).decode("utf-8")
+    except InvalidToken as exc:
+        raise CredentialDecryptionError("Stored credential secret could not be decrypted") from exc

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -202,6 +202,7 @@ async def app(
         approvals,
         artifacts,
         chats,
+        credentials,
         events,
         health,
         job_artifacts,
@@ -229,6 +230,7 @@ async def app(
     application.include_router(workspace.router, prefix="/api")
     application.include_router(voice.router, prefix="/api")
     application.include_router(settings.router, prefix="/api")
+    application.include_router(credentials.router, prefix="/api")
     application.include_router(share.router, prefix="/api")
     application.include_router(terminal.router, prefix="/api")
     application.include_router(chats.router, prefix="/api")

--- a/backend/tests/integration/test_api_credentials.py
+++ b/backend/tests/integration/test_api_credentials.py
@@ -1,0 +1,155 @@
+"""Integration tests for the global Credential API (Story 3.1).
+
+Exercises:
+  GET    /api/settings/credentials
+  GET    /api/settings/credentials/guidance
+  POST   /api/settings/credentials
+  DELETE /api/settings/credentials/{credential_id}
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from backend.services.credentials import encryption
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from httpx import AsyncClient
+
+
+@pytest.fixture(autouse=True)
+def _isolated_codeplane_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(encryption, "get_codeplane_dir", lambda: tmp_path)
+
+
+class TestListCredentials:
+    @pytest.mark.asyncio
+    async def test_empty_list_initially(self, client: AsyncClient) -> None:
+        resp = await client.get("/api/settings/credentials")
+        assert resp.status_code == 200
+        assert resp.json() == {"credentials": []}
+
+
+class TestProviderGuidance:
+    @pytest.mark.asyncio
+    async def test_returns_guidance_for_all_three_providers(self, client: AsyncClient) -> None:
+        resp = await client.get("/api/settings/credentials/guidance")
+        assert resp.status_code == 200
+        guidance = resp.json()["guidance"]
+        assert set(guidance) == {"github", "jira", "azure_devops"}
+        for text in guidance.values():
+            assert isinstance(text, str)
+            assert text
+
+
+class TestCreateCredential:
+    @pytest.mark.asyncio
+    async def test_create_returns_no_secret_field(self, client: AsyncClient) -> None:
+        resp = await client.post(
+            "/api/settings/credentials",
+            json={
+                "provider": "github",
+                "label": "My GitHub Projects",
+                "baseUrl": "https://api.github.com",
+                "pat": "ghp_sentinel_value_should_never_appear",
+            },
+        )
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["provider"] == "github"
+        assert body["label"] == "My GitHub Projects"
+        assert body["baseUrl"] == "https://api.github.com"
+        assert "id" in body
+        assert "createdAt" in body
+        # No secret/pat field anywhere in the response body.
+        assert "pat" not in body
+        assert "secret" not in body
+        assert "encryptedSecret" not in body
+
+    @pytest.mark.asyncio
+    async def test_created_credential_appears_in_list(self, client: AsyncClient) -> None:
+        await client.post(
+            "/api/settings/credentials",
+            json={"provider": "jira", "label": "Jira", "baseUrl": "https://x.atlassian.net", "pat": "tok"},
+        )
+        resp = await client.get("/api/settings/credentials")
+        creds = resp.json()["credentials"]
+        assert len(creds) == 1
+        assert creds[0]["provider"] == "jira"
+        assert "pat" not in creds[0]
+
+    @pytest.mark.asyncio
+    async def test_rejects_unknown_provider(self, client: AsyncClient) -> None:
+        resp = await client.post(
+            "/api/settings/credentials",
+            json={"provider": "bitbucket", "label": "x", "baseUrl": "https://x", "pat": "p"},
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_pat(self, client: AsyncClient) -> None:
+        resp = await client.post(
+            "/api/settings/credentials",
+            json={"provider": "github", "label": "x", "baseUrl": "https://x", "pat": ""},
+        )
+        assert resp.status_code == 422
+
+
+class TestDeleteCredential:
+    @pytest.mark.asyncio
+    async def test_delete_succeeds_for_unreferenced_credential(self, client: AsyncClient) -> None:
+        created = (
+            await client.post(
+                "/api/settings/credentials",
+                json={"provider": "azure_devops", "label": "ADO", "baseUrl": "https://dev.azure.com/org", "pat": "p"},
+            )
+        ).json()
+
+        resp = await client.delete(f"/api/settings/credentials/{created['id']}")
+        assert resp.status_code == 204
+
+        listed = (await client.get("/api/settings/credentials")).json()["credentials"]
+        assert listed == []
+
+    @pytest.mark.asyncio
+    async def test_delete_returns_404_for_unknown_id(self, client: AsyncClient) -> None:
+        resp = await client.delete("/api/settings/credentials/does-not-exist")
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_delete_blocked_while_referenced_by_tracker_link(
+        self, client: AsyncClient, session_factory: object
+    ) -> None:
+        import uuid
+
+        from backend.models.db import TrackerLinkRow
+
+        created = (
+            await client.post(
+                "/api/settings/credentials",
+                json={"provider": "github", "label": "GH", "baseUrl": "https://api.github.com", "pat": "p"},
+            )
+        ).json()
+
+        async with session_factory() as session:  # type: ignore[operator]
+            session.add(
+                TrackerLinkRow(
+                    id=str(uuid.uuid4()),
+                    project_id="proj-1",
+                    credential_id=created["id"],
+                    external_ref="ORG/1",
+                    created_at="2026-01-01T00:00:00Z",
+                )
+            )
+            await session.commit()
+
+        resp = await client.delete(f"/api/settings/credentials/{created['id']}")
+        assert resp.status_code == 409
+
+        # Still present.
+        listed = (await client.get("/api/settings/credentials")).json()["credentials"]
+        assert len(listed) == 1

--- a/backend/tests/unit/test_credential_encryption.py
+++ b/backend/tests/unit/test_credential_encryption.py
@@ -1,0 +1,57 @@
+"""Unit tests for PAT encryption-at-rest (Story 3.1, NFR1)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from backend.services.credentials import encryption
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _isolated_codeplane_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point the key file at a throwaway directory instead of the real home dir."""
+    monkeypatch.setattr(encryption, "get_codeplane_dir", lambda: tmp_path)
+
+
+class TestEncryptDecryptRoundTrip:
+    def test_round_trip_recovers_plaintext(self) -> None:
+        token = encryption.encrypt_secret("super-secret-pat-value")
+        assert encryption.decrypt_secret(token) == "super-secret-pat-value"
+
+    def test_encrypted_token_never_contains_plaintext(self) -> None:
+        secret = "ghp_representative_sentinel_token_123456"
+        token = encryption.encrypt_secret(secret)
+        assert secret not in token
+
+    def test_key_file_created_on_first_use(self, tmp_path: Path) -> None:
+        assert not (tmp_path / "credential.key").exists()
+        encryption.encrypt_secret("x")
+        assert (tmp_path / "credential.key").exists()
+
+    def test_key_reused_across_calls(self, tmp_path: Path) -> None:
+        token1 = encryption.encrypt_secret("value-one")
+        key_bytes_after_first = (tmp_path / "credential.key").read_bytes()
+        token2 = encryption.encrypt_secret("value-two")
+        key_bytes_after_second = (tmp_path / "credential.key").read_bytes()
+
+        assert key_bytes_after_first == key_bytes_after_second
+        assert encryption.decrypt_secret(token1) == "value-one"
+        assert encryption.decrypt_secret(token2) == "value-two"
+
+
+class TestDecryptionFailure:
+    def test_invalid_token_raises_decryption_error(self) -> None:
+        encryption.encrypt_secret("prime-the-key")  # ensure key exists
+        with pytest.raises(encryption.CredentialDecryptionError):
+            encryption.decrypt_secret("not-a-valid-fernet-token")
+
+    def test_tampered_token_raises_decryption_error(self) -> None:
+        token = encryption.encrypt_secret("original-value")
+        tampered = token[:-4] + ("A" * 4)
+        with pytest.raises(encryption.CredentialDecryptionError):
+            encryption.decrypt_secret(tampered)

--- a/backend/tests/unit/test_credential_repo.py
+++ b/backend/tests/unit/test_credential_repo.py
@@ -1,0 +1,156 @@
+"""Unit tests for CredentialRepository (Story 3.1, AD-6)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from sqlalchemy import event as sa_event
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
+
+from backend.models.db import Base, TrackerLinkRow
+from backend.persistence.credential_repo import CredentialReferencedError, CredentialRepository
+from backend.persistence.database import _set_sqlite_pragmas
+from backend.services.credentials import encryption
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _isolated_codeplane_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(encryption, "get_codeplane_dir", lambda: tmp_path)
+
+
+@pytest.fixture
+async def engine() -> AsyncGenerator[AsyncEngine, None]:
+    eng = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+    sa_event.listen(eng.sync_engine, "connect", _set_sqlite_pragmas)
+    async with eng.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield eng
+    await eng.dispose()
+
+
+@pytest.fixture
+async def session(engine: AsyncEngine) -> AsyncGenerator[AsyncSession, None]:
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+
+
+class TestCreateAndList:
+    @pytest.mark.asyncio
+    async def test_create_persists_encrypted_secret_not_plaintext(self, session: AsyncSession) -> None:
+        repo = CredentialRepository(session)
+        result = await repo.create(
+            credential_id="cred-1",
+            provider="github",
+            label="My GitHub",
+            base_url="https://api.github.com",
+            pat="ghp_sentinel_secret_value",
+        )
+        await session.commit()
+
+        assert result == {
+            "id": "cred-1",
+            "provider": "github",
+            "label": "My GitHub",
+            "base_url": "https://api.github.com",
+            "created_at": result["created_at"],
+        }
+        # No key in the returned dict ever carries the plaintext or the token.
+        assert "pat" not in result
+        assert "secret" not in result
+
+    @pytest.mark.asyncio
+    async def test_list_all_never_exposes_secret(self, session: AsyncSession) -> None:
+        repo = CredentialRepository(session)
+        await repo.create(
+            credential_id="cred-1", provider="jira", label="Jira", base_url="https://x.atlassian.net", pat="tok"
+        )
+        await session.commit()
+
+        rows = await repo.list_all()
+        assert len(rows) == 1
+        assert "encrypted_secret" not in rows[0]
+        assert "pat" not in rows[0]
+
+    @pytest.mark.asyncio
+    async def test_get_returns_none_when_missing(self, session: AsyncSession) -> None:
+        repo = CredentialRepository(session)
+        assert await repo.get("does-not-exist") is None
+
+
+class TestResolveSecret:
+    @pytest.mark.asyncio
+    async def test_resolve_secret_decrypts_original_pat(self, session: AsyncSession) -> None:
+        repo = CredentialRepository(session)
+        await repo.create(
+            credential_id="cred-1", provider="github", label="GH", base_url="https://x", pat="my-real-pat"
+        )
+        await session.commit()
+
+        assert await repo.resolve_secret("cred-1") == "my-real-pat"
+
+    @pytest.mark.asyncio
+    async def test_resolve_secret_returns_none_when_missing(self, session: AsyncSession) -> None:
+        repo = CredentialRepository(session)
+        assert await repo.resolve_secret("nope") is None
+
+
+class TestDelete:
+    @pytest.mark.asyncio
+    async def test_delete_succeeds_when_unreferenced(self, session: AsyncSession) -> None:
+        repo = CredentialRepository(session)
+        await repo.create(credential_id="cred-1", provider="github", label="GH", base_url="https://x", pat="p")
+        await session.commit()
+
+        assert await repo.delete("cred-1") is True
+        assert await repo.get("cred-1") is None
+
+    @pytest.mark.asyncio
+    async def test_delete_returns_false_when_not_found(self, session: AsyncSession) -> None:
+        repo = CredentialRepository(session)
+        assert await repo.delete("nonexistent") is False
+
+    @pytest.mark.asyncio
+    async def test_delete_blocked_while_referenced_by_tracker_link(self, session: AsyncSession) -> None:
+        repo = CredentialRepository(session)
+        await repo.create(credential_id="cred-1", provider="github", label="GH", base_url="https://x", pat="p")
+        session.add(
+            TrackerLinkRow(
+                id="link-1",
+                project_id="proj-1",
+                credential_id="cred-1",
+                external_ref="ORG/board",
+                created_at="2026-01-01T00:00:00Z",
+            )
+        )
+        await session.commit()
+
+        with pytest.raises(CredentialReferencedError):
+            await repo.delete("cred-1")
+
+        # Still present after the blocked attempt.
+        assert await repo.get("cred-1") is not None
+
+    @pytest.mark.asyncio
+    async def test_delete_succeeds_after_referencing_tracker_link_removed(self, session: AsyncSession) -> None:
+        repo = CredentialRepository(session)
+        await repo.create(credential_id="cred-1", provider="github", label="GH", base_url="https://x", pat="p")
+        link = TrackerLinkRow(
+            id="link-1",
+            project_id="proj-1",
+            credential_id="cred-1",
+            external_ref="ORG/board",
+            created_at="2026-01-01T00:00:00Z",
+        )
+        session.add(link)
+        await session.commit()
+
+        await session.delete(link)
+        await session.commit()
+
+        assert await repo.delete("cred-1") is True

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -585,6 +585,46 @@ export function updateUsdCeilings(
   });
 }
 
+// --- Credentials (Story 3.1, global Settings > Integrations) ---
+
+export type CredentialProvider = "github" | "jira" | "azure_devops";
+
+export interface Credential {
+  id: string;
+  provider: CredentialProvider;
+  label: string;
+  baseUrl: string;
+  createdAt: string;
+}
+
+export interface CreateCredentialRequest {
+  provider: CredentialProvider;
+  label: string;
+  baseUrl: string;
+  pat: string;
+}
+
+export function fetchCredentials(): Promise<{ credentials: Credential[] }> {
+  return request("/settings/credentials");
+}
+
+export function fetchCredentialGuidance(): Promise<{ guidance: Record<string, string> }> {
+  return request("/settings/credentials/guidance");
+}
+
+export function createCredential(body: CreateCredentialRequest): Promise<Credential> {
+  return request("/settings/credentials", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+export function deleteCredential(credentialId: string): Promise<void> {
+  return request(`/settings/credentials/${encodeURIComponent(credentialId)}`, {
+    method: "DELETE",
+  });
+}
+
 // --- Operator Messages ---
 
 export function sendOperatorMessage(

--- a/frontend/src/components/IntegrationsSettings.tsx
+++ b/frontend/src/components/IntegrationsSettings.tsx
@@ -1,0 +1,212 @@
+import { useEffect, useState, useCallback } from "react";
+import { Trash2, Plus } from "lucide-react";
+import { toast } from "sonner";
+import {
+  fetchCredentials,
+  fetchCredentialGuidance,
+  createCredential,
+  deleteCredential,
+} from "../api/client";
+import type { Credential, CredentialProvider } from "../api/client";
+import { Button } from "./ui/button";
+import { Input } from "./ui/input";
+import { Label } from "./ui/label";
+import { Spinner } from "./ui/spinner";
+import { ConfirmDialog } from "./ui/confirm-dialog";
+
+const PROVIDERS: Array<{ value: CredentialProvider; label: string }> = [
+  { value: "github", label: "GitHub Projects" },
+  { value: "jira", label: "Jira" },
+  { value: "azure_devops", label: "Azure DevOps" },
+];
+
+/**
+ * Settings > Integrations — global Credential registry (Story 3.1, CAP-6/CAP-7).
+ *
+ * A Credential (provider + label + base URL + PAT) is registered once here,
+ * independent of any Project, and may later be attached to any number of
+ * Projects via a TrackerLink (Story 3.2, not implemented by this screen).
+ * The PAT is write-only: it is sent once on creation and never returned or
+ * rendered by any subsequent read.
+ */
+export function IntegrationsSettings() {
+  const [credentials, setCredentials] = useState<Credential[]>([]);
+  const [guidance, setGuidance] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(true);
+
+  const [provider, setProvider] = useState<CredentialProvider>("github");
+  const [label, setLabel] = useState("");
+  const [baseUrl, setBaseUrl] = useState("");
+  const [pat, setPat] = useState("");
+  const [creating, setCreating] = useState(false);
+
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [credsResp, guidanceResp] = await Promise.all([fetchCredentials(), fetchCredentialGuidance()]);
+      setCredentials(credsResp.credentials);
+      setGuidance(guidanceResp.guidance);
+    } catch (e) {
+      toast.error(String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleCreate = async () => {
+    if (!label.trim() || !baseUrl.trim() || !pat.trim()) {
+      toast.error("Provider, label, base URL, and PAT are all required.");
+      return;
+    }
+    setCreating(true);
+    try {
+      await createCredential({ provider, label: label.trim(), baseUrl: baseUrl.trim(), pat: pat.trim() });
+      setLabel("");
+      setBaseUrl("");
+      setPat("");
+      toast.success("Credential registered.");
+      await load();
+    } catch (e) {
+      toast.error(String(e));
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await deleteCredential(id);
+      toast.success("Credential deleted.");
+      await load();
+    } catch (e) {
+      // Delete is blocked (409) while any TrackerLink still references this Credential.
+      toast.error(String(e));
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="rounded-lg border border-border bg-card p-5">
+        <p className="text-sm font-semibold mb-4">Integrations</p>
+        <div className="flex justify-center py-4">
+          <Spinner />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-5 space-y-5">
+      <div>
+        <p className="text-sm font-semibold">Integrations</p>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          Register a provider account once here — attach it to any Project later via a
+          TrackerLink. The PAT is encrypted at rest and never shown again after saving.
+        </p>
+      </div>
+
+      {/* Registered credentials */}
+      <div className="space-y-2">
+        {credentials.length === 0 && (
+          <p className="text-xs text-muted-foreground">No credentials registered yet.</p>
+        )}
+        {credentials.map((cred) => (
+          <div
+            key={cred.id}
+            className="flex items-center justify-between rounded-md border border-border px-3 py-2 text-xs"
+          >
+            <div>
+              <span className="font-medium">{cred.label}</span>
+              <span className="text-muted-foreground ml-2 capitalize">
+                {cred.provider.replace("_", " ")}
+              </span>
+              <p className="text-muted-foreground">{cred.baseUrl}</p>
+            </div>
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label={`Delete ${cred.label}`}
+              onClick={() => setPendingDeleteId(cred.id)}
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </div>
+        ))}
+      </div>
+
+      {/* Register a new credential */}
+      <div className="space-y-2 border-t border-border pt-4">
+        <Label>Provider</Label>
+        <div className="grid gap-2 sm:grid-cols-3">
+          {PROVIDERS.map((p) => (
+            <button
+              key={p.value}
+              onClick={() => setProvider(p.value)}
+              className={`text-left rounded-md border px-3 py-2 text-xs transition-colors ${
+                provider === p.value
+                  ? "border-primary bg-primary/10 text-primary"
+                  : "border-border bg-background text-foreground hover:bg-muted"
+              }`}
+            >
+              {p.label}
+            </button>
+          ))}
+        </div>
+        {guidance[provider] && (
+          <p className="text-xs text-muted-foreground">{guidance[provider]}</p>
+        )}
+
+        <div className="space-y-1.5">
+          <Label htmlFor="credential-label">Label</Label>
+          <Input
+            id="credential-label"
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            placeholder="e.g. Personal GitHub"
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="credential-base-url">Base URL</Label>
+          <Input
+            id="credential-base-url"
+            value={baseUrl}
+            onChange={(e) => setBaseUrl(e.target.value)}
+            placeholder="https://api.github.com"
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="credential-pat">Personal Access Token</Label>
+          <Input
+            id="credential-pat"
+            type="password"
+            value={pat}
+            onChange={(e) => setPat(e.target.value)}
+            placeholder="•••••••••"
+          />
+        </div>
+        <Button onClick={handleCreate} disabled={creating} className="mt-1">
+          <Plus className="h-4 w-4 mr-1" />
+          {creating ? "Registering…" : "Register Credential"}
+        </Button>
+      </div>
+
+      <ConfirmDialog
+        open={pendingDeleteId !== null}
+        onClose={() => setPendingDeleteId(null)}
+        onConfirm={async () => {
+          if (pendingDeleteId) await handleDelete(pendingDeleteId);
+        }}
+        title="Delete Credential"
+        description="Deleting a Credential still referenced by a TrackerLink will be rejected. Are you sure you want to delete this Credential?"
+        confirmLabel="Delete"
+        variant="destructive"
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/SettingsScreen.tsx
+++ b/frontend/src/components/SettingsScreen.tsx
@@ -10,6 +10,7 @@ import {
 import type { Settings } from "../api/types";
 import { AddRepoModal } from "./AddRepoModal";
 import { PolicySettingsPanel } from "./PolicySettingsPanel";
+import { IntegrationsSettings } from "./IntegrationsSettings";
 import { RepoIndexIndicator } from "./RepoIndexIndicator";
 import { SidecarLibraryPanel } from "./SidecarLibraryPanel";
 import { Button } from "./ui/button";
@@ -281,6 +282,9 @@ export function SettingsScreen() {
 
       {/* Action Policy */}
       <PolicySettingsPanel />
+
+      {/* Integrations */}
+      <IntegrationsSettings />
 
       {/* Retention */}
       <div className="rounded-lg border border-border bg-card p-5">

--- a/frontend/src/components/__tests__/IntegrationsSettings.test.tsx
+++ b/frontend/src/components/__tests__/IntegrationsSettings.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, within, fireEvent } from "@testing-library/react";
+
+vi.mock("../../api/client", () => ({
+  fetchCredentials: vi.fn(),
+  fetchCredentialGuidance: vi.fn(),
+  createCredential: vi.fn(),
+  deleteCredential: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { fetchCredentials, fetchCredentialGuidance, createCredential, deleteCredential } from "../../api/client";
+import { IntegrationsSettings } from "../IntegrationsSettings";
+
+const guidance = {
+  github: "Use a fine-grained PAT scoped to Issues: Read & write.",
+  jira: "Jira tokens cannot be scoped down further than the full account.",
+  azure_devops: "Azure DevOps PATs are org-scoped, not project-scoped.",
+};
+
+beforeEach(() => {
+  vi.mocked(fetchCredentials).mockResolvedValue({ credentials: [] });
+  vi.mocked(fetchCredentialGuidance).mockResolvedValue({ guidance });
+  vi.mocked(createCredential).mockReset();
+  vi.mocked(deleteCredential).mockReset();
+});
+
+describe("IntegrationsSettings", () => {
+  it("renders the empty state after loading", async () => {
+    render(<IntegrationsSettings />);
+    await waitFor(() => {
+      expect(screen.getByText("No credentials registered yet.")).toBeInTheDocument();
+    });
+  });
+
+  it("lists registered credentials without ever rendering a secret field", async () => {
+    vi.mocked(fetchCredentials).mockResolvedValue({
+      credentials: [
+        {
+          id: "cred-1",
+          provider: "github",
+          label: "My GitHub",
+          baseUrl: "https://api.github.com",
+          createdAt: "2026-01-01T00:00:00Z",
+        },
+      ],
+    });
+
+    render(<IntegrationsSettings />);
+    await waitFor(() => {
+      expect(screen.getByText("My GitHub")).toBeInTheDocument();
+    });
+    expect(screen.getByText("https://api.github.com")).toBeInTheDocument();
+    expect(screen.queryByText(/^secret$|token value/i)).not.toBeInTheDocument();
+  });
+
+  it("shows per-provider guidance and submits a new credential", async () => {
+    vi.mocked(createCredential).mockResolvedValue({
+      id: "cred-new",
+      provider: "github",
+      label: "New Cred",
+      baseUrl: "https://api.github.com",
+      createdAt: "2026-01-01T00:00:00Z",
+    });
+
+    render(<IntegrationsSettings />);
+    await waitFor(() => {
+      expect(screen.getByText(/fine-grained PAT/)).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText("Label"), { target: { value: "New Cred" } });
+    fireEvent.change(screen.getByLabelText("Base URL"), { target: { value: "https://api.github.com" } });
+    fireEvent.change(screen.getByLabelText("Personal Access Token"), { target: { value: "ghp_sentinel" } });
+    fireEvent.click(screen.getByRole("button", { name: /Register Credential/ }));
+
+    await waitFor(() => {
+      expect(createCredential).toHaveBeenCalledWith({
+        provider: "github",
+        label: "New Cred",
+        baseUrl: "https://api.github.com",
+        pat: "ghp_sentinel",
+      });
+    });
+  });
+
+  it("blocks submission with a toast when required fields are missing", async () => {
+    const { toast } = await import("sonner");
+
+    render(<IntegrationsSettings />);
+    await waitFor(() => {
+      expect(fetchCredentials).toHaveBeenCalled();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Register Credential/ }));
+
+    expect(createCredential).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalled();
+  });
+
+  it("opens a confirm dialog and calls delete when confirmed", async () => {
+    vi.mocked(fetchCredentials).mockResolvedValue({
+      credentials: [
+        {
+          id: "cred-1",
+          provider: "jira",
+          label: "Jira Cred",
+          baseUrl: "https://x.atlassian.net",
+          createdAt: "2026-01-01T00:00:00Z",
+        },
+      ],
+    });
+    vi.mocked(deleteCredential).mockResolvedValue(undefined);
+
+    render(<IntegrationsSettings />);
+    await waitFor(() => {
+      expect(screen.getByText("Jira Cred")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Delete Jira Cred/ }));
+
+    const dialog = await screen.findByRole("dialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(deleteCredential).toHaveBeenCalledWith("cred-1");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements **Story 3.1: Register a Credential** from `_bmad-output/planning-artifacts/epics.md` (Epic 3: Tracker integration), via the `bmad-dev-story` workflow.

Adds a global, **Project-independent** `Credential` entity (provider/label/base URL/encrypted PAT) per CAP-6/CAP-7/AD-6 in `_bmad-output/specs/spec-project-boards/SPEC.md` and the architecture spine. Per the story's explicit scope, this does **not** implement `Project`, Story 3.2 (attach a `TrackerLink` to a Project), or tracker sync/write-back — only the standalone Credential registration flow.

## What's included

**Backend**
- `CredentialRow` ORM model (provider, label, base_url, encrypted_secret, created_at)
- Minimal, FK-decoupled `TrackerLinkRow` (project_id is a plain string, not a foreign key — Project doesn't exist yet) purely so AC2's "delete blocked while referenced" rule has something real to check
- Fernet-based PAT encryption at rest (`backend/services/credentials/encryption.py`), key auto-generated at `~/.codeplane/credential.key`
- `CredentialRepository` — list/get never return the encrypted secret at all; delete raises `CredentialReferencedError` (→ 409) while any `TrackerLinkRow` references the credential
- `/settings/credentials` API: list, create, delete, and a `/guidance` endpoint with NFR9 per-provider PAT scoping guidance
- Alembic migration `0058_add_credentials.py`

**Frontend**
- Settings > Integrations panel: register form (provider/label/base URL/PAT), credential list (never renders the secret), delete with confirm dialog
- New `Credential` API client types/functions in `client.ts`, following the existing hand-written-type precedent (`PolicyState`/`UsdCeiling`)

**Tests**
- Backend: 24 new unit/integration tests (encryption round-trip, repo CRUD + delete-block, API contract incl. 409/404 and never-exposes-secret) — all passing
- Frontend: 5 new component tests (empty state, list rendering, guidance + create, validation, delete confirm flow) — all passing; existing `SettingsScreen` tests unaffected

## Validation
- `ruff check` — clean on all touched backend files
- `npx tsc --noEmit` / `npx eslint` — clean
- Full backend regression suite could not be run to 100% completion in the dev sandbox due to a pre-existing, unrelated Windows/asyncio hang (documented in the story file's Dev Agent Record); verified no regression by running the new tests together with all directly adjacent test modules, and by confirming one scattered pre-existing failure exists on an unmodified tree too.

## Story tracking
- `_bmad-output/implementation-artifacts/3-1-register-a-credential.md` — full story record, status `review`
- `_bmad-output/implementation-artifacts/sprint-status.yaml` — `3-1-register-a-credential` updated to `review`

Please review — not self-approving/self-merging per process.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>