### PR TITLE
feat: manually assign TaskLinks to tracker tickets (Story 4.3)

### DIFF
--- a/_bmad-output/implementation-artifacts/4-3-manually-assign-a-task-to-an-existing-ticket.md
+++ b/_bmad-output/implementation-artifacts/4-3-manually-assign-a-task-to-an-existing-ticket.md
@@ -1,0 +1,96 @@
+---
+baseline_commit: 4e662805
+---
+
+# Story 4.3: Manually assign a task to an existing ticket
+
+Status: in-progress
+
+## Story
+
+As a CodePlane user with a tracker ticket that has no BMAD/spec-kit backing,
+I want to create a task recipe node directly against that ticket with my own prompt,
+so that I can automate work the ticket describes without first authoring a planning document.
+
+## Acceptance Criteria
+
+1. **Given** a Project with an attached TrackerLink showing synced tickets, **when** I pick an existing ticket and create a TaskLink against it with a free-form prompt, **then** a `TaskLink` is created with `tracker_ticket_ref` and `prompt_override` set, and `story_node_id` left null.
+2. **Given** a ticket already has one manually-assigned TaskLink, **when** I create a second TaskLink against the same ticket, **then** both TaskLinks exist independently; many TaskLinks may share one `tracker_ticket_ref`.
+3. **Given** a manually-assigned TaskLink, **when** I view it later, **then** nothing requires it to ever gain a `story_node_id`; it remains valid indefinitely without BMAD/spec-kit backing.
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Add manual TaskLink persistence and service behavior on top of Story 4.2 (AC: 1, 2, 3)
+  - [ ] Extend Story 4.2's TaskLink repository/service rather than adding a second model, table, migration, or execution entity.
+  - [ ] Create a fresh row per request with `tracker_ticket_ref` and `prompt_override` set; leave `story_node_id`, `job_id`, and `epic_id` null and initialize `depends_on` empty.
+  - [ ] Preserve multiplicity: do not upsert or enforce uniqueness by `tracker_ticket_ref`.
+  - [ ] Validate the target Project and repo membership using existing Project patterns; do not call tracker provider write APIs or expose credentials.
+- [ ] Task 2: Expose manual assignment through the Project TaskLink API (AC: 1, 2, 3)
+  - [ ] Add a camelCase request/response contract to the existing `/settings/projects/{project_id}/task-links` surface established by Story 4.2.
+  - [ ] Keep the route thin: validate the request, delegate to `recipe_service.py`, and map existing domain errors consistently.
+  - [ ] Return the persisted nullable fields so a later read proves `story_node_id` and `epic_id` remain null.
+- [ ] Task 3: Add comprehensive automated coverage (AC: 1, 2, 3)
+  - [ ] Unit-test manual row creation, independent rows sharing a ticket ref, Project/repo validation, null story/Epic/job fields, and persistence across a later read.
+  - [ ] Integration-test the POST contract, camelCase serialization, validation failures, multiplicity, and GET visibility through the existing TaskLink list endpoint.
+  - [ ] Run the smallest relevant TaskLink/Project/TrackerLink regression suites plus configured lint and type checks.
+
+## Dev Notes
+
+### Dependency and Scope Boundary
+
+- Story 4.2 owns the canonical `TaskLinkRow`, migration, repository, ingestion path, `recipe_service.py`, and TaskLink list endpoint. Story 4.3 must rebase onto that work and extend it. If Story 4.2 is not yet available, tests and request contracts may be scaffolded, but no duplicate `TaskLinkRow`, `task_links` table, migration, or parallel service may be introduced.
+- Story 4.1 widened the sidecar vocabulary; do not modify that validator here.
+- Story 3.2 provides Project-to-Credential `TrackerLinkRow` attachment. This story does not implement tracker synchronization, polling, ticket mutation, board rendering, job spawning, or frontend UI.
+- The acceptance criteria establish that the ticket was picked from already-visible synced state. The manual-create path records the selected `tracker_ticket_ref`; it must not invent tracker network I/O or a second ticket read model.
+
+### Architecture Compliance
+
+- AD-9 defines one thin Project-scoped `TaskLinkRow`: `id`, `project_id`, `repo_path`, nullable `story_node_id`, `depends_on`, nullable `job_id`, nullable `tracker_ticket_ref`, nullable `prompt_override`, and nullable `epic_id`.
+- Exactly one of `story_node_id` or `tracker_ticket_ref` must be non-null at creation. For this manual path, `tracker_ticket_ref` is required and `story_node_id` is null.
+- Manual TaskLinks never receive an inferred `epic_id`; it is null because no BMAD Epic is the source.
+- Many TaskLinks may share one `tracker_ticket_ref`. Only ingestion upserts by `(project_id, repo_path, story_node_id)`; manual assignment always inserts a new row.
+- `TaskLinkRow` is correlation state, not a competing run model. This story does not create a `JobRow`.
+- All database access remains behind persistence repositories; API handlers stay thin; response models use `CamelModel`.
+- Use `/settings/projects/{project_id}/task-links`, matching AD-11 and the existing `projects.py` route convention.
+
+### Existing Code to Extend and Preserve
+
+- `backend/api/projects.py`: existing Project CRUD routes use `DishkaRoute`, `FromDishka`, generated/backend schema models, and `ProjectService`. Extend Story 4.2's TaskLink routes here rather than creating a competing URL family.
+- `backend/services/project/project_service.py` and `backend/persistence/project_repo.py`: reuse their Project lookup and repo-membership semantics; a manual TaskLink must target a repo that belongs to its Project.
+- `backend/api/tracker_links.py` and `backend/persistence/tracker_link_repo.py`: preserve credential secrecy and existing TrackerLink attachment behavior. Manual TaskLink assignment stores only a ticket reference, never a credential or PAT.
+- `backend/models/api_schemas.py`: remains the backend API contract source; frontend generated types are out of scope unless Story 4.2 has already established another TaskLink schema location.
+- Existing Project, TrackerLink, credential, chat, sidecar, and job behavior must remain unchanged.
+
+### Testing Requirements
+
+- Follow current async pytest patterns with in-memory SQLite for repository/service tests and the integration `client` fixture for HTTP behavior.
+- Prove both independent rows survive a fresh list/read query; checking only two POST response IDs is insufficient for AC2/AC3.
+- Assert nullable fields explicitly and verify no `JobRow` is created as a side effect.
+- Reject empty `tracker_ticket_ref`, empty `prompt_override`, unknown Projects, and repo paths outside the Project using existing validation/error conventions.
+
+### References
+
+- [Source: `_bmad-output/planning-artifacts/epics.md#Story-43-Manually-assign-a-task-to-an-existing-ticket`]
+- [Source: `_bmad-output/specs/spec-project-boards/SPEC.md#CAP-9`]
+- [Source: `_bmad-output/planning-artifacts/architecture/architecture-codeplane-2026-08-10/ARCHITECTURE-SPINE.md#AD-9`]
+- [Source: `_bmad-output/planning-artifacts/architecture/architecture-codeplane-2026-08-10/ARCHITECTURE-SPINE.md#AD-11`]
+- [Source: `_bmad-output/implementation-artifacts/3-2-attach-a-trackerlink-to-a-project.md`]
+- [Source: `_bmad-output/implementation-artifacts/4-1-widen-the-task-recipe-vocabulary.md`]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5.6 Sol (GitHub Copilot CLI).
+
+### Debug Log References
+
+### Completion Notes List
+
+- Comprehensive implementation context created from Epic 4, CAP-9, AD-9/AD-11, and existing Project/TrackerLink patterns.
+
+### File List
+
+## Change Log
+
+- 2026-08-10: Story created with explicit Story 4.2 dependency boundary and manual-assignment guardrails.

