### PR TITLE
feat: implement Story 6.2 - codeplane_pr MCP tool (CAP-14)

### DIFF
--- a/backend/lifespan.py
+++ b/backend/lifespan.py
@@ -731,6 +731,7 @@ async def _init_optional_services(
         session_factory=session_factory,
         runtime_service=services.runtime_service,
         approval_service=services.approval_service,
+        merge_service=services.merge_service,
         sidecar_sessions=services.sidecar_sessions,
     )
     mcp_app = mcp_server.streamable_http_app()

--- a/backend/mcp/server.py
+++ b/backend/mcp/server.py
@@ -56,6 +56,7 @@ if TYPE_CHECKING:
     from backend.config import CPLConfig
     from backend.models.domain import Job
     from backend.services.job.approval_service import ApprovalService
+    from backend.services.merge_service import MergeService
     from backend.services.runtime import RuntimeService
     from backend.services.sidecar.session import SidecarSessionManager
 
@@ -91,6 +92,7 @@ class MCPState:
     session_factory: async_sessionmaker[AsyncSession]
     runtime_service: RuntimeService
     approval_service: ApprovalService
+    merge_service: MergeService
     sidecar_sessions: SidecarSessionManager | None = None
 
 
@@ -141,6 +143,7 @@ def create_mcp_server(
     session_factory: async_sessionmaker[AsyncSession],
     runtime_service: RuntimeService,
     approval_service: ApprovalService,
+    merge_service: MergeService,
     sidecar_sessions: SidecarSessionManager | None = None,
 ) -> FastMCP:
     """Create and configure the MCP server with all CodePlane tools."""
@@ -148,6 +151,7 @@ def create_mcp_server(
         session_factory=session_factory,
         runtime_service=runtime_service,
         approval_service=approval_service,
+        merge_service=merge_service,
         sidecar_sessions=sidecar_sessions,
     )
 
@@ -159,6 +163,7 @@ def create_mcp_server(
     )
 
     _register_job_tool(mcp, state)
+    _register_pr_tool(mcp, state)
     _register_approval_tool(mcp, state)
     _register_workspace_tool(mcp, state)
     _register_artifact_tool(mcp, state)
@@ -349,6 +354,50 @@ def _register_job_tool(mcp: FastMCP, mcp_state: MCPState) -> None:
                 seq=0,
                 timestamp=datetime.now(UTC),
             ).model_dump(mode="json")
+
+
+# ---------------------------------------------------------------------------
+# Agent-initiated PR request (CAP-14)
+# ---------------------------------------------------------------------------
+
+
+def _register_pr_tool(mcp: FastMCP, mcp_state: MCPState) -> None:
+    @mcp.tool(
+        name="codeplane_pr",
+        title="Request a Pull Request",
+        annotations=ToolAnnotations(title="Request a Pull Request", destructiveHint=True, openWorldHint=True),
+        description=(
+            "Proactively request a PR for the calling Job while it is still running, "
+            "instead of waiting for the automatic completion-time PR/merge step."
+            "\n\n"
+            "- job_id (required)"
+            "\n\n"
+            "Idempotent per Job: if a PR already exists for this Job (created via an "
+            "earlier call to this tool, or the automatic completion-time path), the "
+            "existing PR is returned instead of creating a duplicate. The agent never "
+            "receives or handles the underlying Credential's decrypted PAT — CodePlane "
+            "resolves and uses it server-side."
+        ),
+    )
+    async def codeplane_pr(job_id: str | None = None) -> McpToolResult:
+        if not job_id:
+            return {"error": "job_id is required"}
+
+        sf = mcp_state.session_factory
+        config = load_config()
+        async with sf() as session:
+            svc = _make_job_service(mcp_state, session, config, git=False)
+            try:
+                job = await svc.get_job(job_id)
+            except JobNotFoundError as exc:
+                return {"error": str(exc)}
+
+        result = await mcp_state.merge_service.request_pr_for_job(job)
+
+        if result.error:
+            return {"error": result.error}
+
+        return {"pr_url": result.pr_url, "status": str(result.status)}
 
 
 # ---------------------------------------------------------------------------

--- a/backend/services/merge_service/_service.py
+++ b/backend/services/merge_service/_service.py
@@ -349,6 +349,19 @@ class MergeService:
             await self._git.merge_abort(cwd=repo_path)
             return files
 
+    async def _get_existing_pr_url(self, job_id: str) -> str | None:
+        """Return the job's already-recorded PR url, if any.
+
+        Reads the current persisted state directly (not a cached ``Job``
+        the caller may be holding) so a race between two nearly-simultaneous
+        PR requests for the same job still converges on one PR.
+        """
+        from backend.persistence.job_repo import JobRepository
+
+        async with self._session_factory() as session:
+            job = await JobRepository(session).get(job_id)
+        return job.pr_url if job is not None else None
+
     async def _create_pr(
         self,
         job_id: str,
@@ -358,7 +371,18 @@ class MergeService:
         base_ref: str,
         prompt: str,
     ) -> MergeResult:
