### PR TITLE
feat: implement Story 2.5 - Filter Projects by name

### DIFF
--- a/_bmad-output/implementation-artifacts/2-5-filter-projects-by-name.md
+++ b/_bmad-output/implementation-artifacts/2-5-filter-projects-by-name.md
@@ -1,0 +1,86 @@
+---
+baseline_commit: 11af41b0
+---
+
+# Story 2.5: Filter Projects by name
+
+Status: review
+
+## Story
+
+As a CodePlane user with many Projects,
+I want to filter the Overview and sidebar by name,
+so that I can find a specific Project quickly as the list grows.
+
+## Acceptance Criteria
+
+1. **Given** a search/filter box on the Projects Overview and the sidebar Project list, **when** I type a partial name match, **then** only matching Project cards remain visible in both locations, and the same filter mechanism is applied generically at the card-rendering layer, so it also filters Task Recipe/TaskLink cards once Epic 4 introduces them (no Epic-2-only special case).
+2. **Given** the filter text matches nothing, **when** I view the filtered list, **then** an empty state is shown, not an error.
+
+## Tasks / Subtasks
+
+- [x] Task 1: Add a generic, reusable name-filter utility (AC: 1)
+  - [x] Create `frontend/src/lib/nameFilter.ts` exporting `matchesNameFilter(name: string, query: string): boolean` — case-insensitive substring match, trims whitespace, empty/whitespace-only query matches everything
+  - [x] Unit tests in `frontend/src/lib/nameFilter.test.ts` covering case-insensitivity, partial match, empty query, whitespace query, no match
+- [x] Task 2: Filter the Projects Overview grid (AC: 1, 2)
+  - [x] Add a search `<input>` above the card grid in `frontend/src/components/ProjectsOverview.tsx`
+  - [x] Filter the fetched `projects` list through `matchesNameFilter` (against each project's display name) before rendering `ProjectCard`s — additive only, do not modify the existing `fetchProjectsSummary` data-fetching/loading logic (avoids collision with concurrently-developed Story 2.4)
+  - [x] Show a distinct "no matches" empty state when the filter yields zero results but Projects exist (separate from the existing "No Projects registered" empty state)
+- [x] Task 3: Filter the sidebar Project list (AC: 1, 2)
+  - [x] Add a search `<input>` to the sidebar in `frontend/src/components/RepoLayout.tsx` (visible only when the sidebar is expanded)
+  - [x] Filter the fetched `repos` list through `matchesNameFilter` (against each repo's basename) before rendering the `Link` rows
+  - [x] Show a "no matches" text state when filtered to zero but repos exist
+- [x] Task 4: Tests (AC: 1, 2)
+  - [x] Extend `frontend/src/components/__tests__/ProjectsOverview.test.tsx`: typing a filter narrows visible cards; a non-matching filter shows the no-matches empty state
+  - [x] Add sidebar filter coverage for `RepoLayout.tsx` (new or extended test file)
+  - [x] Run targeted vitest for changed test files, eslint/tsc on changed files; confirm no regressions
+
+## Dev Notes
+
+- Architecture: per epics.md AC1, the filter mechanism must be implemented generically (a single reusable helper), not as an Epic-2-only special case, since Epic 4's Task Recipe/TaskLink cards will need the same filtering later.
+- This is a pure client-side, presentational change: filtering happens against data already fetched via the existing batch `GET /settings/projects/summary` call (`ProjectsOverview`) and the existing `fetchRepos` call (`RepoLayout` sidebar). No new endpoint, query param, or backend/database change is required.
+- Story 2.4 (See cross-Project attention signal) is being developed concurrently in a sibling session and also touches `ProjectsOverview.tsx`/the summary endpoint. To avoid collisions, this story's changes to `ProjectsOverview.tsx` are additive-only (new search input + a filter step before render) and do not touch `fetchProjectsSummary`, the attention-signal rendering, or any other existing logic in that file.
+- No alembic migration is expected for this story (confirmed against epics.md — Story 2.5 has no data-model requirement). Verify via `git log origin/main -- alembic/versions/` immediately before opening the PR per repo process.
+
+### Project Structure Notes
+
+- New files: `frontend/src/lib/nameFilter.ts`, `frontend/src/lib/nameFilter.test.ts`
+- Modified files: `frontend/src/components/ProjectsOverview.tsx`, `frontend/src/components/RepoLayout.tsx`, `frontend/src/components/__tests__/ProjectsOverview.test.tsx`, and a sidebar filter test file
+
+### References
+
+- [Source: _bmad-output/planning-artifacts/epics.md#Story 2.5: Filter Projects by name]
+- [Source: _bmad-output/implementation-artifacts/2-2-view-projects-overview.md]
+- [Source: _bmad-output/implementation-artifacts/2-3-view-a-projects-board.md]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-sonnet-5
+
+### Debug Log References
+
+### Completion Notes List
+
+- Added a generic, reusable `matchesNameFilter(name, query)` helper in `frontend/src/lib/nameFilter.ts` (case-insensitive substring match, whitespace-trimmed, empty query matches all) so the same filter mechanism can later be reused for Task Recipe/TaskLink cards (Epic 4) per AC1 — no Epic-2-only special case.
+- `ProjectsOverview.tsx`: added a search input above the grid; filtering is applied only at render time against the already-fetched `projects` list — the `fetchProjectsSummary` call, loading state, and attention-signal-adjacent rendering were left untouched to avoid colliding with the concurrently-developed Story 2.4 in a sibling session. Added a distinct "No Projects match "..."" empty state, kept separate from the existing "No Projects registered" state.
+- `RepoLayout.tsx`: added a search input to the sidebar (shown only when expanded and repos exist), filtering the `repos` list by basename before rendering `Link` rows; added a "No matches" text state.
+- No backend, database, or migration changes were required — pure client-side, presentational filtering over already-fetched data. Confirmed via `git log origin/main -- alembic/versions/` before opening the PR.
+- Full targeted test suite passes: `nameFilter.test.ts` (6), `ProjectsOverview.test.tsx` (6, incl. 2 new filter tests), `RepoLayout.test.tsx` (3, new file) — 15/15. `eslint` and `tsc --noEmit` are clean on all touched files.
+
+### File List
+
+- frontend/src/lib/nameFilter.ts (new)
+- frontend/src/lib/nameFilter.test.ts (new)
+- frontend/src/components/ProjectsOverview.tsx
+- frontend/src/components/RepoLayout.tsx
+- frontend/src/components/__tests__/ProjectsOverview.test.tsx
+- frontend/src/components/__tests__/RepoLayout.test.tsx (new)
+- _bmad-output/implementation-artifacts/2-5-filter-projects-by-name.md (new)
+- _bmad-output/implementation-artifacts/sprint-status.yaml
+
+## Change Log
+
+- 2026-08-10: Story created (Copilot CLI, dev-story workflow).
+- 2026-08-10: Implemented name filter for Projects Overview grid and sidebar Project list; added generic `matchesNameFilter` utility and full test coverage; story moved to review.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -63,7 +63,7 @@ development_status:
   2-2-view-projects-overview: review
   2-3-view-a-projects-board: review
   2-4-see-cross-project-attention-signal: backlog
-  2-5-filter-projects-by-name: backlog
+  2-5-filter-projects-by-name: review
   epic-2-retrospective: optional
 
   epic-3: backlog

--- a/frontend/src/components/ProjectsOverview.tsx
+++ b/frontend/src/components/ProjectsOverview.tsx
@@ -6,6 +6,7 @@ import { fetchProjectsSummary } from "../api/client";
 import type { ProjectSummaryResponse } from "../api/types";
 import { Spinner } from "./ui/spinner";
 import { pathBasename } from "../lib/paths";
+import { matchesNameFilter } from "../lib/nameFilter";
 
 function timeAgo(dateStr: string): string {
   const diff = Date.now() - new Date(dateStr).getTime();
@@ -18,9 +19,13 @@ function timeAgo(dateStr: string): string {
   return `${days}d ago`;
 }
 
+function projectDisplayName(project: ProjectSummaryResponse): string {
+  return project.name || pathBasename(project.repoPaths[0] ?? "") || project.id;
+}
+
 function ProjectCard({ project, onOpen }: { project: ProjectSummaryResponse; onOpen: () => void }) {
   const hasJobs = project.activeJobCount > 0 || project.awaitingInputCount > 0 || project.failedCount > 0;
-  const displayName = project.name || pathBasename(project.repoPaths[0] ?? "") || project.id;
+  const displayName = projectDisplayName(project);
 
   return (
     <button
@@ -63,6 +68,7 @@ export function ProjectsOverview() {
   const navigate = useNavigate();
   const [loading, setLoading] = useState(true);
   const [projects, setProjects] = useState<ProjectSummaryResponse[]>([]);
+  const [filterQuery, setFilterQuery] = useState("");
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -103,14 +109,32 @@ export function ProjectsOverview() {
     );
   }
 
+  const filteredProjects = projects.filter((project) =>
+    matchesNameFilter(projectDisplayName(project), filterQuery),
+  );
+
   return (
     <div className="max-w-5xl mx-auto space-y-4">
       <h1 className="text-xl font-semibold text-foreground">Projects</h1>
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        {projects.map((project) => (
-          <ProjectCard key={project.id} project={project} onOpen={() => openProject(project)} />
-        ))}
-      </div>
+      <input
+        type="text"
+        value={filterQuery}
+        onChange={(e) => setFilterQuery(e.target.value)}
+        placeholder="Filter Projects by name..."
+        aria-label="Filter Projects by name"
+        className="w-full max-w-sm rounded-md border border-border bg-background px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+      />
+      {filteredProjects.length === 0 ? (
+        <div className="flex items-center justify-center h-32 text-muted-foreground">
+          <p className="text-sm">No Projects match &quot;{filterQuery.trim()}&quot;</p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {filteredProjects.map((project) => (
+            <ProjectCard key={project.id} project={project} onOpen={() => openProject(project)} />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/RepoLayout.tsx
+++ b/frontend/src/components/RepoLayout.tsx
@@ -8,6 +8,7 @@ import { cn } from "../lib/utils";
 import { Spinner } from "./ui/spinner";
 import { Button } from "./ui/button";
 import { pathBasename } from "../lib/paths";
+import { matchesNameFilter } from "../lib/nameFilter";
 import { ProjectsOverview } from "./ProjectsOverview";
 
 
@@ -18,6 +19,7 @@ export function RepoLayout() {
   const [repos, setRepos] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
   const [collapsed, setCollapsed] = useState(false);
+  const [filterQuery, setFilterQuery] = useState("");
   const repoIndexState = useStore((s) => s.repoIndexState);
 
   const loadRepos = useCallback(async () => {
@@ -40,6 +42,8 @@ export function RepoLayout() {
   function isActive(path: string) {
     return decoded === path;
   }
+
+  const filteredRepos = repos.filter((r) => matchesNameFilter(repoBasename(r), filterQuery));
 
   return (
     <div className="flex h-full min-h-0">
@@ -66,6 +70,18 @@ export function RepoLayout() {
         </div>
 
         <nav className="flex-1 overflow-y-auto py-1" aria-label="Repository list">
+          {!collapsed && !loading && repos.length > 0 && (
+            <div className="px-2 pb-2">
+              <input
+                type="text"
+                value={filterQuery}
+                onChange={(e) => setFilterQuery(e.target.value)}
+                placeholder="Filter..."
+                aria-label="Filter repositories by name"
+                className="w-full rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+              />
+            </div>
+          )}
           {loading ? (
             <div className="flex justify-center py-4">
               <Spinner className="w-4 h-4" />
@@ -74,8 +90,12 @@ export function RepoLayout() {
             <p className="text-xs text-muted-foreground text-center py-4 px-2">
               No repositories
             </p>
+          ) : filteredRepos.length === 0 ? (
+            <p className="text-xs text-muted-foreground text-center py-4 px-2">
+              No matches
+            </p>
           ) : (
-            repos.map((r) => {
+            filteredRepos.map((r) => {
               const name = repoBasename(r);
               const indexing = repoIndexState[r];
               return (

--- a/frontend/src/components/__tests__/ProjectsOverview.test.tsx
+++ b/frontend/src/components/__tests__/ProjectsOverview.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 
 vi.mock("../../api/client", () => ({
@@ -88,5 +88,47 @@ describe("ProjectsOverview", () => {
     );
 
     await waitFor(() => expect(screen.getByText("No Projects registered")).toBeInTheDocument());
+  });
+
+  it("filters cards by a partial, case-insensitive name match", async () => {
+    vi.mocked(fetchProjectsSummary).mockResolvedValueOnce({
+      items: [
+        makeSummary({ id: "proj-1", name: "Alpha" }),
+        makeSummary({ id: "proj-2", name: "Beta" }),
+      ],
+    } as any);
+
+    render(
+      <MemoryRouter>
+        <ProjectsOverview />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(screen.getByText("Alpha")).toBeInTheDocument());
+    expect(screen.getByText("Beta")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Filter Projects by name"), { target: { value: "alp" } });
+
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.queryByText("Beta")).not.toBeInTheDocument();
+  });
+
+  it("shows a no-matches empty state when the filter matches nothing", async () => {
+    vi.mocked(fetchProjectsSummary).mockResolvedValueOnce({
+      items: [makeSummary({ id: "proj-1", name: "Alpha" })],
+    } as any);
+
+    render(
+      <MemoryRouter>
+        <ProjectsOverview />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(screen.getByText("Alpha")).toBeInTheDocument());
+
+    fireEvent.change(screen.getByLabelText("Filter Projects by name"), { target: { value: "zzz" } });
+
+    expect(screen.queryByText("Alpha")).not.toBeInTheDocument();
+    expect(screen.getByText('No Projects match "zzz"')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/__tests__/RepoLayout.test.tsx
+++ b/frontend/src/components/__tests__/RepoLayout.test.tsx
@@ -1,0 +1,74 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+
+vi.mock("../../api/client", () => ({
+  fetchRepos: vi.fn(),
+  fetchProjectsSummary: vi.fn(),
+}));
+
+import { fetchRepos, fetchProjectsSummary } from "../../api/client";
+import { RepoLayout } from "../RepoLayout";
+
+beforeEach(() => {
+  vi.mocked(fetchRepos).mockReset();
+  vi.mocked(fetchProjectsSummary).mockReset();
+  vi.mocked(fetchProjectsSummary).mockResolvedValue({ items: [] } as any);
+});
+
+function renderLayout() {
+  return render(
+    <MemoryRouter initialEntries={["/repos"]}>
+      <Routes>
+        <Route path="/repos/*" element={<RepoLayout />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("RepoLayout sidebar filter", () => {
+  it("filters the repo list by a partial, case-insensitive name match", async () => {
+    vi.mocked(fetchRepos).mockResolvedValueOnce({
+      items: ["/repos/alpha-project", "/repos/beta-project"],
+    } as any);
+
+    renderLayout();
+
+    await waitFor(() => expect(screen.getByText("alpha-project")).toBeInTheDocument());
+    expect(screen.getByText("beta-project")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Filter repositories by name"), {
+      target: { value: "ALPHA" },
+    });
+
+    expect(screen.getByText("alpha-project")).toBeInTheDocument();
+    expect(screen.queryByText("beta-project")).not.toBeInTheDocument();
+  });
+
+  it("shows a no-matches state when the filter matches nothing", async () => {
+    vi.mocked(fetchRepos).mockResolvedValueOnce({
+      items: ["/repos/alpha-project"],
+    } as any);
+
+    renderLayout();
+
+    await waitFor(() => expect(screen.getByText("alpha-project")).toBeInTheDocument());
+
+    fireEvent.change(screen.getByLabelText("Filter repositories by name"), {
+      target: { value: "zzz" },
+    });
+
+    expect(screen.queryByText("alpha-project")).not.toBeInTheDocument();
+    expect(screen.getByText("No matches")).toBeInTheDocument();
+  });
+
+  it("does not render a filter box when there are no repositories", async () => {
+    vi.mocked(fetchRepos).mockResolvedValueOnce({ items: [] } as any);
+
+    renderLayout();
+
+    await waitFor(() => expect(screen.getByText("No repositories")).toBeInTheDocument());
+    expect(screen.queryByLabelText("Filter repositories by name")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/lib/nameFilter.test.ts
+++ b/frontend/src/lib/nameFilter.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { matchesNameFilter } from "./nameFilter";
+
+describe("matchesNameFilter", () => {
+  it("matches everything when the query is empty", () => {
+    expect(matchesNameFilter("Alpha", "")).toBe(true);
+  });
+
+  it("matches everything when the query is whitespace-only", () => {
+    expect(matchesNameFilter("Alpha", "   ")).toBe(true);
+  });
+
+  it("matches a partial, case-insensitive substring", () => {
+    expect(matchesNameFilter("My Project", "project")).toBe(true);
+    expect(matchesNameFilter("My Project", "PROJ")).toBe(true);
+    expect(matchesNameFilter("My Project", "y pr")).toBe(true);
+  });
+
+  it("trims leading/trailing whitespace from the query", () => {
+    expect(matchesNameFilter("My Project", "  project  ")).toBe(true);
+  });
+
+  it("returns false when there is no match", () => {
+    expect(matchesNameFilter("My Project", "xyz")).toBe(false);
+  });
+
+  it("returns false for an empty name with a non-empty query", () => {
+    expect(matchesNameFilter("", "xyz")).toBe(false);
+  });
+});

--- a/frontend/src/lib/nameFilter.ts
+++ b/frontend/src/lib/nameFilter.ts
@@ -1,0 +1,11 @@
+/**
+ * Generic, reusable name-filter predicate for card-rendering layers.
+ * Used by the Projects Overview grid and sidebar Project list (Story 2.5),
+ * and intended to be reused for Task Recipe/TaskLink cards once Epic 4
+ * introduces them, rather than re-implemented per feature.
+ */
+export function matchesNameFilter(name: string, query: string): boolean {
+  const trimmedQuery = query.trim().toLowerCase();
+  if (trimmedQuery === "") return true;
+  return name.toLowerCase().includes(trimmedQuery);
+}


### PR DESCRIPTION
## Summary
Implements Story 2.5 (Epic 2) per `_bmad-output/planning-artifacts/epics.md`: adds a name filter to both the Projects Overview grid and the sidebar Project list.

## Changes
- **New:** `frontend/src/lib/nameFilter.ts` — generic, reusable `matchesNameFilter(name, query)` predicate (case-insensitive substring match, trims whitespace, empty query matches all). Per AC1, this is implemented once and reused (not an Epic-2-only special case), so it can filter Task Recipe/TaskLink cards once Epic 4 introduces them.
- `ProjectsOverview.tsx`: added a search input above the card grid; filters the already-fetched `projects` list before rendering. Added a distinct "No Projects match "..."" empty state (separate from the existing "No Projects registered" state). **Additive only** — `fetchProjectsSummary` and all existing data/loading logic are untouched.
- `RepoLayout.tsx`: added a search input to the sidebar (shown only when expanded and repos exist), filtering the `repos` list by basename; added a "No matches" state.
- Full test coverage: `nameFilter.test.ts` (new, 6 tests), extended `ProjectsOverview.test.tsx` (+2 filter tests), new `RepoLayout.test.tsx` (3 tests).

## Out of scope
- Story 2.4 (cross-Project attention signal) — being developed concurrently in a sibling session; this PR deliberately avoids touching `fetchProjectsSummary`/attention-signal rendering to prevent collisions.
- No Epic 3/4/5/6 work.
- No backend/database/migration changes (pure client-side filter over already-fetched data). Confirmed via `git log origin/main -- alembic/versions/` before opening this PR — no relevant migrations needed for this story.

## Testing
- `npx vitest run` targeted files: 15/15 passing (nameFilter, ProjectsOverview, RepoLayout).
- `eslint` and `tsc --noEmit` clean on all touched files.
- Rebased onto latest `origin/main`.

## Story tracking
- `_bmad-output/implementation-artifacts/2-5-filter-projects-by-name.md` created, all tasks checked off, Status: review.
- `sprint-status.yaml`: `2-5-filter-projects-by-name` moved to `review`.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>