### PR TITLE
feat: implement Story 2.4 - See cross-Project attention signal (CAP-2)

### DIFF
--- a/_bmad-output/implementation-artifacts/2-4-see-cross-project-attention-signal.md
+++ b/_bmad-output/implementation-artifacts/2-4-see-cross-project-attention-signal.md
@@ -1,0 +1,81 @@
+---
+baseline_commit: 11af41b0
+---
+
+# Story 2.4: See cross-Project attention signal
+
+Status: review
+
+## Story
+
+As a CodePlane user managing several Projects,
+I want one rolled-up signal for anything needing attention across all Projects,
+So that I don't have to open every board to check for problems.
+
+## Acceptance Criteria
+
+1. **Given** two or more Projects, at least one with an awaiting-input or failed job, **when** I view the Overview, **then** I see a single combined count (awaiting input + failed, summed across all Projects), **and** the count updates when a job's state changes, sourced from the same batch summary call as Story 2.2 (no second endpoint).
+2. **Given** no Project has any awaiting-input or failed job, **when** I view the Overview, **then** the attention signal shows zero / is not alarmingly rendered.
+
+## Tasks / Subtasks
+
+- [x] Task 1: Compute combined attention count (AC: 1, 2)
+  - [x] In `frontend/src/components/ProjectsOverview.tsx`, derive `attentionCount` via `useMemo` from the existing `projects` state (the same array populated by `fetchProjectsSummary()` used by Story 2.2) as `sum(awaitingInputCount) + sum(failedCount)` across all items — no new fetch, no new endpoint.
+- [x] Task 2: Render the combined attention badge (AC: 1, 2)
+  - [x] Add a small badge/pill next to the "Projects" `<h1>` heading showing `attentionCount`.
+  - [x] When `attentionCount === 0`, render with neutral/muted styling (no alarming color/icon) — not omitted, just non-alarming.
+  - [x] When `attentionCount > 0`, render with an attention-drawing style (e.g. warning color), consistent with existing per-card badge colors (`text-yellow-400` awaiting / `text-red-400` failed) used elsewhere in the file.
+  - [x] Keep this additive: do not modify the fetch/loading logic, card grid, or `RepoLayout.tsx`; do not touch the area reserved for Story 2.5's name filter box.
+- [x] Task 3: Tests (AC: 1, 2)
+  - [x] Add a vitest case: multiple projects with varying `awaitingInputCount`/`failedCount` produce the correct summed badge value.
+  - [x] Add a vitest case: all projects have zero awaiting/failed → badge renders non-alarming (e.g. assert absence of the alarming CSS class, or assert the neutral variant is used) and still shows `0`.
+  - [x] Confirm existing `ProjectsOverview.test.tsx` cases (per-card counts, zero-job affordance, single fetch call, empty state) still pass unmodified.
+
+## Dev Notes
+
+- Architecture: `_bmad-output/planning-artifacts/architecture/architecture-codeplane-2026-08-10/ARCHITECTURE-SPINE.md` AD-3/AD-5 — Project is the sole summary unit; this story adds no new summary shape, it only aggregates already-fetched per-Project fields client-side.
+- SPEC: `_bmad-output/specs/spec-project-boards/SPEC.md` CAP-2 — the batch `GET /settings/projects/summary` endpoint (implemented in Story 2.2) already returns `awaitingInputCount`/`failedCount` per Project; this story is explicitly scoped to *not* add a second endpoint per the AC wording ("sourced from the same batch summary call as Story 2.2").
+- This story is **frontend-only**. No backend, schema, or alembic migration changes. Confirmed via `git log origin/main -- alembic/versions/` that no new migration is introduced by this story.
+- Coordination note: Story 2.5 (Filter Projects by name) is running concurrently and will likely touch `ProjectsOverview.tsx`'s header/search area. Keep this story's change additive and narrowly scoped to the attention badge only — do not restructure the heading row, fetch logic, or card grid, and do not implement the filter box (that is Story 2.5, out of scope here).
+- "Updates when a job's state changes" (AC: 1) is satisfied automatically since the badge derives from the same `projects` state that already refreshes via the existing `fetchProjectsSummary()` call/SSE-driven refresh path used by Story 2.2 — no separate polling/subscription needed for this story.
+- Follow repo conventions: React functional components, `useMemo` for derived state, Tailwind utility classes matching existing badge styling in this file (`lucide-react` icons, `text-yellow-400`/`text-red-400` patterns).
+
+### Project Structure Notes
+
+- Modified files only: `frontend/src/components/ProjectsOverview.tsx`, `frontend/src/components/__tests__/ProjectsOverview.test.tsx`
+- No new files, no backend files, no migrations.
+
+### References
+
+- [Source: _bmad-output/planning-artifacts/epics.md#Story 2.4: See cross-Project attention signal]
+- [Source: _bmad-output/implementation-artifacts/2-2-view-projects-overview.md]
+- [Source: _bmad-output/planning-artifacts/architecture/architecture-codeplane-2026-08-10/ARCHITECTURE-SPINE.md#AD-3, AD-5]
+- [Source: _bmad-output/specs/spec-project-boards/SPEC.md#CAP-2]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-sonnet-5
+
+### Debug Log References
+
+### Completion Notes List
+
+- Added `attentionCount` via `useMemo` in `ProjectsOverview.tsx`, summing `awaitingInputCount + failedCount` across all Projects from the existing `projects` state (already populated by Story 2.2's `fetchProjectsSummary()` — no new fetch call, no new endpoint).
+- Rendered a `data-testid="attention-badge"` pill next to the "Projects" heading: neutral/muted styling (`bg-muted`, `text-muted-foreground`, class `neutral`) when zero, alarming styling (`bg-red-500/15`, `text-red-400`, `AlertTriangle` icon, class `alarming`) when > 0.
+- Purely additive — no changes to fetch/loading logic, card grid, or `RepoLayout.tsx`; left the header row open for Story 2.5's filter box (not implemented here).
+- 2 new vitest cases added (combined sum across projects; non-alarming zero state); all 4 pre-existing `ProjectsOverview.test.tsx` cases pass unmodified. Full frontend suite: 25 files / 261 passed, 1 pre-existing skip — no regressions.
+- `npx tsc --noEmit` passes with no errors; `npx eslint` on changed files reports no issues.
+- Confirmed via `git log origin/main -- alembic/versions/` that no alembic migration is introduced by this story (frontend-only change, no schema/backend touch).
+
+### File List
+
+- `frontend/src/components/ProjectsOverview.tsx` (modified)
+- `frontend/src/components/__tests__/ProjectsOverview.test.tsx` (modified)
+- `_bmad-output/implementation-artifacts/sprint-status.yaml` (modified)
+
+## Change Log
+
+- 2026-08-10: Story created (Copilot CLI, dev-story workflow) for backlog item `2-4-see-cross-project-attention-signal`.
+- 2026-08-10: Implementation complete — combined cross-Project attention badge (awaiting+failed summed, non-alarming at zero) added to `ProjectsOverview.tsx`, sourced from the existing Story 2.2 batch summary fetch (no new endpoint). 2 new frontend tests added, full suite passes with no regressions. Status set to `review`.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -41,7 +41,7 @@
 # - Retrospective appends its action items to action_items; sprint-status surfaces open ones
 
 generated: 2026-08-10
-last_updated: 2026-08-10
+last_updated: 2026-08-10T21:10:00-04:00
 project: codeplane
 project_key: NOKEY
 tracking_system: file-system
@@ -62,7 +62,7 @@ development_status:
   2-1-create-edit-a-project: review
   2-2-view-projects-overview: review
   2-3-view-a-projects-board: review
-  2-4-see-cross-project-attention-signal: backlog
+  2-4-see-cross-project-attention-signal: review
   2-5-filter-projects-by-name: review
   epic-2-retrospective: optional
 

--- a/frontend/src/components/ProjectsOverview.tsx
+++ b/frontend/src/components/ProjectsOverview.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { FolderGit2, PlayCircle, Clock, AlertTriangle } from "lucide-react";
 import { toast } from "sonner";
@@ -70,6 +70,14 @@ export function ProjectsOverview() {
   const [projects, setProjects] = useState<ProjectSummaryResponse[]>([]);
   const [filterQuery, setFilterQuery] = useState("");
 
+  // Combined cross-Project attention signal (Story 2.4): summed awaiting+failed
+  // across all Projects, derived from the same batch summary fetch as Story 2.2
+  // (no second endpoint, no extra fetch).
+  const attentionCount = useMemo(
+    () => projects.reduce((sum, p) => sum + p.awaitingInputCount + p.failedCount, 0),
+    [projects],
+  );
+
   const load = useCallback(async () => {
     setLoading(true);
     try {
@@ -115,7 +123,21 @@ export function ProjectsOverview() {
 
   return (
     <div className="max-w-5xl mx-auto space-y-4">
-      <h1 className="text-xl font-semibold text-foreground">Projects</h1>
+      <div className="flex items-center gap-3">
+        <h1 className="text-xl font-semibold text-foreground">Projects</h1>
+        <span
+          data-testid="attention-badge"
+          title="Combined awaiting-input + failed jobs across all Projects"
+          className={
+            attentionCount > 0
+              ? "alarming flex items-center gap-1 rounded-full bg-red-500/15 px-2 py-0.5 text-xs font-medium text-red-400"
+              : "neutral flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground"
+          }
+        >
+          {attentionCount > 0 ? <AlertTriangle size={12} /> : null}
+          {attentionCount}
+        </span>
+      </div>
       <input
         type="text"
         value={filterQuery}

--- a/frontend/src/components/__tests__/ProjectsOverview.test.tsx
+++ b/frontend/src/components/__tests__/ProjectsOverview.test.tsx
@@ -131,4 +131,46 @@ describe("ProjectsOverview", () => {
     expect(screen.queryByText("Alpha")).not.toBeInTheDocument();
     expect(screen.getByText('No Projects match "zzz"')).toBeInTheDocument();
   });
+
+  it("shows a combined attention count summed across all projects' awaiting+failed", async () => {
+    vi.mocked(fetchProjectsSummary).mockResolvedValueOnce({
+      items: [
+        makeSummary({ id: "proj-1", name: "Alpha", awaitingInputCount: 2, failedCount: 1 }),
+        makeSummary({ id: "proj-2", name: "Beta", awaitingInputCount: 0, failedCount: 3 }),
+      ],
+    } as any);
+
+    render(
+      <MemoryRouter>
+        <ProjectsOverview />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(screen.getByText("Alpha")).toBeInTheDocument());
+    // 2 + 1 + 0 + 3 = 6
+    const badge = await screen.findByTestId("attention-badge");
+    expect(badge).toHaveTextContent("6");
+    expect(badge.className).toMatch(/alarming/);
+  });
+
+  it("renders the attention badge non-alarmingly when no project needs attention", async () => {
+    vi.mocked(fetchProjectsSummary).mockResolvedValueOnce({
+      items: [
+        makeSummary({ id: "proj-1", name: "Alpha" }),
+        makeSummary({ id: "proj-2", name: "Beta" }),
+      ],
+    } as any);
+
+    render(
+      <MemoryRouter>
+        <ProjectsOverview />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(screen.getByText("Alpha")).toBeInTheDocument());
+    const badge = await screen.findByTestId("attention-badge");
+    expect(badge).toHaveTextContent("0");
+    expect(badge.className).toMatch(/neutral/);
+    expect(badge.className).not.toMatch(/alarming/);
+  });
 });


### PR DESCRIPTION
## Summary

Implements Story 2.4 from Epic 2: a single rolled-up "attention" signal on the Projects Overview showing the combined count of awaiting-input + failed jobs summed across all Projects.

## Acceptance Criteria

1. **Given** two or more Projects, at least one with an awaiting-input or failed job, **when** I view the Overview, **then** I see a single combined count (awaiting input + failed, summed across all Projects), and the count updates when a job's state changes, sourced from the same batch summary call as Story 2.2 (no second endpoint). ✅
2. **Given** no Project has any awaiting-input or failed job, **when** I view the Overview, **then** the attention signal shows zero / is not alarmingly rendered. ✅

## Implementation

Purely additive, **frontend-only** change — no backend/API/schema/migration changes:

- `frontend/src/components/ProjectsOverview.tsx`: added `attentionCount`, a `useMemo`-derived sum of `awaitingInputCount + failedCount` across all Projects in the already-fetched `projects` state (same batch `GET /settings/projects/summary` call from Story 2.2 — no new fetch, no new endpoint). Renders as a small badge next to the "Projects" heading: neutral/muted style when zero, warning style (red, `AlertTriangle` icon) when greater than zero.
- `frontend/src/components/__tests__/ProjectsOverview.test.tsx`: 2 new test cases — combined sum across multiple Projects, and non-alarming zero-state rendering.

Confirmed via `git log origin/main -- alembic/versions/` that no new alembic migration is introduced by this story.

## Scope / Exclusions

- Kept the change narrowly scoped (badge only, next to the heading) to avoid colliding with the concurrently in-flight Story 2.5 (filter Projects by name), which will also touch `ProjectsOverview.tsx`. Did **not** implement the name filter box, and did **not** modify the fetch/loading logic, card grid, or `RepoLayout.tsx`.
- No Epic 3/4/5/6 work included.

## Testing

- `npx vitest run src/components/__tests__/ProjectsOverview.test.tsx` — 6/6 pass
- `npx vitest run` (full frontend suite) — 25 files / 261 passed, 1 pre-existing skip, no regressions
- `npx tsc --noEmit` — no errors
- `npx eslint` on changed files — no issues

## Story tracking

- `_bmad-output/implementation-artifacts/2-4-see-cross-project-attention-signal.md` (new) — moved through ready-for-dev → in-progress → review
- `_bmad-output/implementation-artifacts/sprint-status.yaml` (updated)

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>