-        """Push branch and create a PR via platform adapter."""
+        """Push branch and create a PR via platform adapter.
+
+        Idempotent per Job: if a PR already exists for this job (recorded via
+        an earlier call — either the completion-time auto-PR path or the
+        agent-initiated ``codeplane_pr`` MCP tool), returns that PR instead of
+        pushing again or calling the platform adapter a second time (AD-14).
+        """
+        existing_pr_url = await self._get_existing_pr_url(job_id)
+        if existing_pr_url:
+            log.info("pr_already_exists", job_id=job_id, pr_url=existing_pr_url)
+            return MergeResult(status=MergeStatus.pr_created, strategy="pr", pr_url=existing_pr_url)
+
         cwd = worktree_path or repo_path
 
         # Push branch to origin first
@@ -566,6 +590,40 @@ class MergeService:
             return await self._operator_smart_merge(job_id, repo_path, worktree_path, branch, base_ref)
 
         return MergeResult(status=MergeStatus.error, error=f"Unknown action: {action}")
+
+    # ------------------------------------------------------------------
+    # Agent-initiated PR request (CAP-14) — codeplane_pr MCP tool
+    # ------------------------------------------------------------------
+
+    async def request_pr_for_job(self, job: Job) -> MergeResult:
+        """Create (or reuse) a PR for a still-running Job, on agent request.
+
+        Unlike :meth:`resolve_job`'s ``create_pr`` action — which runs only
+        once a Job has reached ``review`` and cleans up the worktree
+        afterward — this path is called *mid-job*, while the agent may still
+        be working in the worktree.  It therefore never removes the worktree
+        or branch.  Invokes the exact same :meth:`_create_pr` implementation
+        the completion-time auto-PR path uses (AD-14), which is idempotent
+        per Job, so a subsequent automatic PR at job completion (or another
+        mid-job call) reuses the same PR rather than creating a duplicate.
+        """
+        if job.source != "managed":
+            return MergeResult(status=MergeStatus.error, error="PR requests are only supported for managed jobs")
+
+        if not job.branch:
+            return MergeResult(status=MergeStatus.error, error="No branch to create a PR for")
+
+        if not _REF_PATTERN.match(job.branch) or not _REF_PATTERN.match(job.base_ref):
+            return MergeResult(status=MergeStatus.error, error="Invalid branch or base_ref")
+
+        return await self._create_pr(
+            job.id,
+            job.repo,
+            job.worktree_path,
+            job.branch,
+            job.base_ref,
+            job.prompt,
+        )
 
     async def _preserve_diff_snapshot(
         self,

--- a/backend/tests/unit/test_mcp_server.py
+++ b/backend/tests/unit/test_mcp_server.py
@@ -92,11 +92,23 @@ def mock_approval():
 
 
 @pytest.fixture
-def mcp_server(mock_session_factory, mock_runtime, mock_approval):
+def mock_merge_service():
+    from backend.services.merge_service import MergeResult, MergeStatus
+
+    merge = AsyncMock()
+    merge.request_pr_for_job = AsyncMock(
+        return_value=MergeResult(status=MergeStatus.pr_created, strategy="pr", pr_url="https://example.com/pr/1")
+    )
+    return merge
+
+
+@pytest.fixture
+def mcp_server(mock_session_factory, mock_runtime, mock_approval, mock_merge_service):
     return create_mcp_server(
         session_factory=mock_session_factory,
         runtime_service=mock_runtime,
         approval_service=mock_approval,
+        merge_service=mock_merge_service,
     )
 
 
@@ -114,6 +126,7 @@ class TestMCPServerCreation:
         tools = mcp_server._tool_manager._tools
         expected = {
             "codeplane_job",
+            "codeplane_pr",
             "codeplane_approval",
             "codeplane_workspace",
             "codeplane_artifact",
@@ -247,6 +260,67 @@ class TestJobTool:
         mock_runtime.send_message = AsyncMock(return_value=False)
         result = await _tool(mcp_server, "codeplane_job")(action="message", job_id="job-1", content="hi")
         assert "error" in result
+
+
+# ── PR tool (CAP-14) ─────────────────────────────────────────────────
+
+
+class TestPrTool:
+    @pytest.mark.asyncio
+    async def test_missing_job_id(self, mcp_server) -> None:
+        result = await _tool(mcp_server, "codeplane_pr")(job_id=None)
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_job_not_found(self, mcp_server) -> None:
+        from backend.models.domain import JobNotFoundError
+
+        with (
+            patch("backend.mcp.server.JobService") as mock_svc_cls,
+            patch("backend.mcp.server.GitService"),
+        ):
+            svc = AsyncMock()
+            svc.get_job = AsyncMock(side_effect=JobNotFoundError("nope"))
+            mock_svc_cls.return_value = svc
+
+            result = await _tool(mcp_server, "codeplane_pr")(job_id="missing")
+            assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_success(self, mcp_server, mock_merge_service) -> None:
+        job = make_job(id="job-123", repo="/test/repo", branch="feature/x")
+        with (
+            patch("backend.mcp.server.JobService") as mock_svc_cls,
+            patch("backend.mcp.server.GitService"),
+        ):
+            svc = AsyncMock()
+            svc.get_job = AsyncMock(return_value=job)
+            mock_svc_cls.return_value = svc
+
+            result = await _tool(mcp_server, "codeplane_pr")(job_id="job-123")
+
+            assert result["pr_url"] == "https://example.com/pr/1"
+            assert result["status"] == "pr_created"
+            mock_merge_service.request_pr_for_job.assert_awaited_once_with(job)
+
+    @pytest.mark.asyncio
+    async def test_service_error_propagated(self, mcp_server, mock_merge_service) -> None:
+        from backend.services.merge_service import MergeResult, MergeStatus
+
+        job = make_job(id="job-123", repo="/test/repo", branch=None)
+        mock_merge_service.request_pr_for_job = AsyncMock(
+            return_value=MergeResult(status=MergeStatus.error, error="No branch to create a PR for")
+        )
+        with (
+            patch("backend.mcp.server.JobService") as mock_svc_cls,
+            patch("backend.mcp.server.GitService"),
+        ):
+            svc = AsyncMock()
+            svc.get_job = AsyncMock(return_value=job)
+            mock_svc_cls.return_value = svc
+
+            result = await _tool(mcp_server, "codeplane_pr")(job_id="job-123")
+            assert "error" in result
 
 
 # ── Approval tool ────────────────────────────────────────────────────

--- a/backend/tests/unit/test_merge_service.py
+++ b/backend/tests/unit/test_merge_service.py
@@ -330,6 +330,129 @@ class TestPrOnlyStrategy:
 
 
 # ---------------------------------------------------------------------------
+# codeplane_pr — agent-initiated PR request (CAP-14 / AD-14)
+# ---------------------------------------------------------------------------
+
+
+class TestRequestPrForJob:
+    async def test_creates_pr_via_platform_registry(
+        self,
+        tmp_path: Path,
+        session_factory: async_sessionmaker[AsyncSession],
+        event_bus: EventBus,
+    ) -> None:
+        from unittest.mock import AsyncMock, MagicMock
+
+        from backend.services.adapters.platform_adapter import PRResult
+        from backend.services.merge_service import MergeStatus
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _init_repo(repo)
+        _branch_with_change(repo, "cpl/job-1", "file.py", "x = 1\n")
+
+        adapter = MagicMock()
+        adapter.name = "github"
+        adapter.create_pr = AsyncMock(return_value=PRResult(url="https://example.com/pr/1"))
+        registry = MagicMock()
+        registry.get_adapter = AsyncMock(return_value=adapter)
+
+        service = _make_service(event_bus, session_factory, strategy="pr_only")
+        service._platform_registry = registry  # noqa: SLF001
+
+        job = _make_job(str(repo))
+        await _insert_job(session_factory, job)
+
+        result = await service.request_pr_for_job(job)
+
+        assert result.status == MergeStatus.pr_created
+        assert result.pr_url == "https://example.com/pr/1"
+        adapter.create_pr.assert_awaited_once()
+
+    async def test_second_call_reuses_existing_pr(
+        self,
+        tmp_path: Path,
+        session_factory: async_sessionmaker[AsyncSession],
+        event_bus: EventBus,
+    ) -> None:
+        """AD-14: _create_pr is idempotent per Job — no duplicate PR/adapter call."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        from backend.services.adapters.platform_adapter import PRResult
+        from backend.services.merge_service import MergeStatus
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _init_repo(repo)
+        _branch_with_change(repo, "cpl/job-1", "file.py", "x = 1\n")
+
+        adapter = MagicMock()
+        adapter.name = "github"
+        adapter.create_pr = AsyncMock(return_value=PRResult(url="https://example.com/pr/1"))
+        registry = MagicMock()
+        registry.get_adapter = AsyncMock(return_value=adapter)
+
+        service = _make_service(event_bus, session_factory, strategy="pr_only")
+        service._platform_registry = registry  # noqa: SLF001
+
+        job = _make_job(str(repo))
+        await _insert_job(session_factory, job)
+
+        first = await service.request_pr_for_job(job)
+        second = await service.request_pr_for_job(job)
+
+        assert first.pr_url == second.pr_url == "https://example.com/pr/1"
+        assert second.status == MergeStatus.pr_created
+        adapter.create_pr.assert_awaited_once()  # not called again on the second request
+
+    async def test_no_branch_returns_error(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        event_bus: EventBus,
+    ) -> None:
+        from backend.services.merge_service import MergeStatus
+
+        service = _make_service(event_bus, session_factory, strategy="pr_only")
+        job = _make_job("/tmp/repo", branch=None)  # type: ignore[arg-type]
+
+        result = await service.request_pr_for_job(job)
+
+        assert result.status == MergeStatus.error
+        assert result.error is not None
+
+    async def test_invalid_branch_returns_error(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        event_bus: EventBus,
+    ) -> None:
+        from backend.services.merge_service import MergeStatus
+
+        service = _make_service(event_bus, session_factory, strategy="pr_only")
+        job = _make_job("/tmp/repo", branch="feature; rm -rf /")
+
+        result = await service.request_pr_for_job(job)
+
+        assert result.status == MergeStatus.error
+        assert result.error is not None
+
+    async def test_imported_job_rejected(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        event_bus: EventBus,
+    ) -> None:
+        from backend.services.merge_service import MergeStatus
+
+        service = _make_service(event_bus, session_factory, strategy="pr_only")
+        job = _make_job("/tmp/repo")
+        job.source = "imported"
+
+        result = await service.request_pr_for_job(job)
+
+        assert result.status == MergeStatus.error
+        assert result.error is not None
+
+
+# ---------------------------------------------------------------------------
 # False-positive conflict detection (regression tests)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Implements Story 6.2 "Agent requests a PR mid-job" from `_bmad-output/planning-artifacts/epics.md`, per ARCHITECTURE-SPINE AD-13/AD-14/CAP-14.

Adds a new agent-facing `codeplane_pr` MCP tool that lets an agent request a PR be opened mid-job, reusing the existing `MergeService._create_pr` implementation rather than a parallel one. `_create_pr` is now idempotent per Job, so calling `codeplane_pr` and then letting the job complete normally (or vice versa) never produces a duplicate PR.

## Changes

- **`backend/services/merge_service/_service.py`**
  - Added `_get_existing_pr_url(job_id)` helper.
  - `_create_pr` now short-circuits with the existing `pr_url` if one is already recorded on the Job — no re-push, no duplicate platform adapter call. This makes idempotency apply automatically to both the pre-existing `resolve_job("create_pr")` operator path and the new agent path, since both funnel through `_create_pr`.
  - Added new public `request_pr_for_job(job)` method: validates the job is `managed` (not `imported`), validates `branch`/`base_ref` against the existing ref pattern, then delegates to `_create_pr`. Unlike the operator resolve path, it does **not** clean up the worktree afterward, since the job may still be actively running.

- **`backend/mcp/server.py`**
  - New `codeplane_pr` MCP tool (`job_id` param) following the existing thin-handler pattern: validate → delegate to `merge_service.request_pr_for_job` → return `{"pr_url": ..., "status": ...}` or `{"error": ...}`.
  - `MCPState`/`create_mcp_server` now carry a `merge_service` dependency.
  - Never touches Credential/git-auth internals directly (AD-13) — reuses `PlatformRegistry` exactly as the existing merge path already does.

- **`backend/lifespan.py`**
  - Wires `services.merge_service` into `create_mcp_server(...)`.

- **Tests** (`backend/tests/unit/test_merge_service.py`, `backend/tests/unit/test_mcp_server.py`)
  - Idempotency: second call reuses the existing PR URL without a second adapter call.
  - `codeplane_pr` tool: success, missing `job_id`, job-not-found, and service-error-propagated cases.

## Scope

Strictly Story 6.2. Does not touch `codeplane_tracker` (Story 6.1, parallel work) or any tracker-write/approval flow (epic 3).

## Migrations

No schema changes required (`Job.pr_url`/`merge_status` already exist). Verified fresh against `origin/main` right before opening this PR — alembic head is still `0060_add_projects.py`, no new revision needed.

## Testing

- `uv run pytest backend/tests/unit/test_merge_service.py backend/tests/unit/test_mcp_server.py -q` → 63 passed
- `uv run ruff check` on changed files → passed
- `uv run mypy backend/mcp/server.py backend/services/merge_service/_service.py` → no issues found

Rebased onto latest `origin/main` (includes Story 2.1 Project entity, Story 3.2, Story 3.5).