--- a/_bmad-output/implementation-artifacts/4-3-manually-assign-a-task-to-an-existing-ticket.md
+++ b/_bmad-output/implementation-artifacts/4-3-manually-assign-a-task-to-an-existing-ticket.md
@@ -4,7 +4,7 @@ baseline_commit: 4e662805
 
 # Story 4.3: Manually assign a task to an existing ticket
 
-Status: in-progress
+Status: review
 
 ## Story
 
@@ -20,19 +20,19 @@ so that I can automate work the ticket describes without first authoring a plann
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Add manual TaskLink persistence and service behavior on top of Story 4.2 (AC: 1, 2, 3)
-  - [ ] Extend Story 4.2's TaskLink repository/service rather than adding a second model, table, migration, or execution entity.
-  - [ ] Create a fresh row per request with `tracker_ticket_ref` and `prompt_override` set; leave `story_node_id`, `job_id`, and `epic_id` null and initialize `depends_on` empty.
-  - [ ] Preserve multiplicity: do not upsert or enforce uniqueness by `tracker_ticket_ref`.
-  - [ ] Validate the target Project and repo membership using existing Project patterns; do not call tracker provider write APIs or expose credentials.
-- [ ] Task 2: Expose manual assignment through the Project TaskLink API (AC: 1, 2, 3)
-  - [ ] Add a camelCase request/response contract to the existing `/settings/projects/{project_id}/task-links` surface established by Story 4.2.
-  - [ ] Keep the route thin: validate the request, delegate to `recipe_service.py`, and map existing domain errors consistently.
-  - [ ] Return the persisted nullable fields so a later read proves `story_node_id` and `epic_id` remain null.
-- [ ] Task 3: Add comprehensive automated coverage (AC: 1, 2, 3)
-  - [ ] Unit-test manual row creation, independent rows sharing a ticket ref, Project/repo validation, null story/Epic/job fields, and persistence across a later read.
-  - [ ] Integration-test the POST contract, camelCase serialization, validation failures, multiplicity, and GET visibility through the existing TaskLink list endpoint.
-  - [ ] Run the smallest relevant TaskLink/Project/TrackerLink regression suites plus configured lint and type checks.
+- [x] Task 1: Add manual TaskLink persistence and service behavior on top of Story 4.2 (AC: 1, 2, 3)
+  - [x] Extend Story 4.2's TaskLink repository/service rather than adding a second model, table, migration, or execution entity.
+  - [x] Create a fresh row per request with `tracker_ticket_ref` and `prompt_override` set; leave `story_node_id`, `job_id`, and `epic_id` null and initialize `depends_on` empty.
+  - [x] Preserve multiplicity: do not upsert or enforce uniqueness by `tracker_ticket_ref`.
+  - [x] Validate the target Project and repo membership using existing Project patterns; do not call tracker provider write APIs or expose credentials.
+- [x] Task 2: Expose manual assignment through the Project TaskLink API (AC: 1, 2, 3)
+  - [x] Add a camelCase request/response contract to the existing `/settings/projects/{project_id}/task-links` surface established by Story 4.2.
+  - [x] Keep the route thin: validate the request, delegate to `recipe_service.py`, and map existing domain errors consistently.
+  - [x] Return the persisted nullable fields so a later read proves `story_node_id` and `epic_id` remain null.
+- [x] Task 3: Add comprehensive automated coverage (AC: 1, 2, 3)
+  - [x] Unit-test manual row creation, independent rows sharing a ticket ref, Project/repo validation, null story/Epic/job fields, and persistence across a later read.
+  - [x] Integration-test the POST contract, camelCase serialization, validation failures, multiplicity, and GET visibility through the existing TaskLink list endpoint.
+  - [x] Run the smallest relevant TaskLink/Project/TrackerLink regression suites plus configured lint and type checks.
 
 ## Dev Notes
 
