### PR TITLE
feat: implement Story 3.2 - Attach a TrackerLink to a Project (CAP-7)

### DIFF
--- a/_bmad-output/implementation-artifacts/3-2-attach-a-trackerlink-to-a-project.md
+++ b/_bmad-output/implementation-artifacts/3-2-attach-a-trackerlink-to-a-project.md
@@ -1,0 +1,96 @@
+---
+baseline_commit: 162d97a2
+---
+
+# Story 3.2: Attach a TrackerLink to a Project
+
+Status: review
+
+## Story
+
+As a CodePlane user,
+I want to attach a Credential to a Project via a TrackerLink,
+So that my Project's board reflects that Project's ticket state.
+
+## Acceptance Criteria
+
+1. **Given** at least one Credential is registered, **when** I attach it to a Project along with an external project/board reference, **then** a `TrackerLinkRow` (Project + Credential + external ref) is created.
+2. **And** a Project can have more than one TrackerLink (e.g. referencing two external boards).
+3. **And** any number of Projects may attach the same Credential (Credential is global, not consumed per-attachment).
+
+## Tasks / Subtasks
+
+- [x] Task 1: Implement `TrackerLinkRepository` (AC: 1, 2, 3)
+  - [x] `backend/persistence/tracker_link_repo.py`: `create()` validates both the Project and the Credential exist (raising `TrackerLinkProjectNotFoundError`/`TrackerLinkCredentialNotFoundError`) before inserting, since `TrackerLinkRow.project_id` is a plain string with no DB-level FK to `ProjectRow` (per Story 3.1's deliberate decoupling).
+  - [x] `list_for_project(project_id)` — returns all TrackerLinks for a Project, ordered by `created_at`.
+  - [x] No new ORM model or migration — `TrackerLinkRow`/`credentials`/`tracker_links` tables already exist from Story 3.1 (migration `0058_add_credentials.py`); confirmed the current alembic head is `0060_add_projects.py` and no schema change is needed for this story.
+- [x] Task 2: Implement the `/projects/{project_id}/tracker-links` API (AC: 1, 2, 3)
+  - [x] `backend/api/tracker_links.py`: thin `DishkaRoute`-style router mirroring the Story 3.1 `credentials.py` pattern (inline `async_sessionmaker[AsyncSession]` session, not the DI-service pattern used by `projects.py`) — `POST` (attach/create, 201, 404 if Project or Credential missing) and `GET` (list, secret-free by construction since `TrackerLinkRow` never stores a secret).
+  - [x] `CamelModel`-based schemas: `TrackerLinkResponse`, `TrackerLinkListResponse`, `CreateTrackerLinkRequest`.
+  - [x] Mount the router in `backend/app_factory.py` (production) and `backend/tests/integration/conftest.py` (test app fixture).
+  - [x] Structured log event (`tracker_link.created`).
+- [x] Task 3: Author comprehensive tests (AC: 1, 2, 3)
+  - [x] `backend/tests/unit/test_tracker_link_repo.py` — create success, create raises when Project missing, create raises when Credential missing, a Project can have multiple TrackerLinks, the same Credential can attach to multiple Projects, `list_for_project` returns empty/scoped results without leaking across Projects.
+  - [x] `backend/tests/integration/test_api_tracker_links.py` — attach/create endpoint contract, multiple links per Project, same Credential across multiple Projects, 404 for missing Project, 404 for missing Credential, 422 for empty `externalRef`, list endpoint (empty + scoped, no cross-Project leakage).
+
+## Dev Notes
+
+### Implementation Boundary
+
+This story implements only the attach/create + list surface for `TrackerLinkRow`, on top of the schema-only anchor Story 3.1 already added. It explicitly does **not** implement:
+
+- Ticket/board sync or polling (Story 3.3).
+- Outbound write-back through `codeplane_approval` (Story 3.4).
+- Per-provider PAT scope guidance UI (Story 3.5).
+- Any frontend UI: Project management (Story 2.1, CAP-6) itself has no frontend surface in the codebase yet, so there is nothing for a TrackerLink attach/detach UI to hang off of yet — deferred until a Project management UI exists.
+- Detach/delete endpoints — not required by this story's acceptance criteria (attach + multiplicity only); adding delete now would be scope creep beyond the literal ACs.
+
+### Architecture Compliance
+
+- Thin routes: `backend/api/tracker_links.py` validates input and delegates to `TrackerLinkRepository`; no orchestration logic lives in the route handlers.
+- All database access goes through `TrackerLinkRepository` in `backend/persistence/`; no direct SQLAlchemy session usage in the API layer.
+- Response models use the `CamelModel` base class for camelCase serialization, matching the rest of the API contract.
+- `project_id` remains a plain string (not a DB-level FK), per Story 3.1's explicit decoupling decision — Project-existence is instead validated in the repository layer before insert, so the referential-integrity intent (AC1) is still enforced, just at the application layer rather than the schema layer.
+- No new migration: `TrackerLinkRow` already exists from `alembic/versions/0058_add_credentials.py`; verified `0060_add_projects.py` is the current alembic head on `origin/main` with no story adding a migration in between.
+
+### References
+
+- [Source: `_bmad-output/planning-artifacts/epics.md#Story-32-Attach-a-TrackerLink-to-a-Project`]
+- [Source: `_bmad-output/specs/spec-project-boards/SPEC.md` CAP-7, AD-6]
+- [Source: `_bmad-output/implementation-artifacts/3-1-register-a-credential.md` — TrackerLinkRow anchor and explicit Story 3.2 deferral]
+- [Source: `backend/api/credentials.py`, `backend/persistence/credential_repo.py` — thin router/repository pattern precedent reused here]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Claude Sonnet 5 (GitHub Copilot CLI).
+
+### Debug Log References
+
+- `C:\Users\davidfinson\.copilot\repos\codeplane\.venv\Scripts\python.exe -m pytest backend/tests/unit/test_tracker_link_repo.py backend/tests/integration/test_api_tracker_links.py -q` → 15 passed.
+- Regression smoke check: `... -m pytest backend/tests/unit/test_credential_repo.py backend/tests/integration/test_api_credentials.py backend/tests/unit/test_project_repo.py backend/tests/unit/test_project_service.py -q` → 34 passed, no regressions from wiring the new router alongside `credentials`/`projects`.
+- `... -m ruff check` on all new/modified backend files → all checks passed.
+- `... -m mypy backend/persistence/tracker_link_repo.py backend/api/tracker_links.py` → no issues found.
+- Same `uv sync` TLS/PyPI limitation noted in Story 3.1's debug log applies in this worktree; used the pre-built venv from the main checkout (`C:\Users\davidfinson\.copilot\repos\codeplane\.venv`), invoked from within this worktree so tests exercise this branch's code.
+
+### Completion Notes List
+
+- Implemented `TrackerLinkRepository.create()`/`list_for_project()` and the `/projects/{project_id}/tracker-links` POST/GET API, filling the attach/create/list gap Story 3.1 deliberately left open.
+- Confirmed no new ORM model or migration is required: `TrackerLinkRow` already exists from Story 3.1's `0058_add_credentials.py`; `0060_add_projects.py` remains the current alembic head on `origin/main`.
+- Application-layer existence checks (Project, Credential) substitute for the DB-level FK that `project_id` deliberately lacks, per Story 3.1's decoupling rationale — both return 404 via dedicated exception types.
+- No frontend changes: Project management (2.1) has no UI yet in this codebase, so a TrackerLink attach/detach UI has nothing to attach to; deferred.
+- Explicitly did not implement ticket sync (3.3), approval-gated write-back (3.4), or PAT scope guidance (3.5), per story scope.
+
+### File List
+
+- `backend/persistence/tracker_link_repo.py` (new)
+- `backend/api/tracker_links.py` (new)
+- `backend/app_factory.py` (modified — mounted `tracker_links` router)
+- `backend/tests/integration/conftest.py` (modified — mounted `tracker_links` router in test app fixture)
+- `backend/tests/unit/test_tracker_link_repo.py` (new)
+- `backend/tests/integration/test_api_tracker_links.py` (new)
+
+## Change Log
+
+- 2026-08-10: Implemented Story 3.2 (Attach a TrackerLink to a Project): `TrackerLinkRepository` (create + list, with Project/Credential existence validation), `/projects/{project_id}/tracker-links` API, and full test coverage. No new migration required — reused the `TrackerLinkRow` schema anchor from Story 3.1. Status set to `review`.

--- a/backend/api/tracker_links.py
+++ b/backend/api/tracker_links.py
@@ -1,0 +1,86 @@
+"""TrackerLink attach/list API (Story 3.2, CAP-7/AD-6).
+
+Attach a global Credential to a Project along with an external
+project/board reference. A Project may have more than one TrackerLink
+(e.g. referencing two external boards), and any number of Projects may
+attach the same Credential (Credential is global, not consumed
+per-attachment).
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import structlog
+from dishka.integrations.fastapi import DishkaRoute, FromDishka
+from fastapi import APIRouter, HTTPException
+from pydantic import Field
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from backend.models.schemas.base import CamelModel
+from backend.persistence.tracker_link_repo import (
+    TrackerLinkCredentialNotFoundError,
+    TrackerLinkProjectNotFoundError,
+    TrackerLinkRepository,
+)
+
+router = APIRouter(prefix="/projects/{project_id}/tracker-links", tags=["tracker-links"], route_class=DishkaRoute)
+log = structlog.get_logger()
+
+
+class TrackerLinkResponse(CamelModel):
+    id: str
+    project_id: str
+    credential_id: str
+    external_ref: str
+    created_at: str
+
+
+class TrackerLinkListResponse(CamelModel):
+    tracker_links: list[TrackerLinkResponse] = Field(default_factory=list)
+
+
+class CreateTrackerLinkRequest(CamelModel):
+    credential_id: str = Field(min_length=1)
+    external_ref: str = Field(min_length=1)
+
+
+def _to_response(data: dict[str, Any]) -> TrackerLinkResponse:
+    return TrackerLinkResponse(**data)
+
+
+@router.get("", response_model=TrackerLinkListResponse)
+async def list_tracker_links(
+    project_id: str,
+    sf: FromDishka[async_sessionmaker[AsyncSession]],
+) -> TrackerLinkListResponse:
+    async with sf() as session:
+        repo = TrackerLinkRepository(session)
+        rows = await repo.list_for_project(project_id)
+    return TrackerLinkListResponse(tracker_links=[_to_response(r) for r in rows])
+
+
+@router.post("", response_model=TrackerLinkResponse, status_code=201)
+async def create_tracker_link(
+    project_id: str,
+    body: CreateTrackerLinkRequest,
+    sf: FromDishka[async_sessionmaker[AsyncSession]],
+) -> TrackerLinkResponse:
+    link_id = str(uuid.uuid4())
+    async with sf() as session:
+        repo = TrackerLinkRepository(session)
+        try:
+            result = await repo.create(
+                link_id=link_id,
+                project_id=project_id,
+                credential_id=body.credential_id,
+                external_ref=body.external_ref,
+            )
+        except TrackerLinkProjectNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except TrackerLinkCredentialNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        await session.commit()
+    log.info("tracker_link.created", tracker_link_id=link_id, project_id=project_id, credential_id=body.credential_id)
+    return _to_response(result)

--- a/backend/app_factory.py
+++ b/backend/app_factory.py
@@ -46,6 +46,7 @@ from backend.api import (
     share,
     sidecar_templates,
     terminal,
+    tracker_links,
     trail,
     utility_sessions,
     voice,
@@ -229,6 +230,7 @@ def _register_routes(app: FastAPI) -> None:
     app.include_router(sidecar_templates.router, prefix="/api")
     app.include_router(chats.router, prefix="/api")
     app.include_router(projects.router, prefix="/api")
+    app.include_router(tracker_links.router, prefix="/api")
 
 
 def _register_domain_exception_handlers(app: FastAPI) -> None:

--- a/backend/persistence/tracker_link_repo.py
+++ b/backend/persistence/tracker_link_repo.py
@@ -1,0 +1,78 @@
+"""Persistence for TrackerLinks (Story 3.2, CAP-7/AD-6).
+
+A ``TrackerLinkRow`` is the many-to-many join between a Project and a
+Credential: attaching a Credential to a Project along with an external
+project/board reference. ``project_id`` is a plain string (not a foreign
+key — see ``TrackerLinkRow`` docstring), so this repository validates
+Project existence itself before inserting, using ``ProjectRow`` directly.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import select
+
+from backend.models.db import CredentialRow, ProjectRow, TrackerLinkRow
+from backend.persistence.repository import BaseRepository
+
+
+class TrackerLinkCredentialNotFoundError(Exception):
+    """Raised when attaching a TrackerLink to a Credential that does not exist."""
+
+
+class TrackerLinkProjectNotFoundError(Exception):
+    """Raised when attaching a TrackerLink to a Project that does not exist."""
+
+
+class TrackerLinkRepository(BaseRepository):
+    """Database access for TrackerLinks."""
+
+    async def create(
+        self, *, link_id: str, project_id: str, credential_id: str, external_ref: str
+    ) -> dict[str, Any]:
+        """Attach a Credential to a Project via a new TrackerLink (AC1).
+
+        Validates both the Project and the Credential exist before inserting,
+        since ``project_id`` is a plain string with no DB-level FK constraint.
+        """
+        project_result = await self._session.execute(select(ProjectRow.id).where(ProjectRow.id == project_id))
+        if project_result.scalar_one_or_none() is None:
+            raise TrackerLinkProjectNotFoundError(f"Project '{project_id}' does not exist")
+
+        credential_result = await self._session.execute(
+            select(CredentialRow.id).where(CredentialRow.id == credential_id)
+        )
+        if credential_result.scalar_one_or_none() is None:
+            raise TrackerLinkCredentialNotFoundError(f"Credential '{credential_id}' does not exist")
+
+        row = TrackerLinkRow(
+            id=link_id,
+            project_id=project_id,
+            credential_id=credential_id,
+            external_ref=external_ref,
+            created_at=datetime.now(UTC).isoformat(),
+        )
+        self._session.add(row)
+        await self._session.flush()
+        return _row_to_dict(row)
+
+    async def list_for_project(self, project_id: str) -> list[dict[str, Any]]:
+        """List all TrackerLinks attached to a Project (AC2 — a Project may have several)."""
+        result = await self._session.execute(
+            select(TrackerLinkRow)
+            .where(TrackerLinkRow.project_id == project_id)
+            .order_by(TrackerLinkRow.created_at)
+        )
+        return [_row_to_dict(r) for r in result.scalars()]
+
+
+def _row_to_dict(row: TrackerLinkRow) -> dict[str, Any]:
+    return {
+        "id": row.id,
+        "project_id": row.project_id,
+        "credential_id": row.credential_id,
+        "external_ref": row.external_ref,
+        "created_at": row.created_at,
+    }

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -212,6 +212,7 @@ async def app(
         settings,
         share,
         terminal,
+        tracker_links,
         voice,
         workspace,
     )
@@ -236,6 +237,7 @@ async def app(
     application.include_router(share.router, prefix="/api")
     application.include_router(terminal.router, prefix="/api")
     application.include_router(chats.router, prefix="/api")
+    application.include_router(tracker_links.router, prefix="/api")
 
     # -- dishka DI container (replaces app.state) --------------------------
     container = make_async_container(

--- a/backend/tests/integration/test_api_tracker_links.py
+++ b/backend/tests/integration/test_api_tracker_links.py
@@ -1,0 +1,174 @@
+"""Integration tests for the TrackerLink attach/list API (Story 3.2).
+
+Exercises:
+  POST /api/projects/{project_id}/tracker-links
+  GET  /api/projects/{project_id}/tracker-links
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from backend.services.credentials import encryption
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from httpx import AsyncClient
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+
+@pytest.fixture(autouse=True)
+def _isolated_codeplane_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(encryption, "get_codeplane_dir", lambda: tmp_path)
+
+
+async def _seed_project(session_factory: async_sessionmaker[AsyncSession], project_id: str = "proj-1") -> None:
+    from datetime import UTC, datetime
+
+    from backend.models.db import ProjectRow
+
+    async with session_factory() as session:
+        session.add(
+            ProjectRow(
+                id=project_id,
+                name="Test Project",
+                repo_paths="[]",
+                created_at=datetime.now(UTC),
+                updated_at=datetime.now(UTC),
+            )
+        )
+        await session.commit()
+
+
+async def _create_credential(client: AsyncClient) -> str:
+    resp = await client.post(
+        "/api/settings/credentials",
+        json={"provider": "github", "label": "GH", "baseUrl": "https://api.github.com", "pat": "p"},
+    )
+    return resp.json()["id"]
+
+
+class TestCreateTrackerLink:
+    @pytest.mark.asyncio
+    async def test_attach_credential_to_project_creates_tracker_link(
+        self, client: AsyncClient, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        await _seed_project(session_factory)
+        credential_id = await _create_credential(client)
+
+        resp = await client.post(
+            "/api/projects/proj-1/tracker-links",
+            json={"credentialId": credential_id, "externalRef": "ORG/board-1"},
+        )
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["projectId"] == "proj-1"
+        assert body["credentialId"] == credential_id
+        assert body["externalRef"] == "ORG/board-1"
+        assert "id" in body
+        assert "createdAt" in body
+
+    @pytest.mark.asyncio
+    async def test_project_can_have_more_than_one_tracker_link(
+        self, client: AsyncClient, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        await _seed_project(session_factory)
+        cred_1 = await _create_credential(client)
+        cred_2_resp = await client.post(
+            "/api/settings/credentials",
+            json={"provider": "jira", "label": "Jira", "baseUrl": "https://x.atlassian.net", "pat": "tok"},
+        )
+        cred_2 = cred_2_resp.json()["id"]
+
+        await client.post(
+            "/api/projects/proj-1/tracker-links", json={"credentialId": cred_1, "externalRef": "ORG/board-1"}
+        )
+        await client.post(
+            "/api/projects/proj-1/tracker-links", json={"credentialId": cred_2, "externalRef": "ORG/board-2"}
+        )
+
+        resp = await client.get("/api/projects/proj-1/tracker-links")
+        assert resp.status_code == 200
+        links = resp.json()["trackerLinks"]
+        assert len(links) == 2
+
+    @pytest.mark.asyncio
+    async def test_same_credential_attaches_to_multiple_projects(
+        self, client: AsyncClient, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        await _seed_project(session_factory, "proj-1")
+        await _seed_project(session_factory, "proj-2")
+        credential_id = await _create_credential(client)
+
+        resp_1 = await client.post(
+            "/api/projects/proj-1/tracker-links", json={"credentialId": credential_id, "externalRef": "ORG/board-1"}
+        )
+        resp_2 = await client.post(
+            "/api/projects/proj-2/tracker-links", json={"credentialId": credential_id, "externalRef": "ORG/board-2"}
+        )
+        assert resp_1.status_code == 201
+        assert resp_2.status_code == 201
+
+    @pytest.mark.asyncio
+    async def test_returns_404_when_project_does_not_exist(self, client: AsyncClient) -> None:
+        credential_id = await _create_credential(client)
+
+        resp = await client.post(
+            "/api/projects/does-not-exist/tracker-links",
+            json={"credentialId": credential_id, "externalRef": "ORG/board-1"},
+        )
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_returns_404_when_credential_does_not_exist(
+        self, client: AsyncClient, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        await _seed_project(session_factory)
+
+        resp = await client.post(
+            "/api/projects/proj-1/tracker-links",
+            json={"credentialId": "does-not-exist", "externalRef": "ORG/board-1"},
+        )
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_external_ref(
+        self, client: AsyncClient, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        await _seed_project(session_factory)
+        credential_id = await _create_credential(client)
+
+        resp = await client.post(
+            "/api/projects/proj-1/tracker-links", json={"credentialId": credential_id, "externalRef": ""}
+        )
+        assert resp.status_code == 422
+
+
+class TestListTrackerLinks:
+    @pytest.mark.asyncio
+    async def test_empty_list_for_project_with_no_links(
+        self, client: AsyncClient, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        await _seed_project(session_factory)
+
+        resp = await client.get("/api/projects/proj-1/tracker-links")
+        assert resp.status_code == 200
+        assert resp.json() == {"trackerLinks": []}
+
+    @pytest.mark.asyncio
+    async def test_list_does_not_leak_across_projects(
+        self, client: AsyncClient, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        await _seed_project(session_factory, "proj-1")
+        await _seed_project(session_factory, "proj-2")
+        credential_id = await _create_credential(client)
+
+        await client.post(
+            "/api/projects/proj-1/tracker-links", json={"credentialId": credential_id, "externalRef": "ORG/board-1"}
+        )
+
+        resp = await client.get("/api/projects/proj-2/tracker-links")
+        assert resp.json() == {"trackerLinks": []}

--- a/backend/tests/unit/test_tracker_link_repo.py
+++ b/backend/tests/unit/test_tracker_link_repo.py
@@ -1,0 +1,154 @@
+"""Unit tests for TrackerLinkRepository (Story 3.2, CAP-7/AD-6)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import pytest
+from sqlalchemy import event as sa_event
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
+
+from backend.models.db import Base, CredentialRow, ProjectRow
+from backend.persistence.database import _set_sqlite_pragmas
+from backend.persistence.tracker_link_repo import (
+    TrackerLinkCredentialNotFoundError,
+    TrackerLinkProjectNotFoundError,
+    TrackerLinkRepository,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+
+@pytest.fixture
+async def engine() -> AsyncGenerator[AsyncEngine, None]:
+    eng = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+    sa_event.listen(eng.sync_engine, "connect", _set_sqlite_pragmas)
+    async with eng.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield eng
+    await eng.dispose()
+
+
+@pytest.fixture
+async def session(engine: AsyncEngine) -> AsyncGenerator[AsyncSession, None]:
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+
+
+async def _seed_project(session: AsyncSession, project_id: str = "proj-1") -> None:
+    session.add(
+        ProjectRow(
+            id=project_id,
+            name="Test Project",
+            repo_paths="[]",
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+    )
+    await session.commit()
+
+
+async def _seed_credential(session: AsyncSession, credential_id: str = "cred-1") -> None:
+    session.add(
+        CredentialRow(
+            id=credential_id,
+            provider="github",
+            label="GH",
+            base_url="https://api.github.com",
+            encrypted_secret="encrypted",
+            created_at="2026-01-01T00:00:00Z",
+        )
+    )
+    await session.commit()
+
+
+class TestCreate:
+    @pytest.mark.asyncio
+    async def test_create_attaches_credential_to_project(self, session: AsyncSession) -> None:
+        await _seed_project(session)
+        await _seed_credential(session)
+        repo = TrackerLinkRepository(session)
+
+        result = await repo.create(
+            link_id="link-1", project_id="proj-1", credential_id="cred-1", external_ref="ORG/board-1"
+        )
+        await session.commit()
+
+        assert result["id"] == "link-1"
+        assert result["project_id"] == "proj-1"
+        assert result["credential_id"] == "cred-1"
+        assert result["external_ref"] == "ORG/board-1"
+        assert result["created_at"]
+
+    @pytest.mark.asyncio
+    async def test_create_raises_when_project_missing(self, session: AsyncSession) -> None:
+        await _seed_credential(session)
+        repo = TrackerLinkRepository(session)
+
+        with pytest.raises(TrackerLinkProjectNotFoundError):
+            await repo.create(
+                link_id="link-1", project_id="does-not-exist", credential_id="cred-1", external_ref="ORG/board-1"
+            )
+
+    @pytest.mark.asyncio
+    async def test_create_raises_when_credential_missing(self, session: AsyncSession) -> None:
+        await _seed_project(session)
+        repo = TrackerLinkRepository(session)
+
+        with pytest.raises(TrackerLinkCredentialNotFoundError):
+            await repo.create(
+                link_id="link-1", project_id="proj-1", credential_id="does-not-exist", external_ref="ORG/board-1"
+            )
+
+    @pytest.mark.asyncio
+    async def test_project_can_have_multiple_tracker_links(self, session: AsyncSession) -> None:
+        await _seed_project(session)
+        await _seed_credential(session, "cred-1")
+        await _seed_credential(session, "cred-2")
+        repo = TrackerLinkRepository(session)
+
+        await repo.create(link_id="link-1", project_id="proj-1", credential_id="cred-1", external_ref="ORG/board-1")
+        await repo.create(link_id="link-2", project_id="proj-1", credential_id="cred-2", external_ref="ORG/board-2")
+        await session.commit()
+
+        links = await repo.list_for_project("proj-1")
+        assert len(links) == 2
+
+    @pytest.mark.asyncio
+    async def test_same_credential_can_attach_to_multiple_projects(self, session: AsyncSession) -> None:
+        await _seed_project(session, "proj-1")
+        await _seed_project(session, "proj-2")
+        await _seed_credential(session)
+        repo = TrackerLinkRepository(session)
+
+        await repo.create(link_id="link-1", project_id="proj-1", credential_id="cred-1", external_ref="ORG/board-1")
+        await repo.create(link_id="link-2", project_id="proj-2", credential_id="cred-1", external_ref="ORG/board-2")
+        await session.commit()
+
+        assert len(await repo.list_for_project("proj-1")) == 1
+        assert len(await repo.list_for_project("proj-2")) == 1
+
+
+class TestListForProject:
+    @pytest.mark.asyncio
+    async def test_list_returns_empty_for_project_with_no_links(self, session: AsyncSession) -> None:
+        await _seed_project(session)
+        repo = TrackerLinkRepository(session)
+
+        assert await repo.list_for_project("proj-1") == []
+
+    @pytest.mark.asyncio
+    async def test_list_does_not_leak_links_between_projects(self, session: AsyncSession) -> None:
+        await _seed_project(session, "proj-1")
+        await _seed_project(session, "proj-2")
+        await _seed_credential(session)
+        repo = TrackerLinkRepository(session)
+
+        await repo.create(link_id="link-1", project_id="proj-1", credential_id="cred-1", external_ref="ORG/board-1")
+        await session.commit()
+
+        assert len(await repo.list_for_project("proj-1")) == 1
+        assert await repo.list_for_project("proj-2") == []


### PR DESCRIPTION
## Summary

Implements **Story 3.2: Attach a TrackerLink to a Project** from `_bmad-output/planning-artifacts/epics.md`, on top of latest `main` (Project entity from Story 2.1 and Credential entity from Story 3.1).

Story 3.1 already added `TrackerLinkRow` as a schema-only referential-integrity anchor (id, project_id as plain string, credential_id FK, external_ref). This PR adds the missing attach/create/list surface on top of it.

## Changes

- **`backend/persistence/tracker_link_repo.py`** (new) — `TrackerLinkRepository`:
  - `create()` validates both the Project and Credential exist before inserting (raises `TrackerLinkProjectNotFoundError` / `TrackerLinkCredentialNotFoundError`), since `project_id` is deliberately a plain string with no DB-level FK to `ProjectRow`.
  - `list_for_project(project_id)` — all TrackerLinks for a Project.
- **`backend/api/tracker_links.py`** (new) — `POST`/`GET /projects/{project_id}/tracker-links`, mirroring the Story 3.1 `credentials.py` thin-router pattern (inline session, 404 on missing Project/Credential).
- **`backend/app_factory.py`** / **`backend/tests/integration/conftest.py`** — mounted the new router.
- **No new migration** — `TrackerLinkRow` schema already exists from `0058_add_credentials.py`. Confirmed `0060_add_projects.py` is still the current alembic head on `origin/main` right before opening this PR (no other parallel story added a migration in between).
- Unit tests (`test_tracker_link_repo.py`) + integration tests (`test_api_tracker_links.py`): create success, missing-project/missing-credential 404s, multiple links per project, same credential across multiple projects, list scoping (no cross-project leakage).

## Acceptance Criteria coverage

1. ✅ Attaching a registered Credential + external ref to a Project creates a `TrackerLinkRow`.
2. ✅ A Project can have more than one TrackerLink.
3. ✅ Any number of Projects may attach the same Credential.

## Explicitly out of scope (per story boundaries)

- Ticket/board sync or polling (Story 3.3)
- Outbound write-back via `codeplane_approval` (Story 3.4)
- Per-provider PAT scope guidance (Story 3.5)
- Frontend UI — Project management (2.1) has no frontend surface yet, so there's nothing for a TrackerLink attach/detach UI to hang off of.
- Detach/delete endpoints — not required by the literal ACs.

## Testing

- `pytest backend/tests/unit/test_tracker_link_repo.py backend/tests/integration/test_api_tracker_links.py -q` → 15 passed
- Regression smoke: `pytest backend/tests/unit/test_credential_repo.py backend/tests/integration/test_api_credentials.py backend/tests/unit/test_project_repo.py backend/tests/unit/test_project_service.py -q` → 34 passed, no regressions
- `ruff check` on all new/modified files → clean
- `mypy` on new files → no issues found

Story status set to `review` in `_bmad-output/implementation-artifacts/3-2-attach-a-trackerlink-to-a-project.md`.