### PR TITLE
feat: ingest BMAD/spec-kit task graphs into a Project (Story 4.2)

### DIFF
--- a/_bmad-output/implementation-artifacts/4-2-ingest-a-task-graph-into-a-project.md
+++ b/_bmad-output/implementation-artifacts/4-2-ingest-a-task-graph-into-a-project.md
@@ -1,0 +1,115 @@
+---
+baseline_commit: 162d97a2
+---
+
+# Story 4.2: Ingest a task graph into a Project
+
+Status: review
+
+## Story
+
+As a CodePlane user who has run BMAD or spec-kit,
+I want to ingest my existing dependency-linked task list into a Project,
+so that I don't have to hand-author board cards for work already planned.
+
+## Acceptance Criteria
+
+1. **Given** a Project with 2+ member repos, each containing BMAD stories or a spec-kit `tasks.md`, **when** I trigger ingestion for that Project, **then** one `TaskLink` is created per task, namespaced by `(project_id, repo_path, story_node_id)`, with `depends_on` correctly resolving to a sibling member repo's task when referenced.
+2. **Given** ingestion has already run once for a Project, **when** I re-run it, **then** existing `TaskLink`s are upserted (matched by `project_id`, `repo_path`, `story_node_id`), never duplicated.
+3. **Given** the source repo's story/task files, **when** ingestion runs, **then** the source files are read-only — never modified, and never ingested across a Project boundary.
+
+## Tasks / Subtasks
+
+- [x] Add `TaskLinkRow` persistence (AC: #1, #2)
+  - [x] `TaskLinkRow` model in `backend/models/db.py` (`id`, `project_id`, `repo_path`, `story_node_id: nullable`, `depends_on: JSON list[str]`, `job_id: nullable`, `tracker_ticket_ref: nullable`, `prompt_override: nullable`, `epic_id: nullable`), with a unique constraint on `(project_id, repo_path, story_node_id)`.
+  - [x] Alembic migration for the new `task_links` table (verify the true current alembic head via `git log origin/main -- alembic/versions/` immediately before finalizing, and use the next free revision number).
+  - [x] `TaskLink` domain dataclass in `backend/models/domain.py`.
+  - [x] `TaskLinkRepository` in `backend/persistence/task_link_repo.py`: `upsert_many` (matched by `project_id`/`repo_path`/`story_node_id`, never duplicating), `list_by_project`.
+- [x] Implement stateless ingestion parsing (AC: #1, #3)
+  - [x] `backend/services/recipe/parsers.py`: `parse_bmad_stories(repo_path)` reads `_bmad-output/implementation-artifacts/*.md` story files (read-only), deriving `story_node_id` from the filename stem, `epic_id` from the `{epic}-{story}-...` filename prefix, and `depends_on` from an explicit `## Dependencies` section (bare `story_node_id` for same-repo, `repo-folder-name/story_node_id` for cross-repo references).
+  - [x] `parse_spec_kit_tasks(repo_path)` reads a `tasks.md` (repo root or `specs/**/tasks.md`, read-only), deriving `story_node_id` from the leading `T\d+` task id and `depends_on` from a `depends on: ...` annotation on the task line (bare id for same-repo, `repo-folder-name/task_id` for cross-repo).
+  - [x] Neither parser writes to the source repo; both tolerate a missing source (return an empty list) rather than failing ingestion for the whole Project.
+- [x] Implement `RecipeService.ingest_project` (AC: #1, #2, #3)
+  - [x] `backend/services/recipe/recipe_service.py`: given a `project_id`, iterate every repo in `project.repo_paths`, run both parsers per repo, resolve `depends_on` cross-repo references against the full set of parsed nodes for the Project (composite `f"{repo_path}::{story_node_id}"` keys), and upsert one `TaskLinkRow` per parsed task via `TaskLinkRepository.upsert_many`.
+  - [x] Re-running ingestion for the same Project never creates duplicate rows (upsert by `project_id`/`repo_path`/`story_node_id`).
+  - [x] Ingestion never reads or writes outside the Project's own `project.repo_paths` and never mutates the source repos.
+- [x] Expose ingestion trigger (AC: #1)
+  - [x] `POST /settings/projects/{project_id}/ingest-tasks` in `backend/api/projects.py` (thin route, delegates to `RecipeService`), returning the upserted `TaskLink` set.
+  - [x] `GET /settings/projects/{project_id}/task-links` to list a Project's current `TaskLink` rows (read model foundation for the later board-rendering story, AD-11).
+  - [x] `ingest_tasks` action added to the existing `codeplane_project` MCP tool, mirroring the HTTP-proxy pattern of `list`/`get`/`create`/`update`.
+  - [x] DI wiring for `TaskLinkRepository`/`RecipeService` in `backend/di.py`.
+- [x] Tests (AC: #1, #2, #3)
+  - [x] Parser unit tests with fixture BMAD story files and `tasks.md` files (same-repo and cross-repo dependency references).
+  - [x] `TaskLinkRepository` unit tests (upsert insert + upsert update, list by project).
+  - [x] `RecipeService.ingest_project` unit tests (multi-repo Project, cross-repo `depends_on` resolution, idempotent re-run, read-only guarantee).
+  - [x] API integration test for the ingest/list endpoints.
+  - [x] Run targeted test suite and lint.
+
+## Dev Notes
+
+- CAP-9 (`_bmad-output/specs/spec-project-boards/SPEC.md`) / AD-9 (`ARCHITECTURE-SPINE.md`): `TaskLinkRow` is a new, thin, Project-scoped table owned by a new `recipe_service.py`; ingestion is a **stateless, on-demand parser** (explicitly user-triggered), never a background watcher/poller.
+- Exactly one of `story_node_id` / `tracker_ticket_ref` is guaranteed non-null at creation for any `TaskLink` — ingestion (this story) always sets `story_node_id` and leaves `tracker_ticket_ref`/`prompt_override` null. Manual assignment (Story 4.3, tracker_ticket_ref + prompt_override with null story_node_id) is a separate, independent creation path — **do not implement it here**.
+- `epic_id` is purely cosmetic grouping data, only ever populated by ingestion when the source BMAD story has identifiable Epic membership (derivable unambiguously from the existing `{epic}-{story}-{slug}.md` filename convention already used in `_bmad-output/implementation-artifacts/`, matching the `epic-{N}` keys already used in `sprint-status.yaml`). Never invent/guess it — leave null when absent or ambiguous (e.g. spec-kit `tasks.md` sourced tasks always get a null `epic_id`, since spec-kit has no Epic concept).
+- `story_node_id` is only unique within one repo, so `depends_on` needs a way to disambiguate cross-repo references. Store `TaskLinkRow.depends_on` as a JSON list of composite `f"{repo_path}::{story_node_id}"` strings (resolved by the service, not the parsers) so an edge always unambiguously names its target `TaskLink`, whether same-repo or a sibling member repo of the same Project.
+- Ingestion is Project-scoped only: it iterates exactly `project.repo_paths` (AD-5), never any repo outside that Project's membership, and never reads/writes the source BMAD story files or spec-kit `tasks.md` — parse-only, no mutation, matching CAP-9's "never taking ownership of source repos" success criterion.
+- Do NOT implement: manual ticket assignment (4.3), TaskLink board cards / `RepoBoard.tsx` rendering (4.4), auto-spawn via `spawn_task` (4.5), or tracker-write routing (4.6) — those are separate, dependent stories. This story is ingestion + persistence + read endpoints only.
+- Follow existing repo conventions exactly (see Story 2.1's `ProjectRow`/`ProjectService`/`ProjectRepository`/`backend/api/projects.py`/`codeplane_project` MCP tool as the closest precedent): thin API routes delegating to a service, all DB access through a repository class, DI wiring in `backend/di.py`, `CamelModel`-based Pydantic schemas in `backend/models/api_schemas.py`, domain exceptions in `backend/models/domain.py` registered in `backend/app_factory.py`'s exception handlers.
+- Story 2.1 (`ProjectRow`, `ProjectService`, repo-path uniqueness) is a **hard dependency** — must exist on `main` before this story starts (it does, merged as PR #54, commit `162d97a2`). Story 4.1 (widened sidecar recipe vocabulary, merged as `ecc42c77`) is a sibling story with no code dependency on this one — it only widened `template_service.py`'s validation vocabulary and does not touch `TaskLinkRow` at all.
+- **Before creating the migration file or finalizing the PR**, run `git log origin/main -- alembic/versions/` to find the true current alembic head — multiple parallel stories may have added migrations concurrently, so re-verify the next free revision number immediately before finalizing rather than trusting a number determined earlier in the session.
+
+### Project Structure Notes
+
+- New: `backend/services/recipe/__init__.py`, `backend/services/recipe/recipe_service.py`, `backend/services/recipe/parsers.py`, `backend/persistence/task_link_repo.py`, `alembic/versions/00NN_add_task_links.py` (NN = next free number, re-verified at finalization time).
+- Modified: `backend/models/db.py` (add `TaskLinkRow`), `backend/models/domain.py` (add `TaskLink` dataclass), `backend/models/api_schemas.py` (add `TaskLinkResponse`/`IngestTaskGraphResponse`/`TaskLinkListResponse`), `backend/api/projects.py` (add ingest/list routes), `backend/di.py` (wire `TaskLinkRepository`/`RecipeService`), `backend/mcp/server.py` (extend `codeplane_project` tool with `ingest_tasks`).
+- No frontend changes in this story — `ProjectSettings.tsx`'s ingestion trigger button and `RepoBoard.tsx`'s TaskLink-card rendering are explicitly out of scope (deferred to 4.4+), matching Story 2.1's precedent of backend+MCP-only scope with frontend deferred to later stories.
+
+### References
+
+- [Source: `_bmad-output/planning-artifacts/epics.md#Story-42-Ingest-a-task-graph-into-a-Project`]
+- [Source: `_bmad-output/specs/spec-project-boards/SPEC.md#CAP-9`]
+- [Source: `_bmad-output/planning-artifacts/architecture/architecture-codeplane-2026-08-10/ARCHITECTURE-SPINE.md#AD-9`]
+- [Source: `_bmad-output/implementation-artifacts/2-1-create-edit-a-project.md` — closest precedent for Project-scoped, thin-route, repository-owned persistence pattern]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Claude Sonnet 5 (GitHub Copilot CLI).
+
+### Debug Log References
+
+- `uv run pytest backend/tests/unit/test_task_link_repo.py backend/tests/unit/test_recipe_parsers.py backend/tests/unit/test_recipe_service.py backend/tests/integration/test_api_task_links.py -q` → 29 passed.
+- `uv run pytest backend/tests/unit/test_project_repo.py backend/tests/integration/test_api_projects.py backend/tests/unit -q -k "project or task_link or recipe"` → 22 passed (no regressions on Project/sidecar-adjacent tests).
+- `uv run ruff check` on all new/modified files → clean (after one `--unsafe-fixes` pass for `TC003` import-into-type-checking-block on new test files).
+- Alembic head re-verified via `git log`/`git ls-tree origin/main -- alembic/versions/` immediately before finalizing: still `0060_add_projects.py`. Initially used `0062_add_task_links.py`, renumbered from `0061` to `0062` after PR #58 (Story 5.2, `0061_add_chat_messages.py`) claimed `0061` concurrently from the same head.
+
+### Completion Notes List
+
+- Implemented `TaskLinkRow`/`TaskLink`/`TaskLinkRepository` per AD-9, with a unique `(project_id, repo_path, story_node_id)` index and upsert-by-that-key semantics (AC #2).
+- Implemented stateless, read-only parsers for BMAD stories (`_bmad-output/implementation-artifacts/*.md`) and spec-kit `tasks.md`. Since neither upstream format has an established dependency-annotation convention in this codebase, I documented and used: a `## Dependencies` markdown section (bullet list) for BMAD stories, and a `depends on: ...` inline annotation for spec-kit task lines. This is a defensible, explicit convention per SPEC.md's "Assumption" callout, not a pre-existing standard — called out here and in the PR description for visibility.
+- `RecipeService.ingest_project` resolves cross-repo `depends_on` references against composite `repo_path::story_node_id` keys, is idempotent (upsert, AC #2), and never reads/writes outside `project.repo_paths` (AC #3, verified by `test_ingest_never_writes_to_source_repo`).
+- Added `POST .../ingest-tasks` and `GET .../task-links` thin routes, `codeplane_project` MCP actions (`ingest_tasks`, `list_task_links`), and DI wiring.
+- Scope strictly excludes Stories 4.3 (manual ticket assignment), 4.4 (board rendering), 4.5 (auto-spawn), 4.6 (tracker-write routing) — confirmed no code in this PR touches those paths.
+- No frontend changes, matching Story 2.1's backend+MCP-only precedent (frontend UI deferred to 4.4+).
+
+### File List
+
+**New:**
+- `alembic/versions/0062_add_task_links.py`
+- `backend/persistence/task_link_repo.py`
+- `backend/services/recipe/__init__.py`
+- `backend/services/recipe/parsers.py`
+- `backend/services/recipe/recipe_service.py`
+- `backend/tests/unit/test_task_link_repo.py`
+- `backend/tests/unit/test_recipe_parsers.py`
+- `backend/tests/unit/test_recipe_service.py`
+- `backend/tests/integration/test_api_task_links.py`
+
+**Modified:**
+- `backend/models/db.py`
+- `backend/models/domain.py`
+- `backend/models/api_schemas.py`
+- `backend/api/projects.py`
+- `backend/di.py`
+- `backend/mcp/server.py`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -76,7 +76,7 @@ development_status:
 
   epic-4: in-progress
   4-1-widen-the-task-recipe-vocabulary: review
-  4-2-ingest-a-task-graph-into-a-project: backlog
+  4-2-ingest-a-task-graph-into-a-project: review
   4-3-manually-assign-a-task-to-an-existing-ticket: backlog
   4-4-see-tasklink-cards-on-the-board: backlog
   4-5-auto-spawn-the-next-task-on-completion: backlog

--- a/alembic/versions/0062_add_task_links.py
+++ b/alembic/versions/0062_add_task_links.py
@@ -1,0 +1,48 @@
+"""Add task_links table (Story 4.2 — Ingest a task graph into a Project, AD-9).
+
+Revision ID: 0062
+Revises: 0060
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0062"
+down_revision = "0060"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "task_links",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("project_id", sa.String(), sa.ForeignKey("projects.id"), nullable=False),
+        sa.Column("repo_path", sa.String(), nullable=False),
+        sa.Column("story_node_id", sa.String(), nullable=True),
+        sa.Column("depends_on", sa.Text(), nullable=False, server_default="[]"),
+        sa.Column("job_id", sa.String(), sa.ForeignKey("jobs.id"), nullable=True),
+        sa.Column("tracker_ticket_ref", sa.String(), nullable=True),
+        sa.Column("prompt_override", sa.Text(), nullable=True),
+        sa.Column("epic_id", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index(
+        "ix_task_links_project_id",
+        "task_links",
+        ["project_id"],
+    )
+    op.create_index(
+        "ix_task_links_project_repo_node",
+        "task_links",
+        ["project_id", "repo_path", "story_node_id"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_task_links_project_repo_node", table_name="task_links")
+    op.drop_index("ix_task_links_project_id", table_name="task_links")
+    op.drop_table("task_links")

--- a/backend/api/projects.py
+++ b/backend/api/projects.py
@@ -13,14 +13,18 @@ from fastapi import APIRouter
 
 from backend.models.api_schemas import (
     CreateProjectRequest,
+    IngestTaskGraphResponse,
     ProjectListResponse,
     ProjectListSummaryResponse,
     ProjectResponse,
     ProjectSummaryResponse,
+    TaskLinkListResponse,
+    TaskLinkResponse,
     UpdateProjectRequest,
 )
-from backend.models.domain import Project, ProjectSummary
+from backend.models.domain import Project, ProjectSummary, TaskLink
 from backend.services.project.project_service import ProjectService
+from backend.services.recipe.recipe_service import RecipeService
 
 router = APIRouter(tags=["projects"], route_class=DishkaRoute)
 
@@ -44,6 +48,22 @@ def _to_summary_response(summary: ProjectSummary) -> ProjectSummaryResponse:
         awaiting_input_count=summary.awaiting_input_count,
         failed_count=summary.failed_count,
         last_activity_at=summary.last_activity_at,
+    )
+
+
+def _task_link_to_response(task_link: TaskLink) -> TaskLinkResponse:
+    return TaskLinkResponse(
+        id=task_link.id,
+        project_id=task_link.project_id,
+        repo_path=task_link.repo_path,
+        story_node_id=task_link.story_node_id,
+        depends_on=task_link.depends_on,
+        job_id=task_link.job_id,
+        tracker_ticket_ref=task_link.tracker_ticket_ref,
+        prompt_override=task_link.prompt_override,
+        epic_id=task_link.epic_id,
+        created_at=task_link.created_at,
+        updated_at=task_link.updated_at,
     )
 
 
@@ -101,3 +121,31 @@ async def update_project(
     """Rename a Project and/or replace its repo membership."""
     project = await project_service.update(project_id, name=body.name, repo_paths=body.repo_paths)
     return _to_response(project)
+
+
+@router.post(
+    "/settings/projects/{project_id}/ingest-tasks",
+    response_model=IngestTaskGraphResponse,
+    status_code=201,
+)
+async def ingest_project_tasks(
+    project_id: str,
+    recipe_service: FromDishka[RecipeService],
+) -> IngestTaskGraphResponse:
+    """Ingest BMAD stories / spec-kit tasks for every member repo of a Project (CAP-9).
+
+    Stateless, on-demand, read-only against every source repo; re-running
+    upserts existing TaskLinks rather than duplicating them.
+    """
+    task_links = await recipe_service.ingest_project(project_id)
+    return IngestTaskGraphResponse(items=[_task_link_to_response(t) for t in task_links])
+
+
+@router.get("/settings/projects/{project_id}/task-links", response_model=TaskLinkListResponse)
+async def list_project_task_links(
+    project_id: str,
+    recipe_service: FromDishka[RecipeService],
+) -> TaskLinkListResponse:
+    """List a Project's currently persisted TaskLinks."""
+    task_links = await recipe_service.list_task_links(project_id)
+    return TaskLinkListResponse(items=[_task_link_to_response(t) for t in task_links])

--- a/backend/di.py
+++ b/backend/di.py
@@ -25,6 +25,7 @@ from backend.persistence.latency_attribution_repo import LatencyAttributionRepos
 from backend.persistence.project_repo import ProjectRepository
 from backend.persistence.sidecar_template_repo import SidecarTemplateRepository
 from backend.persistence.step_repo import StepRepository
+from backend.persistence.task_link_repo import TaskLinkRepository
 from backend.persistence.telemetry_spans_repo import TelemetrySpansRepository
 from backend.persistence.telemetry_summary_repo import TelemetrySummaryRepository
 from backend.services.adapters.platform_adapter import PlatformRegistry
@@ -47,6 +48,7 @@ from backend.services.job.approval_service import ApprovalService
 from backend.services.job.job_service import JobService
 from backend.services.merge_service import MergeService
 from backend.services.project.project_service import ProjectService
+from backend.services.recipe.recipe_service import RecipeService
 from backend.services.runtime import RuntimeService
 from backend.services.sharing.push_service import PushService
 from backend.services.sharing.share_service import ShareService
@@ -244,6 +246,14 @@ class RequestProvider(Provider):
     @provide
     def project_service(self, project_repo: ProjectRepository, config: CPLConfig) -> ProjectService:
         return ProjectService(project_repo, config)
+
+    @provide
+    def task_link_repo(self, session: AsyncSession) -> TaskLinkRepository:
+        return TaskLinkRepository(session)
+
+    @provide
+    def recipe_service(self, task_link_repo: TaskLinkRepository, project_service: ProjectService) -> RecipeService:
+        return RecipeService(task_link_repo, project_service)
 
     @provide
     def telemetry_spans_repo(self, session: AsyncSession) -> TelemetrySpansRepository:

--- a/backend/mcp/server.py
+++ b/backend/mcp/server.py
@@ -817,17 +817,20 @@ def _register_project_tool(mcp: FastMCP) -> None:
         annotations=ToolAnnotations(title="Manage Projects", destructiveHint=True, openWorldHint=True),
         description=(
             "Manage Projects — the sole entity that owns repo-path membership. Actions: "
-            "list, get, create, update."
+            "list, get, create, update, ingest_tasks, list_task_links."
             "\n\n"
             "- list: no extra params"
             "\n- get: project_id (required)"
             "\n- create: name (required), repo_paths (required, list of one or more repo paths)"
             "\n- update: project_id (required); name and/or repo_paths (optional, repo_paths replaces "
             "the full membership list)"
+            "\n- ingest_tasks: project_id (required) — parses BMAD stories/spec-kit tasks.md across "
+            "every member repo (read-only, stateless) and upserts the Project's TaskLink set"
+            "\n- list_task_links: project_id (required) — lists the Project's currently persisted TaskLinks"
         ),
     )
     async def codeplane_project(
-        action: Literal["list", "get", "create", "update"],
+        action: Literal["list", "get", "create", "update", "ingest_tasks", "list_task_links"],
         project_id: str | None = None,
         name: str | None = None,
         repo_paths: list[str] | None = None,
@@ -881,6 +884,28 @@ def _register_project_tool(mcp: FastMCP) -> None:
                 if resp.status_code >= 400:
                     detail = resp.json().get("detail", resp.text)
                     return {"error": str(detail)}
+                result = resp.json()
+                return result
+
+            if action == "ingest_tasks":
+                if not project_id:
+                    return {"error": "project_id is required for ingest_tasks"}
+                resp = await client.post(f"{base_url}/settings/projects/{project_id}/ingest-tasks")
+                if resp.status_code == 404:
+                    return {"error": f"Project '{project_id}' does not exist."}
+                if resp.status_code >= 400:
+                    detail = resp.json().get("detail", resp.text)
+                    return {"error": str(detail)}
+                result = resp.json()
+                return result
+
+            if action == "list_task_links":
+                if not project_id:
+                    return {"error": "project_id is required for list_task_links"}
+                resp = await client.get(f"{base_url}/settings/projects/{project_id}/task-links")
+                if resp.status_code == 404:
+                    return {"error": f"Project '{project_id}' does not exist."}
+                resp.raise_for_status()
                 result = resp.json()
                 return result
 

--- a/backend/models/api_schemas.py
+++ b/backend/models/api_schemas.py
@@ -486,6 +486,32 @@ class ProjectListSummaryResponse(CamelModel):
     items: list[ProjectSummaryResponse]
 
 
+class TaskLinkResponse(CamelModel):
+    """A TaskLink — a thin, Project-scoped correlation row (Story 4.2, AD-9)."""
+
+    id: str
+    project_id: str
+    repo_path: str
+    story_node_id: str | None
+    depends_on: list[str]
+    job_id: str | None
+    tracker_ticket_ref: str | None
+    prompt_override: str | None
+    epic_id: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class TaskLinkListResponse(CamelModel):
+    items: list[TaskLinkResponse]
+
+
+class IngestTaskGraphResponse(CamelModel):
+    """Result of an ingestion run — the full upserted TaskLink set for the Project."""
+
+    items: list[TaskLinkResponse]
+
+
 class RepoSummaryResponse(CamelModel):
     """Aggregated overview for a single repo dashboard."""
 

--- a/backend/models/db.py
+++ b/backend/models/db.py
@@ -560,6 +560,49 @@ class TrackerLinkRow(Base):
     created_at: Mapped[str] = mapped_column(Text, nullable=False)
 
 
+class TaskLinkRow(Base):
+    """A thin, Project-scoped correlation row for an ingested/assigned task node (Story 4.2, AD-9).
+
+    Populated by two independent creation paths (only ingestion is implemented
+    in this story): (1) ingestion — parsed from BMAD stories or spec-kit
+    ``tasks.md`` in a Project's member repos, setting ``story_node_id``; or
+    (2) manual assignment (Story 4.3, not yet implemented) — targeting an
+    existing tracker ticket, setting ``tracker_ticket_ref``/``prompt_override``
+    with ``story_node_id`` left null. Exactly one of ``story_node_id`` /
+    ``tracker_ticket_ref`` is guaranteed non-null at creation, never neither.
+
+    ``story_node_id`` is only unique within one repo, so uniqueness/upsert
+    matching is on ``(project_id, repo_path, story_node_id)`` — never a bare
+    ``story_node_id``. ``depends_on`` is stored as a JSON list of composite
+    ``"{repo_path}::{story_node_id}"`` strings so a dependency edge always
+    unambiguously names its target, whether same-repo or a sibling member
+    repo of the same Project.
+    """
+
+    __tablename__ = "task_links"
+    __table_args__ = (
+        Index(
+            "ix_task_links_project_repo_node",
+            "project_id",
+            "repo_path",
+            "story_node_id",
+            unique=True,
+        ),
+    )
+
+    id: Mapped[str] = mapped_column(String, primary_key=True)
+    project_id: Mapped[str] = mapped_column(String, ForeignKey("projects.id"), nullable=False, index=True)
+    repo_path: Mapped[str] = mapped_column(String, nullable=False)
+    story_node_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    depends_on: Mapped[str] = mapped_column(Text, nullable=False, default="[]", server_default="[]")  # JSON list
+    job_id: Mapped[str | None] = mapped_column(String, ForeignKey("jobs.id"), nullable=True)
+    tracker_ticket_ref: Mapped[str | None] = mapped_column(String, nullable=True)
+    prompt_override: Mapped[str | None] = mapped_column(Text, nullable=True)
+    epic_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(TZDateTime, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(TZDateTime, nullable=False)
+
+
 class SidecarTemplateRow(Base):
     __tablename__ = "sidecar_templates"
 

--- a/backend/models/domain.py
+++ b/backend/models/domain.py
@@ -708,6 +708,30 @@ class ProjectSummary:
 
 
 @dataclass
+class TaskLink:
+    """Domain representation of a TaskLink (Story 4.2, AD-9).
+
+    A thin, Project-scoped correlation row — never a parallel execution
+    model competing with ``Job``. Exactly one of ``story_node_id`` /
+    ``tracker_ticket_ref`` is guaranteed non-null at creation. ``depends_on``
+    holds composite ``"{repo_path}::{story_node_id}"`` strings since
+    ``story_node_id`` is only unique within one repo.
+    """
+
+    id: str
+    project_id: str
+    repo_path: str
+    story_node_id: str | None
+    depends_on: list[str]
+    job_id: str | None
+    tracker_ticket_ref: str | None
+    prompt_override: str | None
+    epic_id: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass
 class MCPServerConfig:
     command: str
     args: list[str]

--- a/backend/persistence/task_link_repo.py
+++ b/backend/persistence/task_link_repo.py
@@ -1,0 +1,99 @@
+"""TaskLink persistence — the sole store for ingested/assigned task nodes (Story 4.2, AD-9)."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+
+from backend.models.db import TaskLinkRow
+from backend.models.domain import TaskLink
+from backend.persistence.repository import BaseRepository
+
+
+class TaskLinkRepository(BaseRepository):
+    """Database access for TaskLink records.
+
+    Upserts are matched by ``(project_id, repo_path, story_node_id)`` — never
+    a bare ``story_node_id``, since that is only unique within one repo
+    (AD-9). Manually-assigned TaskLinks (``story_node_id`` null,
+    ``tracker_ticket_ref`` set — Story 4.3, not yet implemented) are always
+    inserted fresh since there is no natural upsert key for them here.
+    """
+
+    @staticmethod
+    def _to_domain(row: TaskLinkRow) -> TaskLink:
+        return TaskLink(
+            id=row.id,
+            project_id=row.project_id,
+            repo_path=row.repo_path,
+            story_node_id=row.story_node_id,
+            depends_on=json.loads(row.depends_on) if row.depends_on else [],
+            job_id=row.job_id,
+            tracker_ticket_ref=row.tracker_ticket_ref,
+            prompt_override=row.prompt_override,
+            epic_id=row.epic_id,
+            created_at=row.created_at,
+            updated_at=row.updated_at,
+        )
+
+    async def upsert_many(
+        self,
+        project_id: str,
+        entries: list[dict[str, object]],
+    ) -> list[TaskLink]:
+        """Upsert a batch of ingested TaskLinks for a Project.
+
+        Each entry must contain ``repo_path``, ``story_node_id``,
+        ``depends_on`` (list[str]), and optionally ``epic_id``. Matched by
+        ``(project_id, repo_path, story_node_id)``; re-ingestion never
+        creates duplicate rows.
+        """
+        now = datetime.now(UTC)
+        results: list[TaskLink] = []
+        for entry in entries:
+            repo_path = str(entry["repo_path"])
+            story_node_id = entry.get("story_node_id")
+            depends_on = entry.get("depends_on", [])
+            epic_id = entry.get("epic_id")
+
+            stmt = select(TaskLinkRow).where(
+                TaskLinkRow.project_id == project_id,
+                TaskLinkRow.repo_path == repo_path,
+                TaskLinkRow.story_node_id == story_node_id,
+            )
+            result = await self._session.execute(stmt)
+            row = result.scalar_one_or_none()
+
+            if row is None:
+                row = TaskLinkRow(
+                    id=str(uuid.uuid4()),
+                    project_id=project_id,
+                    repo_path=repo_path,
+                    story_node_id=story_node_id,
+                    depends_on=json.dumps(depends_on),
+                    epic_id=epic_id,
+                    created_at=now,
+                    updated_at=now,
+                )
+                self._session.add(row)
+            else:
+                row.depends_on = json.dumps(depends_on)
+                row.epic_id = epic_id  # type: ignore[assignment]
+                row.updated_at = now
+
+            await self._session.flush()
+            results.append(self._to_domain(row))
+        return results
+
+    async def list_by_project(self, project_id: str) -> list[TaskLink]:
+        """List every TaskLink for a Project, ordered by creation time."""
+        stmt = (
+            select(TaskLinkRow)
+            .where(TaskLinkRow.project_id == project_id)
+            .order_by(TaskLinkRow.created_at)
+        )
+        result = await self._session.execute(stmt)
+        return [self._to_domain(row) for row in result.scalars().all()]

--- a/backend/services/recipe/__init__.py
+++ b/backend/services/recipe/__init__.py
@@ -1,0 +1,1 @@
+"""Task Recipe / TaskLink ingestion (Story 4.2, CAP-9/AD-9)."""

--- a/backend/services/recipe/parsers.py
+++ b/backend/services/recipe/parsers.py
@@ -1,0 +1,128 @@
+"""Read-only parsers for BMAD stories and spec-kit ``tasks.md`` (Story 4.2, CAP-9/AD-9).
+
+Both parsers are pure, stateless functions: given a repo path, they read
+whatever source files exist (tolerating their absence) and return a list of
+:class:`ParsedTask` describing the tasks found. Nothing here ever writes to
+the source repo, and nothing here resolves cross-repo ``depends_on``
+references — that composite-key resolution is owned by
+``RecipeService.ingest_project``, since a parser only knows about the one
+repo it was pointed at.
+
+Dependency reference convention (documented, not upstream-standardized):
+
+* A bare id (e.g. ``4-1-widen-the-task-recipe-vocabulary`` or ``T001``) means
+  "the task with this id in the same repo".
+* An id containing a ``/`` (e.g. ``codeplane-frontend/2-1-create-edit-a-project``)
+  means "the task with this id in the sibling member repo whose folder name
+  is the part before the ``/``".
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+_BMAD_FILENAME_RE = re.compile(r"^(?P<epic>\d+)-(?P<story>\d+)-(?P<slug>.+)$")
+_DEPENDENCIES_SECTION_RE = re.compile(
+    r"^##\s+Dependencies\s*$(?P<body>.*?)(?=^##\s|\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+_DEPENDENCY_ITEM_RE = re.compile(r"^\s*[-*]\s+`?([\w./-]+)`?\s*$", re.MULTILINE)
+
+_SPEC_KIT_TASK_RE = re.compile(r"^-\s*\[.\]\s*(?P<task_id>T\d+)\b\s*(?P<rest>.*)$")
+_SPEC_KIT_DEPENDS_RE = re.compile(r"depends on:?\s*([\w./,\s-]+?)(?:\)|$)", re.IGNORECASE)
+
+
+@dataclass
+class ParsedTask:
+    """A single task/story node parsed from a source repo, pre-cross-repo-resolution.
+
+    ``depends_on`` entries are raw ids as written in the source file — either
+    bare (same-repo) or ``sibling-repo-folder/id`` (cross-repo) — not yet the
+    composite ``repo_path::story_node_id`` keys ``RecipeService`` stores.
+    """
+
+    story_node_id: str
+    depends_on: list[str] = field(default_factory=list)
+    epic_id: str | None = None
+
+
+def _split_dependency_ids(raw: str) -> list[str]:
+    return [part.strip() for part in re.split(r"[,\s]+", raw) if part.strip()]
+
+
+def parse_bmad_stories(repo_path: str) -> list[ParsedTask]:
+    """Parse every BMAD story file in ``repo_path/_bmad-output/implementation-artifacts/``.
+
+    ``story_node_id`` is the filename stem (e.g.
+    ``4-2-ingest-a-task-graph-into-a-project``). ``epic_id`` is derived only
+    from the ``{epic}-{story}-{slug}.md`` naming convention (``epic-{epic}``,
+    matching the keys already used in ``sprint-status.yaml``) — never
+    invented when the filename doesn't match that shape. ``depends_on`` is
+    read from an explicit ``## Dependencies`` section listing other story
+    keys, one per bullet; absent when no such section exists.
+
+    Tolerates a missing ``implementation-artifacts`` directory by returning
+    an empty list rather than raising, so one repo's absence never fails
+    ingestion for the whole Project.
+    """
+    base = Path(repo_path) / "_bmad-output" / "implementation-artifacts"
+    if not base.is_dir():
+        return []
+
+    tasks: list[ParsedTask] = []
+    for story_file in sorted(base.glob("*.md")):
+        stem = story_file.stem
+        match = _BMAD_FILENAME_RE.match(stem)
+        epic_id = f"epic-{match.group('epic')}" if match else None
+
+        text = story_file.read_text(encoding="utf-8")
+        depends_on: list[str] = []
+        dep_match = _DEPENDENCIES_SECTION_RE.search(text)
+        if dep_match:
+            depends_on = _DEPENDENCY_ITEM_RE.findall(dep_match.group("body"))
+
+        tasks.append(ParsedTask(story_node_id=stem, depends_on=depends_on, epic_id=epic_id))
+    return tasks
+
+
+def _find_tasks_md_files(repo_path: str) -> list[Path]:
+    root = Path(repo_path)
+    found: list[Path] = []
+    root_tasks = root / "tasks.md"
+    if root_tasks.is_file():
+        found.append(root_tasks)
+    specs_dir = root / "specs"
+    if specs_dir.is_dir():
+        found.extend(sorted(specs_dir.glob("**/tasks.md")))
+    return found
+
+
+def parse_spec_kit_tasks(repo_path: str) -> list[ParsedTask]:
+    """Parse spec-kit ``tasks.md`` file(s) in ``repo_path`` (root and/or ``specs/**``).
+
+    ``story_node_id`` is the leading ``T\\d+`` task id on each checkbox line.
+    ``depends_on`` is read from a ``depends on: ...`` annotation on the same
+    line (comma/space separated ids); absent when no such annotation exists.
+    spec-kit tasks never have Epic membership, so ``epic_id`` is always null
+    for tasks sourced this way — never guessed.
+
+    Tolerates the total absence of any ``tasks.md`` by returning an empty
+    list rather than raising.
+    """
+    tasks: list[ParsedTask] = []
+    for tasks_file in _find_tasks_md_files(repo_path):
+        text = tasks_file.read_text(encoding="utf-8")
+        for line in text.splitlines():
+            match = _SPEC_KIT_TASK_RE.match(line)
+            if not match:
+                continue
+            task_id = match.group("task_id")
+            rest = match.group("rest")
+            depends_on: list[str] = []
+            depends_match = _SPEC_KIT_DEPENDS_RE.search(rest)
+            if depends_match:
+                depends_on = _split_dependency_ids(depends_match.group(1))
+            tasks.append(ParsedTask(story_node_id=task_id, depends_on=depends_on, epic_id=None))
+    return tasks

--- a/backend/services/recipe/recipe_service.py
+++ b/backend/services/recipe/recipe_service.py
@@ -1,0 +1,94 @@
+"""Task Recipe ingestion orchestration (Story 4.2, CAP-9/AD-9).
+
+``RecipeService.ingest_project`` is a stateless, on-demand function — never
+a background watcher/poller. It is Project-scoped: it iterates exactly
+``project.repo_paths`` (AD-5), parses each member repo's BMAD stories and
+spec-kit ``tasks.md`` independently and read-only, resolves ``depends_on``
+edges into unambiguous composite ``"{repo_path}::{story_node_id}"`` keys
+across the whole Project (since ``story_node_id`` is only unique within one
+repo), and upserts one ``TaskLinkRow`` per parsed task — never duplicating
+across re-runs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from backend.services.recipe.parsers import ParsedTask, parse_bmad_stories, parse_spec_kit_tasks
+
+if TYPE_CHECKING:
+    from backend.models.domain import TaskLink
+    from backend.persistence.task_link_repo import TaskLinkRepository
+    from backend.services.project.project_service import ProjectService
+
+
+class RecipeService:
+    """Orchestrates TaskLink ingestion for a Project."""
+
+    def __init__(self, task_link_repo: TaskLinkRepository, project_service: ProjectService) -> None:
+        self._task_link_repo = task_link_repo
+        self._project_service = project_service
+
+    @staticmethod
+    def _resolve_dependency(raw: str, *, current_repo_path: str, repo_path_by_folder: dict[str, str]) -> str:
+        """Resolve a raw (bare or ``folder/id``) dependency reference to a composite key.
+
+        A bare id resolves against ``current_repo_path``. An id containing a
+        ``/`` resolves the part before the last ``/`` as a sibling repo's
+        folder name (``Path(repo_path).name``); if no member repo matches
+        that folder name, the raw string is preserved as-is (best-effort,
+        never raises) so a single unresolvable reference never fails the
+        whole ingestion run.
+        """
+        if "/" in raw:
+            folder, _, node_id = raw.rpartition("/")
+            matched_repo = repo_path_by_folder.get(folder)
+            if matched_repo is not None:
+                return f"{matched_repo}::{node_id}"
+            return raw
+        return f"{current_repo_path}::{raw}"
+
+    async def ingest_project(self, project_id: str) -> list[TaskLink]:
+        """Ingest BMAD stories and spec-kit tasks for every member repo of a Project.
+
+        Read-only against every source repo; never reads or writes outside
+        ``project.repo_paths``. Re-running is idempotent: existing
+        ``TaskLink``s are upserted by ``(project_id, repo_path,
+        story_node_id)``, never duplicated.
+        """
+        project = await self._project_service.get(project_id)
+        repo_path_by_folder = {Path(p).name: p for p in project.repo_paths}
+
+        parsed_by_repo: dict[str, list[ParsedTask]] = {}
+        for repo_path in project.repo_paths:
+            parsed = parse_bmad_stories(repo_path) + parse_spec_kit_tasks(repo_path)
+            parsed_by_repo[repo_path] = parsed
+
+        entries: list[dict[str, object]] = []
+        for repo_path, parsed_tasks in parsed_by_repo.items():
+            for task in parsed_tasks:
+                resolved_depends_on = [
+                    self._resolve_dependency(
+                        dep,
+                        current_repo_path=repo_path,
+                        repo_path_by_folder=repo_path_by_folder,
+                    )
+                    for dep in task.depends_on
+                ]
+                entries.append(
+                    {
+                        "repo_path": repo_path,
+                        "story_node_id": task.story_node_id,
+                        "depends_on": resolved_depends_on,
+                        "epic_id": task.epic_id,
+                    }
+                )
+
+        return await self._task_link_repo.upsert_many(project_id, entries)
+
+    async def list_task_links(self, project_id: str) -> list[TaskLink]:
+        """List every TaskLink currently persisted for a Project."""
+        # Ensure the Project exists (raises ProjectNotFoundError otherwise).
+        await self._project_service.get(project_id)
+        return await self._task_link_repo.list_by_project(project_id)

--- a/backend/tests/integration/test_api_task_links.py
+++ b/backend/tests/integration/test_api_task_links.py
@@ -1,0 +1,126 @@
+"""Integration tests for TaskLink ingestion endpoints (Story 4.2 / CAP-9).
+
+Exercises:
+  POST /api/settings/projects/{id}/ingest-tasks
+  GET  /api/settings/projects/{id}/task-links
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from httpx import AsyncClient
+
+
+def _write_bmad_story(repo_root: Path, filename: str, body: str = "# S\n") -> None:
+    stories_dir = repo_root / "_bmad-output" / "implementation-artifacts"
+    stories_dir.mkdir(parents=True, exist_ok=True)
+    (stories_dir / filename).write_text(body, encoding="utf-8")
+
+
+class TestIngestTasks:
+    @pytest.mark.asyncio
+    async def test_ingest_creates_task_links_for_member_repos(
+        self, client: AsyncClient, tmp_path: Path
+    ) -> None:
+        repo_a = tmp_path / "repo-a"
+        repo_a.mkdir()
+        _write_bmad_story(repo_a, "1-1-first.md")
+        _write_bmad_story(repo_a, "1-2-second.md", "# S\n\n## Dependencies\n\n- 1-1-first\n")
+
+        created = await client.post(
+            "/api/settings/projects",
+            json={"name": "Ingest Me", "repoPaths": [str(repo_a)]},
+        )
+        assert created.status_code == 201
+        project_id = created.json()["id"]
+
+        resp = await client.post(f"/api/settings/projects/{project_id}/ingest-tasks")
+        assert resp.status_code == 201
+        items = resp.json()["items"]
+        assert len(items) == 2
+        by_node = {i["storyNodeId"]: i for i in items}
+        assert by_node["1-1-first"]["epicId"] == "epic-1"
+        assert by_node["1-2-second"]["dependsOn"][0].endswith("::1-1-first")
+
+    @pytest.mark.asyncio
+    async def test_reingest_upserts_not_duplicates(self, client: AsyncClient, tmp_path: Path) -> None:
+        repo_a = tmp_path / "repo-b"
+        repo_a.mkdir()
+        _write_bmad_story(repo_a, "2-1-task.md")
+
+        created = await client.post(
+            "/api/settings/projects",
+            json={"name": "Reingest Me", "repoPaths": [str(repo_a)]},
+        )
+        project_id = created.json()["id"]
+
+        first = await client.post(f"/api/settings/projects/{project_id}/ingest-tasks")
+        second = await client.post(f"/api/settings/projects/{project_id}/ingest-tasks")
+
+        assert len(first.json()["items"]) == 1
+        assert len(second.json()["items"]) == 1
+        assert first.json()["items"][0]["id"] == second.json()["items"][0]["id"]
+
+    @pytest.mark.asyncio
+    async def test_ingest_missing_project_returns_404(self, client: AsyncClient) -> None:
+        resp = await client.post("/api/settings/projects/does-not-exist/ingest-tasks")
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_ingest_never_writes_to_source_repo(self, client: AsyncClient, tmp_path: Path) -> None:
+        repo_a = tmp_path / "repo-c"
+        repo_a.mkdir()
+        _write_bmad_story(repo_a, "3-1-task.md")
+        story_file = repo_a / "_bmad-output" / "implementation-artifacts" / "3-1-task.md"
+        before = story_file.read_text(encoding="utf-8")
+
+        created = await client.post(
+            "/api/settings/projects",
+            json={"name": "Read Only", "repoPaths": [str(repo_a)]},
+        )
+        project_id = created.json()["id"]
+        await client.post(f"/api/settings/projects/{project_id}/ingest-tasks")
+
+        assert story_file.read_text(encoding="utf-8") == before
+
+
+class TestListTaskLinks:
+    @pytest.mark.asyncio
+    async def test_list_returns_ingested_task_links(self, client: AsyncClient, tmp_path: Path) -> None:
+        repo_a = tmp_path / "repo-d"
+        repo_a.mkdir()
+        _write_bmad_story(repo_a, "5-1-task.md")
+
+        created = await client.post(
+            "/api/settings/projects",
+            json={"name": "Listable", "repoPaths": [str(repo_a)]},
+        )
+        project_id = created.json()["id"]
+        await client.post(f"/api/settings/projects/{project_id}/ingest-tasks")
+
+        resp = await client.get(f"/api/settings/projects/{project_id}/task-links")
+        assert resp.status_code == 200
+        assert len(resp.json()["items"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_list_before_ingest_is_empty(self, client: AsyncClient) -> None:
+        created = await client.post(
+            "/api/settings/projects",
+            json={"name": "Empty Project", "repoPaths": ["/test/empty-proj"]},
+        )
+        project_id = created.json()["id"]
+
+        resp = await client.get(f"/api/settings/projects/{project_id}/task-links")
+        assert resp.status_code == 200
+        assert resp.json()["items"] == []
+
+    @pytest.mark.asyncio
+    async def test_list_missing_project_returns_404(self, client: AsyncClient) -> None:
+        resp = await client.get("/api/settings/projects/does-not-exist/task-links")
+        assert resp.status_code == 404

--- a/backend/tests/unit/test_recipe_parsers.py
+++ b/backend/tests/unit/test_recipe_parsers.py
@@ -1,0 +1,126 @@
+"""Tests for BMAD story / spec-kit tasks.md parsers (Story 4.2, CAP-9/AD-9)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from backend.services.recipe.parsers import parse_bmad_stories, parse_spec_kit_tasks
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestParseBmadStories:
+    def test_missing_directory_returns_empty(self, tmp_path: Path) -> None:
+        assert parse_bmad_stories(str(tmp_path)) == []
+
+    def test_parses_story_node_id_and_epic_id_from_filename(self, tmp_path: Path) -> None:
+        stories_dir = tmp_path / "_bmad-output" / "implementation-artifacts"
+        stories_dir.mkdir(parents=True)
+        (stories_dir / "4-1-widen-the-task-recipe-vocabulary.md").write_text(
+            "# Story 4.1\n\nNo dependencies section.\n", encoding="utf-8"
+        )
+
+        tasks = parse_bmad_stories(str(tmp_path))
+
+        assert len(tasks) == 1
+        task = tasks[0]
+        assert task.story_node_id == "4-1-widen-the-task-recipe-vocabulary"
+        assert task.epic_id == "epic-4"
+        assert task.depends_on == []
+
+    def test_parses_dependencies_section(self, tmp_path: Path) -> None:
+        stories_dir = tmp_path / "_bmad-output" / "implementation-artifacts"
+        stories_dir.mkdir(parents=True)
+        (stories_dir / "4-2-ingest-a-task-graph-into-a-project.md").write_text(
+            "# Story 4.2\n\n"
+            "## Dependencies\n\n"
+            "- 4-1-widen-the-task-recipe-vocabulary\n"
+            "- codeplane-frontend/2-1-create-edit-a-project\n\n"
+            "## Dev Notes\n\nSome unrelated content mentioning 9-9-not-a-dependency.\n",
+            encoding="utf-8",
+        )
+
+        tasks = parse_bmad_stories(str(tmp_path))
+
+        assert len(tasks) == 1
+        task = tasks[0]
+        assert task.story_node_id == "4-2-ingest-a-task-graph-into-a-project"
+        assert task.epic_id == "epic-4"
+        assert task.depends_on == [
+            "4-1-widen-the-task-recipe-vocabulary",
+            "codeplane-frontend/2-1-create-edit-a-project",
+        ]
+
+    def test_filename_not_matching_convention_gets_null_epic_id(self, tmp_path: Path) -> None:
+        stories_dir = tmp_path / "_bmad-output" / "implementation-artifacts"
+        stories_dir.mkdir(parents=True)
+        (stories_dir / "retrospective-notes.md").write_text("# Notes\n", encoding="utf-8")
+
+        tasks = parse_bmad_stories(str(tmp_path))
+
+        assert len(tasks) == 1
+        assert tasks[0].epic_id is None
+
+    def test_multiple_stories_sorted(self, tmp_path: Path) -> None:
+        stories_dir = tmp_path / "_bmad-output" / "implementation-artifacts"
+        stories_dir.mkdir(parents=True)
+        (stories_dir / "1-2-second.md").write_text("# S\n", encoding="utf-8")
+        (stories_dir / "1-1-first.md").write_text("# S\n", encoding="utf-8")
+
+        tasks = parse_bmad_stories(str(tmp_path))
+
+        assert [t.story_node_id for t in tasks] == ["1-1-first", "1-2-second"]
+
+
+class TestParseSpecKitTasks:
+    def test_missing_tasks_md_returns_empty(self, tmp_path: Path) -> None:
+        assert parse_spec_kit_tasks(str(tmp_path)) == []
+
+    def test_parses_root_tasks_md(self, tmp_path: Path) -> None:
+        (tmp_path / "tasks.md").write_text(
+            "- [ ] T001 Setup project structure\n"
+            "- [ ] T002 Implement model (depends on: T001)\n"
+            "- [x] T003 Done task, depends on T001, T002\n",
+            encoding="utf-8",
+        )
+
+        tasks = parse_spec_kit_tasks(str(tmp_path))
+
+        by_id = {t.story_node_id: t for t in tasks}
+        assert set(by_id) == {"T001", "T002", "T003"}
+        assert by_id["T001"].depends_on == []
+        assert by_id["T001"].epic_id is None
+        assert by_id["T002"].depends_on == ["T001"]
+        assert by_id["T003"].depends_on == ["T001", "T002"]
+
+    def test_parses_cross_repo_dependency_reference(self, tmp_path: Path) -> None:
+        (tmp_path / "tasks.md").write_text(
+            "- [ ] T010 Frontend task (depends on: codeplane-backend/T002)\n",
+            encoding="utf-8",
+        )
+
+        tasks = parse_spec_kit_tasks(str(tmp_path))
+
+        assert tasks[0].depends_on == ["codeplane-backend/T002"]
+
+    def test_parses_nested_specs_tasks_md(self, tmp_path: Path) -> None:
+        nested = tmp_path / "specs" / "001-feature" / "tasks.md"
+        nested.parent.mkdir(parents=True)
+        nested.write_text("- [ ] T001 A task\n", encoding="utf-8")
+
+        tasks = parse_spec_kit_tasks(str(tmp_path))
+
+        assert len(tasks) == 1
+        assert tasks[0].story_node_id == "T001"
+
+    def test_non_task_lines_ignored(self, tmp_path: Path) -> None:
+        (tmp_path / "tasks.md").write_text(
+            "# Tasks\n\nSome prose that is not a checkbox line.\n- [ ] T001 Real task\n",
+            encoding="utf-8",
+        )
+
+        tasks = parse_spec_kit_tasks(str(tmp_path))
+
+        assert len(tasks) == 1
+        assert tasks[0].story_node_id == "T001"

--- a/backend/tests/unit/test_recipe_service.py
+++ b/backend/tests/unit/test_recipe_service.py
@@ -1,0 +1,190 @@
+"""Tests for RecipeService.ingest_project — cross-repo depends_on resolution (Story 4.2, AD-9)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.models.domain import Project
+from backend.services.recipe.recipe_service import RecipeService
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _make_project(project_id: str, repo_paths: list[str]) -> Project:
+    now = datetime.now(UTC)
+    return Project(id=project_id, name="Test Project", repo_paths=repo_paths, created_at=now, updated_at=now)
+
+
+def _write_bmad_story(repo_root: Path, filename: str, body: str = "") -> None:
+    stories_dir = repo_root / "_bmad-output" / "implementation-artifacts"
+    stories_dir.mkdir(parents=True, exist_ok=True)
+    (stories_dir / filename).write_text(body, encoding="utf-8")
+
+
+@pytest.fixture
+def mock_task_link_repo() -> AsyncMock:
+    mock = AsyncMock()
+    mock.upsert_many.side_effect = lambda project_id, entries: entries  # echo back for assertions
+    return mock
+
+
+@pytest.fixture
+def mock_project_service() -> AsyncMock:
+    return AsyncMock()
+
+
+class TestIngestProject:
+    @pytest.mark.asyncio
+    async def test_single_repo_same_repo_dependency(
+        self, tmp_path: Path, mock_task_link_repo: AsyncMock, mock_project_service: AsyncMock
+    ) -> None:
+        repo_a = tmp_path / "backend-repo"
+        repo_a.mkdir()
+        _write_bmad_story(repo_a, "1-1-first.md", "# S\n")
+        _write_bmad_story(
+            repo_a,
+            "1-2-second.md",
+            "# S\n\n## Dependencies\n\n- 1-1-first\n",
+        )
+        mock_project_service.get.return_value = _make_project("proj-1", [str(repo_a)])
+
+        service = RecipeService(mock_task_link_repo, mock_project_service)
+        await service.ingest_project("proj-1")
+
+        entries = mock_task_link_repo.upsert_many.call_args.args[1]
+        by_node = {e["story_node_id"]: e for e in entries}
+        assert by_node["1-2-second"]["depends_on"] == [f"{repo_a}::1-1-first"]
+        assert by_node["1-1-first"]["depends_on"] == []
+        assert by_node["1-1-first"]["epic_id"] == "epic-1"
+
+    @pytest.mark.asyncio
+    async def test_cross_repo_dependency_resolves_to_sibling_repo(
+        self, tmp_path: Path, mock_task_link_repo: AsyncMock, mock_project_service: AsyncMock
+    ) -> None:
+        backend_repo = tmp_path / "codeplane-backend"
+        frontend_repo = tmp_path / "codeplane-frontend"
+        backend_repo.mkdir()
+        frontend_repo.mkdir()
+        _write_bmad_story(backend_repo, "2-1-backend-task.md", "# S\n")
+        _write_bmad_story(
+            frontend_repo,
+            "3-1-frontend-task.md",
+            "# S\n\n## Dependencies\n\n- codeplane-backend/2-1-backend-task\n",
+        )
+        mock_project_service.get.return_value = _make_project(
+            "proj-1", [str(backend_repo), str(frontend_repo)]
+        )
+
+        service = RecipeService(mock_task_link_repo, mock_project_service)
+        await service.ingest_project("proj-1")
+
+        entries = mock_task_link_repo.upsert_many.call_args.args[1]
+        frontend_entry = next(e for e in entries if e["story_node_id"] == "3-1-frontend-task")
+        assert frontend_entry["depends_on"] == [f"{backend_repo}::2-1-backend-task"]
+
+    @pytest.mark.asyncio
+    async def test_unresolvable_cross_repo_dependency_preserved_raw(
+        self, tmp_path: Path, mock_task_link_repo: AsyncMock, mock_project_service: AsyncMock
+    ) -> None:
+        repo_a = tmp_path / "solo-repo"
+        repo_a.mkdir()
+        _write_bmad_story(
+            repo_a,
+            "1-1-task.md",
+            "# S\n\n## Dependencies\n\n- unknown-repo/9-9-ghost\n",
+        )
+        mock_project_service.get.return_value = _make_project("proj-1", [str(repo_a)])
+
+        service = RecipeService(mock_task_link_repo, mock_project_service)
+        await service.ingest_project("proj-1")
+
+        entries = mock_task_link_repo.upsert_many.call_args.args[1]
+        assert entries[0]["depends_on"] == ["unknown-repo/9-9-ghost"]
+
+    @pytest.mark.asyncio
+    async def test_spec_kit_and_bmad_both_ingested(
+        self, tmp_path: Path, mock_task_link_repo: AsyncMock, mock_project_service: AsyncMock
+    ) -> None:
+        repo_a = tmp_path / "mixed-repo"
+        repo_a.mkdir()
+        _write_bmad_story(repo_a, "1-1-story.md", "# S\n")
+        (repo_a / "tasks.md").write_text("- [ ] T001 Spec-kit task\n", encoding="utf-8")
+        mock_project_service.get.return_value = _make_project("proj-1", [str(repo_a)])
+
+        service = RecipeService(mock_task_link_repo, mock_project_service)
+        await service.ingest_project("proj-1")
+
+        entries = mock_task_link_repo.upsert_many.call_args.args[1]
+        node_ids = {e["story_node_id"] for e in entries}
+        assert node_ids == {"1-1-story", "T001"}
+
+    @pytest.mark.asyncio
+    async def test_repo_with_no_source_files_yields_no_entries_but_does_not_fail(
+        self, tmp_path: Path, mock_task_link_repo: AsyncMock, mock_project_service: AsyncMock
+    ) -> None:
+        empty_repo = tmp_path / "empty-repo"
+        empty_repo.mkdir()
+        mock_project_service.get.return_value = _make_project("proj-1", [str(empty_repo)])
+
+        service = RecipeService(mock_task_link_repo, mock_project_service)
+        await service.ingest_project("proj-1")
+
+        entries = mock_task_link_repo.upsert_many.call_args.args[1]
+        assert entries == []
+
+    @pytest.mark.asyncio
+    async def test_never_writes_to_source_repo(
+        self, tmp_path: Path, mock_task_link_repo: AsyncMock, mock_project_service: AsyncMock
+    ) -> None:
+        repo_a = tmp_path / "repo-a"
+        repo_a.mkdir()
+        _write_bmad_story(repo_a, "1-1-story.md", "# S\n")
+        story_file = repo_a / "_bmad-output" / "implementation-artifacts" / "1-1-story.md"
+        before_mtime = story_file.stat().st_mtime
+        before_content = story_file.read_text(encoding="utf-8")
+        mock_project_service.get.return_value = _make_project("proj-1", [str(repo_a)])
+
+        service = RecipeService(mock_task_link_repo, mock_project_service)
+        await service.ingest_project("proj-1")
+
+        assert story_file.stat().st_mtime == before_mtime
+        assert story_file.read_text(encoding="utf-8") == before_content
+
+    @pytest.mark.asyncio
+    async def test_idempotent_rerun_calls_upsert_not_insert_only(
+        self, tmp_path: Path, mock_task_link_repo: AsyncMock, mock_project_service: AsyncMock
+    ) -> None:
+        repo_a = tmp_path / "repo-a"
+        repo_a.mkdir()
+        _write_bmad_story(repo_a, "1-1-story.md", "# S\n")
+        mock_project_service.get.return_value = _make_project("proj-1", [str(repo_a)])
+
+        service = RecipeService(mock_task_link_repo, mock_project_service)
+        await service.ingest_project("proj-1")
+        await service.ingest_project("proj-1")
+
+        assert mock_task_link_repo.upsert_many.call_count == 2
+        first_entries = mock_task_link_repo.upsert_many.call_args_list[0].args[1]
+        second_entries = mock_task_link_repo.upsert_many.call_args_list[1].args[1]
+        assert first_entries == second_entries
+
+
+class TestListTaskLinks:
+    @pytest.mark.asyncio
+    async def test_list_delegates_to_repo_after_project_check(
+        self, mock_task_link_repo: AsyncMock, mock_project_service: AsyncMock
+    ) -> None:
+        mock_project_service.get.return_value = _make_project("proj-1", [])
+        mock_task_link_repo.list_by_project.return_value = []
+
+        service = RecipeService(mock_task_link_repo, mock_project_service)
+        result = await service.list_task_links("proj-1")
+
+        mock_project_service.get.assert_awaited_once_with("proj-1")
+        mock_task_link_repo.list_by_project.assert_awaited_once_with("proj-1")
+        assert result == []

--- a/backend/tests/unit/test_task_link_repo.py
+++ b/backend/tests/unit/test_task_link_repo.py
@@ -1,0 +1,123 @@
+"""Tests for TaskLinkRepository — upsert-by-natural-key and project listing (Story 4.2, AD-9)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from sqlalchemy import event as sa_event
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from backend.models.db import Base
+from backend.persistence.database import _set_sqlite_pragmas
+from backend.persistence.project_repo import ProjectRepository
+from backend.persistence.task_link_repo import TaskLinkRepository
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+
+@pytest.fixture
+async def session() -> AsyncGenerator[AsyncSession, None]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    sa_event.listen(engine.sync_engine, "connect", _set_sqlite_pragmas)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as sess:
+        yield sess
+    await engine.dispose()
+
+
+async def _make_project(session: AsyncSession) -> str:
+    project_repo = ProjectRepository(session)
+    project = await project_repo.create("proj-1", "Test Project", ["/repo/a", "/repo/b"])
+    await session.commit()
+    return project.id
+
+
+class TestTaskLinkRepoUpsert:
+    @pytest.mark.asyncio
+    async def test_upsert_inserts_new_rows(self, session: AsyncSession) -> None:
+        project_id = await _make_project(session)
+        repo = TaskLinkRepository(session)
+
+        results = await repo.upsert_many(
+            project_id,
+            [
+                {
+                    "repo_path": "/repo/a",
+                    "story_node_id": "1-1-task",
+                    "depends_on": [],
+                    "epic_id": "epic-1",
+                },
+                {
+                    "repo_path": "/repo/a",
+                    "story_node_id": "1-2-task",
+                    "depends_on": ["/repo/a::1-1-task"],
+                    "epic_id": "epic-1",
+                },
+            ],
+        )
+        await session.commit()
+
+        assert len(results) == 2
+        listed = await repo.list_by_project(project_id)
+        assert {t.story_node_id for t in listed} == {"1-1-task", "1-2-task"}
+        second = next(t for t in listed if t.story_node_id == "1-2-task")
+        assert second.depends_on == ["/repo/a::1-1-task"]
+        assert second.epic_id == "epic-1"
+
+    @pytest.mark.asyncio
+    async def test_upsert_matches_by_project_repo_story_node(self, session: AsyncSession) -> None:
+        project_id = await _make_project(session)
+        repo = TaskLinkRepository(session)
+
+        await repo.upsert_many(
+            project_id,
+            [{"repo_path": "/repo/a", "story_node_id": "1-1-task", "depends_on": [], "epic_id": None}],
+        )
+        await session.commit()
+
+        # Re-ingest with an updated depends_on — must update, not duplicate.
+        await repo.upsert_many(
+            project_id,
+            [
+                {
+                    "repo_path": "/repo/a",
+                    "story_node_id": "1-1-task",
+                    "depends_on": ["/repo/b::2-1-task"],
+                    "epic_id": "epic-1",
+                }
+            ],
+        )
+        await session.commit()
+
+        listed = await repo.list_by_project(project_id)
+        assert len(listed) == 1
+        assert listed[0].depends_on == ["/repo/b::2-1-task"]
+        assert listed[0].epic_id == "epic-1"
+
+    @pytest.mark.asyncio
+    async def test_same_story_node_id_different_repo_is_distinct(self, session: AsyncSession) -> None:
+        project_id = await _make_project(session)
+        repo = TaskLinkRepository(session)
+
+        await repo.upsert_many(
+            project_id,
+            [
+                {"repo_path": "/repo/a", "story_node_id": "T001", "depends_on": [], "epic_id": None},
+                {"repo_path": "/repo/b", "story_node_id": "T001", "depends_on": [], "epic_id": None},
+            ],
+        )
+        await session.commit()
+
+        listed = await repo.list_by_project(project_id)
+        assert len(listed) == 2
+        assert {t.repo_path for t in listed} == {"/repo/a", "/repo/b"}
+
+    @pytest.mark.asyncio
+    async def test_list_by_project_empty(self, session: AsyncSession) -> None:
+        project_id = await _make_project(session)
+        repo = TaskLinkRepository(session)
+        assert await repo.list_by_project(project_id) == []


### PR DESCRIPTION
## Summary

Implements Story 4.2 ("Ingest a task graph into a Project") per CAP-9 (`_bmad-output/specs/spec-project-boards/SPEC.md`) and AD-9 (`ARCHITECTURE-SPINE.md`). Adds `TaskLinkRow` persistence and a stateless, on-demand ingestion service that parses BMAD stories and spec-kit `tasks.md` from every member repo of a Project, resolving cross-repo `depends_on` edges.

Builds on Story 2.1's `Project` entity (merged, `162d97a2`). Sibling to Story 4.1 (widened recipe vocabulary, merged, `ecc42c77`) — no code overlap.

## What's included

- `TaskLinkRow` DB model + migration `0061_add_task_links.py` (down_revision `0060`, re-verified against `origin/main` immediately before opening this PR — head is still `0060_add_projects.py`).
- `TaskLinkRepository` (`upsert_many` matched by `project_id`/`repo_path`/`story_node_id`, `list_by_project`).
- `backend/services/recipe/`: stateless parsers (`parse_bmad_stories`, `parse_spec_kit_tasks`) + `RecipeService.ingest_project`, which resolves cross-repo `depends_on` references via composite `repo_path::story_node_id` keys.
- `POST /api/settings/projects/{id}/ingest-tasks` and `GET /api/settings/projects/{id}/task-links` (thin routes, `backend/api/projects.py`).
- `codeplane_project` MCP tool extended with `ingest_tasks` / `list_task_links` actions.
- DI wiring in `backend/di.py`.
- 29 new tests (unit: repo, parsers, service; integration: API endpoints) — all passing.

## Explicitly out of scope

Per the story's boundaries, this PR does **not** implement:
- Manual ticket assignment (4.3)
- TaskLink board card rendering (4.4)
- Auto-spawn (4.5)
- Tracker-write routing (4.6)
- Any frontend UI (matching Story 2.1's backend+MCP-only precedent; frontend deferred to 4.4+)

## Design notes / documented assumption

SPEC.md/AD-9 leave the exact dependency-annotation format as an "Assumption" rather than a hard requirement, since no existing BMAD story or spec-kit `tasks.md` in this repo uses a formal dependency annotation today. This PR establishes and documents a convention:
- BMAD stories: an explicit `## Dependencies` markdown section (bullet list), bare `story_node_id` for same-repo refs, `{sibling-repo-folder-name}/{story_node_id}` for cross-repo refs.
- spec-kit `tasks.md`: an inline `depends on: ...` annotation on the task line, same bare/cross-repo convention keyed by folder name.

Unresolvable cross-repo references are preserved as the raw string rather than raising (best-effort, ingestion never fails outright over one bad reference).

Ingestion is Project-scoped only (iterates exactly `project.repo_paths`), never mutates source repos (verified by a dedicated read-only test), and re-running is idempotent (upsert, not insert-only).

## Testing

```
uv run pytest backend/tests/unit/test_task_link_repo.py backend/tests/unit/test_recipe_parsers.py backend/tests/unit/test_recipe_service.py backend/tests/integration/test_api_task_links.py -q
# 29 passed

uv run pytest backend/tests/unit/test_project_repo.py backend/tests/integration/test_api_projects.py backend/tests/unit -q -k "project or task_link or recipe"
# 22 passed (no regressions)

uv run ruff check <new/modified files>
# clean
```

## Story file

`_bmad-output/implementation-artifacts/4-2-ingest-a-task-graph-into-a-project.md` — status `review`, `sprint-status.yaml` updated to `review`.