@@ -85,12 +85,40 @@ GPT-5.6 Sol (GitHub Copilot CLI).
 
 ### Debug Log References
 
+- Red phase: focused TaskLink tests -> 11 failed, 19 passed before implementation.
+- `uv run --active pytest backend/tests/unit/test_task_link_repo.py backend/tests/unit/test_recipe_service.py backend/tests/integration/test_api_task_links.py -q` -> 30 passed.
+- Focused TaskLink/Project/TrackerLink regression -> 72 passed.
+- `ruff check` on all Story 4.3 production/test files -> all checks passed.
+- `mypy backend/persistence/task_link_repo.py` -> no issues found. The broader service/API command also reported the two pre-existing `list` annotation errors in Project code.
+- Full backend regression reached the pre-existing `TestGetRepoDetail.test_registered_repo` failure (404 vs 200); the same isolated test fails identically on `origin/main`, proving it is not introduced by Story 4.3.
+
+### Implementation Plan
+
+- Reuse Story 4.2's canonical `TaskLinkRow`, repository, service, API response, and migration.
+- Add an insert-only repository method for manual assignments, with Project membership validation in `RecipeService`.
+- Add one POST operation beside the existing GET TaskLink endpoint and cover persistence, multiplicity, nullable fields, validation, and absence of Job creation.
+
 ### Completion Notes List
 
 - Comprehensive implementation context created from Epic 4, CAP-9, AD-9/AD-11, and existing Project/TrackerLink patterns.
+- Added insert-only manual TaskLink creation; repeated assignments to one ticket produce independent persisted rows.
+- Manual rows retain null `story_node_id`, `job_id`, and `epic_id`, an empty dependency list, and the supplied ticket reference/prompt indefinitely.
+- Added the camelCase `POST /api/settings/projects/{project_id}/task-links` contract with non-blank text validation and Project repo-membership enforcement.
+- No model, migration, tracker network call, credential access, Job creation, board rendering, or Story 4.2 ingestion behavior was duplicated or changed.
 
 ### File List
+
+- `_bmad-output/implementation-artifacts/4-3-manually-assign-a-task-to-an-existing-ticket.md` (added)
+- `_bmad-output/implementation-artifacts/sprint-status.yaml` (modified)
+- `backend/api/projects.py` (modified)
+- `backend/models/api_schemas.py` (modified)
+- `backend/persistence/task_link_repo.py` (modified)
+- `backend/services/recipe/recipe_service.py` (modified)
+- `backend/tests/integration/test_api_task_links.py` (modified)
+- `backend/tests/unit/test_recipe_service.py` (modified)
+- `backend/tests/unit/test_task_link_repo.py` (modified)
 
 ## Change Log
 
 - 2026-08-10: Story created with explicit Story 4.2 dependency boundary and manual-assignment guardrails.
+- 2026-08-10: Implemented manual TaskLink assignment, API validation, independent same-ticket rows, and focused regression coverage; status set to review.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -77,7 +77,7 @@ development_status:
   epic-4: in-progress
   4-1-widen-the-task-recipe-vocabulary: review
   4-2-ingest-a-task-graph-into-a-project: review
-  4-3-manually-assign-a-task-to-an-existing-ticket: in-progress
+  4-3-manually-assign-a-task-to-an-existing-ticket: review
   4-4-see-tasklink-cards-on-the-board: backlog
   4-5-auto-spawn-the-next-task-on-completion: backlog
   4-6-route-recipe-tracker-writes-to-the-paired-ticket: backlog

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -77,7 +77,7 @@ development_status:
   epic-4: in-progress
   4-1-widen-the-task-recipe-vocabulary: review
   4-2-ingest-a-task-graph-into-a-project: review
-  4-3-manually-assign-a-task-to-an-existing-ticket: backlog
+  4-3-manually-assign-a-task-to-an-existing-ticket: in-progress
   4-4-see-tasklink-cards-on-the-board: backlog
   4-5-auto-spawn-the-next-task-on-completion: backlog
   4-6-route-recipe-tracker-writes-to-the-paired-ticket: backlog

--- a/backend/api/projects.py
+++ b/backend/api/projects.py
@@ -12,6 +12,7 @@ from dishka.integrations.fastapi import DishkaRoute, FromDishka
 from fastapi import APIRouter
 
 from backend.models.api_schemas import (
+    CreateManualTaskLinkRequest,
     CreateProjectRequest,
     IngestTaskGraphResponse,
     ProjectListResponse,
@@ -149,3 +150,23 @@ async def list_project_task_links(
     """List a Project's currently persisted TaskLinks."""
     task_links = await recipe_service.list_task_links(project_id)
     return TaskLinkListResponse(items=[_task_link_to_response(t) for t in task_links])
+
+
+@router.post(
+    "/settings/projects/{project_id}/task-links",
+    response_model=TaskLinkResponse,
+    status_code=201,
+)
+async def create_manual_task_link(
+    project_id: str,
+    body: CreateManualTaskLinkRequest,
+    recipe_service: FromDishka[RecipeService],
+) -> TaskLinkResponse:
+    """Create a fresh TaskLink directly against an existing tracker ticket."""
+    task_link = await recipe_service.create_manual_task_link(
+        project_id=project_id,
+        repo_path=body.repo_path,
+        tracker_ticket_ref=body.tracker_ticket_ref,
+        prompt_override=body.prompt_override,
+    )
+    return _task_link_to_response(task_link)

--- a/backend/models/api_schemas.py
+++ b/backend/models/api_schemas.py
@@ -182,6 +182,22 @@ class UpdateProjectRequest(CamelModel):
     repo_paths: list[str] | None = Field(None, min_length=1)
 
 
+class CreateManualTaskLinkRequest(CamelModel):
+    """Create a TaskLink directly from an existing tracker ticket (Story 4.3)."""
+
+    repo_path: str = Field(min_length=1)
+    tracker_ticket_ref: str = Field(min_length=1)
+    prompt_override: str = Field(min_length=1)
+
+    @field_validator("repo_path", "tracker_ticket_ref", "prompt_override")
+    @classmethod
+    def _strip_required_text(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("Value must not be blank")
+        return stripped
+
+
 class SuggestNamesRequest(CamelModel):
     prompt: str = Field(min_length=1, max_length=50_000)
     repo: str | None = None

--- a/backend/persistence/task_link_repo.py
+++ b/backend/persistence/task_link_repo.py
@@ -39,6 +39,33 @@ class TaskLinkRepository(BaseRepository):
             updated_at=row.updated_at,
         )
 
+    async def create_manual(
+        self,
+        *,
+        project_id: str,
+        repo_path: str,
+        tracker_ticket_ref: str,
+        prompt_override: str,
+    ) -> TaskLink:
+        """Insert a fresh manually-assigned TaskLink without story backing."""
+        now = datetime.now(UTC)
+        row = TaskLinkRow(
+            id=str(uuid.uuid4()),
+            project_id=project_id,
+            repo_path=repo_path,
+            story_node_id=None,
+            depends_on="[]",
+            job_id=None,
+            tracker_ticket_ref=tracker_ticket_ref,
+            prompt_override=prompt_override,
+            epic_id=None,
+            created_at=now,
+            updated_at=now,
+        )
+        self._session.add(row)
+        await self._session.flush()
+        return self._to_domain(row)
+
     async def upsert_many(
         self,
         project_id: str,

--- a/backend/persistence/task_link_repo.py
+++ b/backend/persistence/task_link_repo.py
@@ -82,9 +82,11 @@ class TaskLinkRepository(BaseRepository):
         results: list[TaskLink] = []
         for entry in entries:
             repo_path = str(entry["repo_path"])
-            story_node_id = entry.get("story_node_id")
+            raw_story_node_id = entry.get("story_node_id")
+            story_node_id = str(raw_story_node_id) if raw_story_node_id is not None else None
             depends_on = entry.get("depends_on", [])
-            epic_id = entry.get("epic_id")
+            raw_epic_id = entry.get("epic_id")
+            epic_id = str(raw_epic_id) if raw_epic_id is not None else None
 
             stmt = select(TaskLinkRow).where(
                 TaskLinkRow.project_id == project_id,
@@ -108,7 +110,7 @@ class TaskLinkRepository(BaseRepository):
                 self._session.add(row)
             else:
                 row.depends_on = json.dumps(depends_on)
-                row.epic_id = epic_id  # type: ignore[assignment]
+                row.epic_id = epic_id
                 row.updated_at = now
 
             await self._session.flush()

--- a/backend/services/recipe/recipe_service.py
+++ b/backend/services/recipe/recipe_service.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from backend.models.domain import RepoNotAllowedError
 from backend.services.recipe.parsers import ParsedTask, parse_bmad_stories, parse_spec_kit_tasks
 
 if TYPE_CHECKING:
@@ -24,7 +25,7 @@ if TYPE_CHECKING:
 
 
 class RecipeService:
-    """Orchestrates TaskLink ingestion for a Project."""
+    """Orchestrates Project-scoped TaskLink creation and ingestion."""
 
     def __init__(self, task_link_repo: TaskLinkRepository, project_service: ProjectService) -> None:
         self._task_link_repo = task_link_repo
@@ -86,6 +87,28 @@ class RecipeService:
                 )
 
         return await self._task_link_repo.upsert_many(project_id, entries)
+
+    async def create_manual_task_link(
+        self,
+        *,
+        project_id: str,
+        repo_path: str,
+        tracker_ticket_ref: str,
+        prompt_override: str,
+    ) -> TaskLink:
+        """Create a fresh TaskLink directly against an existing tracker ticket."""
+        project = await self._project_service.get(project_id)
+        resolved_repo_path = str(Path(repo_path).expanduser().resolve())
+        if resolved_repo_path not in project.repo_paths:
+            raise RepoNotAllowedError(
+                f"Repo path '{resolved_repo_path}' does not belong to Project '{project_id}'."
+            )
+        return await self._task_link_repo.create_manual(
+            project_id=project_id,
+            repo_path=resolved_repo_path,
+            tracker_ticket_ref=tracker_ticket_ref,
+            prompt_override=prompt_override,
+        )
 
     async def list_task_links(self, project_id: str) -> list[TaskLink]:
         """List every TaskLink currently persisted for a Project."""

--- a/backend/tests/integration/test_api_task_links.py
+++ b/backend/tests/integration/test_api_task_links.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from httpx import AsyncClient
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 
 def _write_bmad_story(repo_root: Path, filename: str, body: str = "# S\n") -> None:
@@ -124,3 +125,152 @@ class TestListTaskLinks:
     async def test_list_missing_project_returns_404(self, client: AsyncClient) -> None:
         resp = await client.get("/api/settings/projects/does-not-exist/task-links")
         assert resp.status_code == 404
+
+
+class TestCreateManualTaskLink:
+    @pytest.mark.asyncio
+    async def test_create_and_later_list_manual_task_link(
+        self, client: AsyncClient, tmp_path: Path, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        from sqlalchemy import select
+
+        from backend.models.db import JobRow
+
+        repo_path = tmp_path / "manual-repo"
+        repo_path.mkdir()
+        created_project = await client.post(
+            "/api/settings/projects",
+            json={"name": "Manual Tasks", "repoPaths": [str(repo_path)]},
+        )
+        project_id = created_project.json()["id"]
+
+        created = await client.post(
+            f"/api/settings/projects/{project_id}/task-links",
+            json={
+                "repoPath": str(repo_path),
+                "trackerTicketRef": "JIRA-123",
+                "promptOverride": "Implement the ticket",
+            },
+        )
+
+        assert created.status_code == 201
+        body = created.json()
+        assert body["trackerTicketRef"] == "JIRA-123"
+        assert body["promptOverride"] == "Implement the ticket"
+        assert body["storyNodeId"] is None
+        assert body["dependsOn"] == []
+        assert body["jobId"] is None
+        assert body["epicId"] is None
+
+        listed = await client.get(f"/api/settings/projects/{project_id}/task-links")
+        assert listed.status_code == 200
+        assert listed.json()["items"] == [body]
+        async with session_factory() as session:
+            jobs = (await session.execute(select(JobRow.id))).scalars().all()
+        assert jobs == []
+
+    @pytest.mark.asyncio
+    async def test_same_ticket_allows_multiple_independent_task_links(
+        self, client: AsyncClient, tmp_path: Path
+    ) -> None:
+        repo_path = tmp_path / "multi-task-repo"
+        repo_path.mkdir()
+        created_project = await client.post(
+            "/api/settings/projects",
+            json={"name": "Multiple Tasks", "repoPaths": [str(repo_path)]},
+        )
+        project_id = created_project.json()["id"]
+        endpoint = f"/api/settings/projects/{project_id}/task-links"
+
+        first = await client.post(
+            endpoint,
+            json={
+                "repoPath": str(repo_path),
+                "trackerTicketRef": "JIRA-123",
+                "promptOverride": "Implement part one",
+            },
+        )
+        second = await client.post(
+            endpoint,
+            json={
+                "repoPath": str(repo_path),
+                "trackerTicketRef": "JIRA-123",
+                "promptOverride": "Implement part two",
+            },
+        )
+
+        assert first.status_code == second.status_code == 201
+        assert first.json()["id"] != second.json()["id"]
+        listed = (await client.get(endpoint)).json()["items"]
+        assert [item["trackerTicketRef"] for item in listed] == ["JIRA-123", "JIRA-123"]
+        assert [item["promptOverride"] for item in listed] == ["Implement part one", "Implement part two"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("trackerTicketRef", ""),
+            ("trackerTicketRef", "   "),
+            ("promptOverride", ""),
+            ("promptOverride", "   "),
+        ],
+    )
+    async def test_rejects_blank_required_text(
+        self, client: AsyncClient, tmp_path: Path, field: str, value: str
+    ) -> None:
+        repo_path = tmp_path / f"blank-{field}-{len(value)}"
+        repo_path.mkdir()
+        created_project = await client.post(
+            "/api/settings/projects",
+            json={"name": "Validation", "repoPaths": [str(repo_path)]},
+        )
+        project_id = created_project.json()["id"]
+        payload = {
+            "repoPath": str(repo_path),
+            "trackerTicketRef": "JIRA-123",
+            "promptOverride": "Implement this",
+        }
+        payload[field] = value
+
+        response = await client.post(
+            f"/api/settings/projects/{project_id}/task-links",
+            json=payload,
+        )
+
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_rejects_repo_outside_project(self, client: AsyncClient, tmp_path: Path) -> None:
+        member_repo = tmp_path / "member-repo"
+        other_repo = tmp_path / "other-repo"
+        member_repo.mkdir()
+        other_repo.mkdir()
+        created_project = await client.post(
+            "/api/settings/projects",
+            json={"name": "Scoped Tasks", "repoPaths": [str(member_repo)]},
+        )
+        project_id = created_project.json()["id"]
+
+        response = await client.post(
+            f"/api/settings/projects/{project_id}/task-links",
+            json={
+                "repoPath": str(other_repo),
+                "trackerTicketRef": "JIRA-123",
+                "promptOverride": "Implement this",
+            },
+        )
+
+        assert response.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_missing_project_returns_404(self, client: AsyncClient) -> None:
+        response = await client.post(
+            "/api/settings/projects/does-not-exist/task-links",
+            json={
+                "repoPath": "/repo/a",
+                "trackerTicketRef": "JIRA-123",
+                "promptOverride": "Implement this",
+            },
+        )
+
+        assert response.status_code == 404

--- a/backend/tests/unit/test_recipe_service.py
+++ b/backend/tests/unit/test_recipe_service.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from backend.models.domain import Project
+from backend.models.domain import Project, RepoNotAllowedError, TaskLink
 from backend.services.recipe.recipe_service import RecipeService
 
 if TYPE_CHECKING:
@@ -188,3 +188,64 @@ class TestListTaskLinks:
         mock_project_service.get.assert_awaited_once_with("proj-1")
         mock_task_link_repo.list_by_project.assert_awaited_once_with("proj-1")
         assert result == []
+
+
+class TestCreateManualTaskLink:
+    @pytest.mark.asyncio
+    async def test_creates_manual_link_for_project_member_repo(
+        self, tmp_path: Path, mock_task_link_repo: AsyncMock, mock_project_service: AsyncMock
+    ) -> None:
+        repo_path = tmp_path / "member-repo"
+        repo_path.mkdir()
+        mock_project_service.get.return_value = _make_project("proj-1", [str(repo_path)])
+        expected = TaskLink(
+            id="task-1",
+            project_id="proj-1",
+            repo_path=str(repo_path),
+            story_node_id=None,
+            depends_on=[],
+            job_id=None,
+            tracker_ticket_ref="JIRA-123",
+            prompt_override="Implement this ticket",
+            epic_id=None,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        mock_task_link_repo.create_manual.return_value = expected
+
+        service = RecipeService(mock_task_link_repo, mock_project_service)
+        result = await service.create_manual_task_link(
+            project_id="proj-1",
+            repo_path=str(repo_path),
+            tracker_ticket_ref="JIRA-123",
+            prompt_override="Implement this ticket",
+        )
+
+        assert result is expected
+        mock_task_link_repo.create_manual.assert_awaited_once_with(
+            project_id="proj-1",
+            repo_path=str(repo_path),
+            tracker_ticket_ref="JIRA-123",
+            prompt_override="Implement this ticket",
+        )
+
+    @pytest.mark.asyncio
+    async def test_rejects_repo_outside_project(
+        self, tmp_path: Path, mock_task_link_repo: AsyncMock, mock_project_service: AsyncMock
+    ) -> None:
+        member_repo = tmp_path / "member-repo"
+        other_repo = tmp_path / "other-repo"
+        member_repo.mkdir()
+        other_repo.mkdir()
+        mock_project_service.get.return_value = _make_project("proj-1", [str(member_repo)])
+
+        service = RecipeService(mock_task_link_repo, mock_project_service)
+        with pytest.raises(RepoNotAllowedError):
+            await service.create_manual_task_link(
+                project_id="proj-1",
+                repo_path=str(other_repo),
+                tracker_ticket_ref="JIRA-123",
+                prompt_override="Implement this ticket",
+            )
+
+        mock_task_link_repo.create_manual.assert_not_awaited()

--- a/backend/tests/unit/test_task_link_repo.py
+++ b/backend/tests/unit/test_task_link_repo.py
@@ -121,3 +121,52 @@ class TestTaskLinkRepoUpsert:
         project_id = await _make_project(session)
         repo = TaskLinkRepository(session)
         assert await repo.list_by_project(project_id) == []
+
+
+class TestCreateManual:
+    @pytest.mark.asyncio
+    async def test_creates_manual_task_link_without_story_backing(self, session: AsyncSession) -> None:
+        project_id = await _make_project(session)
+        repo = TaskLinkRepository(session)
+
+        created = await repo.create_manual(
+            project_id=project_id,
+            repo_path="/repo/a",
+            tracker_ticket_ref="JIRA-123",
+            prompt_override="Implement the ticket",
+        )
+        await session.commit()
+
+        assert created.project_id == project_id
+        assert created.repo_path == "/repo/a"
+        assert created.tracker_ticket_ref == "JIRA-123"
+        assert created.prompt_override == "Implement the ticket"
+        assert created.story_node_id is None
+        assert created.depends_on == []
+        assert created.job_id is None
+        assert created.epic_id is None
+
+    @pytest.mark.asyncio
+    async def test_same_ticket_ref_creates_independent_persisted_rows(self, session: AsyncSession) -> None:
+        project_id = await _make_project(session)
+        repo = TaskLinkRepository(session)
+
+        first = await repo.create_manual(
+            project_id=project_id,
+            repo_path="/repo/a",
+            tracker_ticket_ref="JIRA-123",
+            prompt_override="Implement part one",
+        )
+        second = await repo.create_manual(
+            project_id=project_id,
+            repo_path="/repo/a",
+            tracker_ticket_ref="JIRA-123",
+            prompt_override="Implement part two",
+        )
+        await session.commit()
+
+        listed = await repo.list_by_project(project_id)
+        assert first.id != second.id
+        assert [task.tracker_ticket_ref for task in listed] == ["JIRA-123", "JIRA-123"]
+        assert [task.prompt_override for task in listed] == ["Implement part one", "Implement part two"]
+        assert all(task.story_node_id is None for task in listed)


### PR DESCRIPTION
## Summary
- add insert-only manual TaskLink creation against an existing tracker ticket
- preserve independent rows when multiple tasks share one `tracker_ticket_ref`
- add `POST /api/settings/projects/{project_id}/task-links` with camelCase validation and Project repo-membership enforcement
- prove manual rows remain valid with null `story_node_id`, `job_id`, and `epic_id`, and create no Job

## Dependency
Stacked on #60 (Story 4.2), which owns the canonical TaskLink model, migration, ingestion path, and list endpoint. The PR base is the rebased Story 4.2 branch, so this diff contains only Story 4.3. After #60 merges, this PR can be retargeted to `main` without duplicating the model or migration.

## Validation
- 31 focused Story 4.3 tests passed after restacking
- 72 related TaskLink/Project/TrackerLink regression tests passed
- 32 merged Project API + TaskLink integration tests passed after rebasing onto current `main`
- Ruff passed on all changed production and test files
- TaskLink persistence passed mypy
- full-suite first failure (`TestGetRepoDetail.test_registered_repo`) reproduces identically on `origin/main` (404 vs expected 200) and is unrelated to this story

## Migration
No Story 4.3 migration. Story 4.2 owns `0061_add_task_links.py`; `origin/main` still has `0060` as its latest migration.