### PR TITLE
feat: Story 4.4 - See TaskLink cards on the board

### DIFF
--- a/_bmad-output/implementation-artifacts/4-4-see-tasklink-cards-on-the-board.md
+++ b/_bmad-output/implementation-artifacts/4-4-see-tasklink-cards-on-the-board.md
@@ -1,0 +1,99 @@
+---
+baseline_commit: d96db821
+---
+
+# Story 4.4: See TaskLink cards on the board
+
+Status: review
+
+## Story
+
+As a CodePlane user watching a Project board,
+I want to see task recipe nodes as cards alongside regular job cards,
+so that I can see the whole graph of planned and running work in one place.
+
+## Acceptance Criteria
+
+1. **Given** a Project with TaskLinks created via ingestion (4.2), manual assignment (4.3), or both, **when** I view that Project's board, **then** every TaskLink renders as a card in the same column grid as job cards, through one client-side rendering pass (not a separate screen).
+2. **Given** a TaskLink whose `depends_on` list has unsatisfied entries, **when** I view the board, **then** that card renders greyed out with a chained-lifetime badge, distinguishing it from an active job card.
+3. **Given** a TaskLink whose dependencies are all satisfied, **when** I view the board, **then** the card renders in its normal (non-greyed) state, ready to spawn or already linked to a running `job_id`.
+
+## Tasks / Subtasks
+
+- [x] Resolve the owning Project for the board's `repoPath` (AC: #1)
+  - [x] `fetchProjects()` in `frontend/src/api/client.ts` (`GET /settings/projects`, already exists server-side from Story 2.1 — no backend change).
+  - [x] `fetchProjectTaskLinks(projectId)` in `frontend/src/api/client.ts` (`GET /settings/projects/{id}/task-links`, already exists server-side from Story 4.2 — no backend change).
+  - [x] Regenerate `frontend/src/api/schema.d.ts` (`npm run generate:api` against a locally running backend) — purely refreshing stale generated types for already-shipped endpoints, no functional backend change.
+- [x] Render TaskLink cards in the board's column grid (AC: #1, #2, #3)
+  - [x] New `TaskLinkCard.tsx` component: chain-lifetime icon/badge, story-node/tracker-ticket label, repo name, satisfied vs. greyed-waiting visual state — styled consistently with the existing `JobCard.tsx`.
+  - [x] `KanbanColumn.tsx`: optional `extraCards` prop to render non-job cards after the job list, used only for the "In Progress" column (a TaskLink represents planned/chained work, not a job-state outcome, matching the CAP-10 wireframe in `ui-flows.md`).
+  - [x] `RepoBoard.tsx`: on mount, fetch Projects, find the one whose `repoPaths` contains the current `repoPath`; if found, fetch its full TaskLink set; render cards only for TaskLinks whose own `repoPath` matches the current board (single-repo-Project reduction, consistent with existing job filtering per Story 2.3's Dev Notes).
+- [x] Compute dependency satisfaction (AC: #2, #3)
+  - [x] A `dependsOn` entry (composite `"{repoPath}::{storyNodeId}"`) is satisfied when its target TaskLink is found within the full Project TaskLink set (so cross-repo dependencies resolve) **and** that target has a `jobId` whose Job (looked up from the already-populated jobs store) is in the `completed` state.
+  - [x] An entry whose target cannot be resolved, or whose target's Job isn't `completed`, is unsatisfied.
+  - [x] Empty `dependsOn` ⇒ trivially satisfied (AC #3's "ready to spawn" case).
+- [x] Tests (AC: #1, #2, #3)
+  - [x] `TaskLinkCard.test.tsx`: satisfied vs. greyed-waiting rendering, badge text/labels.
+  - [x] Extend `RepoBoard.test.tsx`: TaskLink cards render in "In Progress" alongside job cards; greyed state for unsatisfied deps; normal state for satisfied/empty deps; cards scoped to the board's own repo only.
+  - [x] Run targeted vitest + eslint + tsc on changed frontend files.
+
+## Dev Notes
+
+- **No backend changes required.** Story 4.2 (merged, PR #60) already shipped `TaskLinkRow`/`TaskLink`/`TaskLinkResponse` (including `tracker_ticket_ref`/`prompt_override`, which Story 4.3 will populate later but which already exist in the schema), `GET /settings/projects/{id}/task-links`, and `GET /settings/projects` (list, from Story 2.1). This story is a frontend-only consumer of already-shipped read endpoints — confirmed directly against `backend/models/db.py`, `backend/models/api_schemas.py`, and `backend/api/projects.py` before starting.
+- **Story 4.3 status:** in PR #63, in final review, not yet merged as of this story's start. Verified it introduces no new schema/contract that 4.4 needs — `tracker_ticket_ref`/`prompt_override` already exist from 4.2. Not a blocker; explicitly not implementing 4.3's manual-assignment UI/flow here.
+- Per `_bmad-output/specs/spec-project-boards/ui-flows.md` (CAP-8 through CAP-11): "`TaskLink` cards (CAP-9/CAP-10) render inside the *same* `RepoBoard` column grid as regular job cards (CAP-1), fetched by the same board via a second call (`GET /settings/projects/:id/task-links`, AD-11)." The wireframe places both a satisfied ("✓ deps satisfied") and an unsatisfied greyed ("⏳ waiting on …") TaskLink card in the "In progress" column, alongside a real job card — this story follows that placement exactly.
+- `RepoBoard.tsx` (Story 2.3) currently reduces "Project" to `job.repo === repoPath` for job filtering (documented in its own header comment) since multi-repo Project wiring into the frontend job-fetch path hasn't landed yet. This story does **not** change that job-filtering reduction — it only adds a second, independent fetch (Projects list → owning Project → its TaskLinks) needed to resolve TaskLink cards, scoped defensively: if no Project claims this `repoPath` (e.g., a pre-migration bare repo), simply render zero TaskLink cards rather than erroring.
+- Dependency-satisfaction rule for this story (AC #2/#3) is intentionally conservative and read-only: satisfied only requires the target TaskLink's linked Job to have reached the `completed` state (using the existing job-state classification already used by `frontend/src/store/selectors.ts`, not a new one). This is *not* Story 4.5's auto-spawn trigger logic — 4.4 only renders a visual state, it never calls any spawn/create-job endpoint itself.
+- Do NOT implement: 4.3 manual assignment UI, 4.5 auto-spawn via `spawn_task`, 4.6 tracker-write routing, any Epic 5/6 (Chat, MCP tools) work, or CAP-5's name-filter integration (Story 1.5, a separate cross-cutting concern not gated by this AC).
+- Follow existing conventions: components read store state via selectors (no local copies of job state), large-list virtualization is not triggered here (TaskLink counts are small, matching existing `KanbanColumn` job-card rendering which is also non-virtualized), domain types are imported from `frontend/src/api/types.ts` (re-exporting the regenerated `schema.d.ts`, never hand-written duplicates).
+- **Alembic:** none expected — this is a pure read/render feature with zero backend changes. Verify the true current alembic head via `git log origin/main -- alembic/versions/` and rebase onto latest `origin/main` immediately before opening the PR, per standing instruction, even though no migration is anticipated.
+
+### Project Structure Notes
+
+- `frontend/src/components/RepoBoard.tsx` — extended, not rewritten.
+- `frontend/src/components/KanbanColumn.tsx` — extended with an optional prop, backward compatible with existing job-only usage (`DashboardScreen`'s flat `KanbanBoard.tsx` continues to work unchanged).
+- `frontend/src/components/TaskLinkCard.tsx` — new.
+- `frontend/src/api/client.ts`, `frontend/src/api/types.ts`, `frontend/src/api/schema.d.ts` — extended (schema.d.ts regenerated, not hand-edited).
+
+### References
+
+- `_bmad-output/planning-artifacts/epics.md` — Epic 4, Story 4.4 (source of the ACs above).
+- `_bmad-output/specs/spec-project-boards/SPEC.md` — CAP-10.
+- `_bmad-output/specs/spec-project-boards/ui-flows.md` — CAP-8 through CAP-11 wireframe and data-flow section.
+- `_bmad-output/implementation-artifacts/4-2-ingest-a-task-graph-into-a-project.md` — prerequisite story (TaskLink persistence + read endpoints).
+- `_bmad-output/implementation-artifacts/2-3-view-a-projects-board.md` — prerequisite story (`RepoBoard.tsx`, job-card rendering conventions).
+
+## Dev Agent Record
+
+### Debug Log
+
+- Confirmed via direct code inspection (`backend/models/db.py`, `backend/models/api_schemas.py`, `backend/api/projects.py`) that no backend changes were needed: `GET /settings/projects` and `GET /settings/projects/{id}/task-links` already existed and returned all fields needed (`repo_path`, `story_node_id`, `tracker_ticket_ref`, `depends_on`, `job_id`).
+- `frontend/src/api/schema.d.ts` was stale (missing `ProjectResponse`/`TaskLinkResponse` types) — regenerated by running `create_app().openapi()` in-process, dumping to a temp `openapi.json`, and running `npx openapi-typescript` against it (no live server needed).
+- Rebased onto latest `origin/main` after Story 4.3 (PR #63) merged mid-session; confirmed via `git show` that 4.3 only added a new `CreateManualTaskLinkRequest` schema and a POST endpoint — `TaskLinkResponse` itself is unchanged, so no re-regeneration of `schema.d.ts` was required after rebase.
+- Verified alembic head against `origin/main`: still `0063_add_chat_messages.py` (no new migrations landed), confirming this story's "no migration needed" assumption held after rebase.
+
+### Completion Notes
+
+- Implemented as a frontend-only feature: `RepoBoard` resolves the Project owning its `repoPath` via `fetchProjects()`, fetches that Project's TaskLinks via `fetchProjectTaskLinks(projectId)`, computes per-TaskLink dependency satisfaction (`computeSatisfaction` helper: a `depends_on` entry is satisfied iff its target TaskLink exists in the Project's full TaskLink set and that target's `jobId` maps to a job with `state === "completed"`; empty `depends_on` is trivially satisfied), and renders `TaskLinkCard` entries in the "In Progress" `KanbanColumn` via a new optional `extraCards` prop — matching the `ui-flows.md` CAP-8–11 wireframe exactly.
+- TaskLink cards are scoped to the board's own `repoPath` only (consistent with `RepoBoard`'s existing single-repo-Project job-filtering reduction).
+- No backend changes were made or needed. Story 4.3 (manual assignment) merged mid-implementation but introduced no new fields relevant to 4.4's rendering — confirmed by diffing `api_schemas.py` after rebase.
+- Explicitly NOT implemented (out of scope): Story 4.3's manual-assignment UI/flow, Story 4.5's auto-spawn-on-completion (`spawn_task`) logic, Story 4.6's tracker-write routing, any Epic 5/6 work, and CAP-5's name-filter integration.
+- Tests: 5 new tests in `TaskLinkCard.test.tsx` (label rendering, tracker-ticket fallback, satisfied styling, greyed waiting styling, generic waiting badge) + 4 new tests added to `RepoBoard.test.tsx` (TaskLink cards render for resolved Project, greyed when dependency incomplete, satisfied once dependency completes, scoped to board's own repo only). All 15 relevant tests (9 pre-existing + new) pass. `eslint` and `tsc --noEmit` pass clean on all changed files. `DashboardScreen.test.tsx` re-run to confirm the optional `extraCards` prop addition to `KanbanColumn.tsx` didn't regress the flat-board usage — all 7 tests pass.
+
+## File List
+
+- `_bmad-output/implementation-artifacts/4-4-see-tasklink-cards-on-the-board.md` (new)
+- `_bmad-output/implementation-artifacts/sprint-status.yaml` (modified)
+- `frontend/src/api/client.ts` (modified — added `fetchProjects()`, `fetchProjectTaskLinks()`)
+- `frontend/src/api/types.ts` (modified — re-exported `ProjectResponse`, `ProjectListResponse`, `TaskLinkResponse`, `TaskLinkListResponse`)
+- `frontend/src/api/schema.d.ts` (modified — regenerated from live OpenAPI schema, no functional backend change)
+- `frontend/src/components/TaskLinkCard.tsx` (new)
+- `frontend/src/components/KanbanColumn.tsx` (modified — added optional `extraCards` prop)
+- `frontend/src/components/RepoBoard.tsx` (modified — Project/TaskLink fetch, satisfaction computation, card wiring)
+- `frontend/src/components/__tests__/TaskLinkCard.test.tsx` (new)
+- `frontend/src/components/__tests__/RepoBoard.test.tsx` (modified — added TaskLink rendering test cases)
+
+## Change Log
+
+- 2026-08-10: Story drafted from epics.md Epic 4 / Story 4.4 and started (bmad-dev-story).
+- 2026-08-10: Implementation complete — TaskLink cards render on `RepoBoard` per AC #1–#3, no backend changes, rebased onto `origin/main` (post Story 4.3 merge), all targeted tests/eslint/tsc pass. Status → review.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -78,7 +78,7 @@ development_status:
   4-1-widen-the-task-recipe-vocabulary: review
   4-2-ingest-a-task-graph-into-a-project: review
   4-3-manually-assign-a-task-to-an-existing-ticket: review
-  4-4-see-tasklink-cards-on-the-board: backlog
+  4-4-see-tasklink-cards-on-the-board: review
   4-5-auto-spawn-the-next-task-on-completion: backlog
   4-6-route-recipe-tracker-writes-to-the-paired-ticket: backlog
   epic-4-retrospective: optional

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -19,6 +19,8 @@ import type {
   RepoDetailResponse,
   RepoListResponse,
   ProjectListSummaryResponse,
+  ProjectListResponse,
+  TaskLinkListResponse,
   SDKListResponse,
   Settings,
   SidecarTemplate,
@@ -406,6 +408,16 @@ export function fetchRepos(): Promise<RepoListResponse> {
 
 export function fetchProjectsSummary(): Promise<ProjectListSummaryResponse> {
   return request("/settings/projects/summary");
+}
+
+/** List every registered Project, including its member repo paths (Story 2.1 / CAP-6). */
+export function fetchProjects(): Promise<ProjectListResponse> {
+  return request("/settings/projects");
+}
+
+/** List a Project's currently persisted TaskLinks (Story 4.2 / CAP-9). */
+export function fetchProjectTaskLinks(projectId: string): Promise<TaskLinkListResponse> {
+  return request(`/settings/projects/${encodeURIComponent(projectId)}/task-links`);
 }
 
 export function fetchRepoDetail(repoPath: string): Promise<RepoDetailResponse> {

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -89,7 +89,10 @@ export interface paths {
          *
          *     Returns immediately with ``state=preparing``. Workspace setup and agent
          *     launch happen in a background task — the frontend watches progress via
-         *     SSE ``job_setup_progress`` events.
+         *     SSE ``job_setup_progress`` events. Naming is also asynchronous: the job
+         *     gets an instant heuristic-slug identity, and if a title wasn't already
+         *     pre-computed by the frontend, the real LLM-generated title/description
+         *     are filled in afterwards and pushed via SSE ``job_title_updated``.
          */
         post: operations["create_job_api_jobs_post"];
         delete?: never;
@@ -464,6 +467,31 @@ export interface paths {
          *     Blocked while the agent is actively running.
          */
         post: operations["restore_to_sha_api_jobs__job_id__restore_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/jobs/{job_id}/reenrich": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Reenrich Job
+         * @description Re-enrich historical events for a job through TraceForge.
+         *
+         *     Replays all persisted events through a fresh TraceForge Enricher so
+         *     that classification, visibility, tool_display and other metadata are
+         *     backfilled.  Idempotent — a marker event prevents double processing
+         *     unless ``force=true``.
+         */
+        post: operations["reenrich_job_api_jobs__job_id__reenrich_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1168,6 +1196,11 @@ export interface paths {
         /**
          * Update Settings
          * @description Update settings. Only provided fields are changed.
+         *
+         *     Mutates the app-scoped ``CPLConfig`` singleton in place (rather than a
+         *     freshly ``load_config()``-ed copy) so the change is visible immediately
+         *     to ``GET /settings`` and to any running services holding a reference to
+         *     this same config object — not just after the next server restart.
          */
         put: operations["update_settings_api_settings_put"];
         post?: never;
@@ -1279,30 +1312,6 @@ export interface paths {
          * @description Create a new git repository and register it.
          */
         post: operations["create_repo_endpoint_api_settings_repos_create_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/settings/projects/summary": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Projects Summary
-         * @description Batch Overview summary for every Project (Story 2.2 / CAP-2).
-         *
-         *     Single call for all Projects — the Overview screen never does N
-         *     sequential per-Project fetches. Projects with no jobs at all are still
-         *     included, with all-zero counts.
-         */
-        get: operations["get_projects_summary_api_settings_projects_summary_get"];
-        put?: never;
-        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -2156,33 +2165,33 @@ export interface paths {
          * Preview Proxy
          * @description Reverse-proxy a request to a local development server.
          */
-        get: operations["preview_proxy_api_preview__port___path__delete"];
+        get: operations["preview_proxy_api_preview__port___path__post"];
         /**
          * Preview Proxy
          * @description Reverse-proxy a request to a local development server.
          */
-        put: operations["preview_proxy_api_preview__port___path__delete"];
+        put: operations["preview_proxy_api_preview__port___path__post"];
         /**
          * Preview Proxy
          * @description Reverse-proxy a request to a local development server.
          */
-        post: operations["preview_proxy_api_preview__port___path__delete"];
+        post: operations["preview_proxy_api_preview__port___path__post"];
         /**
          * Preview Proxy
          * @description Reverse-proxy a request to a local development server.
          */
-        delete: operations["preview_proxy_api_preview__port___path__delete"];
+        delete: operations["preview_proxy_api_preview__port___path__post"];
         options?: never;
         /**
          * Preview Proxy
          * @description Reverse-proxy a request to a local development server.
          */
-        head: operations["preview_proxy_api_preview__port___path__delete"];
+        head: operations["preview_proxy_api_preview__port___path__post"];
         /**
          * Preview Proxy
          * @description Reverse-proxy a request to a local development server.
          */
-        patch: operations["preview_proxy_api_preview__port___path__delete"];
+        patch: operations["preview_proxy_api_preview__port___path__post"];
         trace?: never;
     };
     "/api/jobs/{job_id}/share": {
@@ -2464,6 +2473,61 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/settings/credentials": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Credentials */
+        get: operations["list_credentials_api_settings_credentials_get"];
+        put?: never;
+        /** Create Credential */
+        post: operations["create_credential_api_settings_credentials_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/settings/credentials/guidance": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Provider Guidance
+         * @description Return per-provider PAT scope guidance (NFR9). Static, no DB access.
+         */
+        get: operations["get_provider_guidance_api_settings_credentials_guidance_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/settings/credentials/{credential_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete Credential */
+        delete: operations["delete_credential_api_settings_credentials__credential_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/metrics/chat": {
         parameters: {
             query?: never;
@@ -2664,6 +2728,227 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/chats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Chats
+         * @description List all chats.
+         */
+        get: operations["list_chats_api_chats_get"];
+        put?: never;
+        /**
+         * Create Chat
+         * @description Start a new Chat. ``project_id`` defaults from caller context and is user-overridable.
+         */
+        post: operations["create_chat_api_chats_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/chats/{chat_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Chat
+         * @description Get a single chat by ID.
+         */
+        get: operations["get_chat_api_chats__chat_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/chats/{chat_id}/messages": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Add Chat Message
+         * @description Append a message to a Chat's transcript.
+         */
+        post: operations["add_chat_message_api_chats__chat_id__messages_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/chats/{chat_id}/launch-job": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Launch Job From Chat
+         * @description Launch a new Job from this Chat, seeded from its transcript (CAP-12/AD-12).
+         *
+         *     Provisions a worktree/branch for the first time at this call — the
+         *     Chat itself remains open and unconsumed, and can launch further,
+         *     independent Jobs later (Story 5.2).
+         */
+        post: operations["launch_job_from_chat_api_chats__chat_id__launch_job_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/settings/projects": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Projects
+         * @description List all registered Projects.
+         */
+        get: operations["list_projects_api_settings_projects_get"];
+        put?: never;
+        /**
+         * Create Project
+         * @description Create a new Project, registering each repo path (AD-5).
+         */
+        post: operations["create_project_api_settings_projects_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/settings/projects/summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Projects Summary
+         * @description Batch Overview summary for every Project (Story 2.2 / CAP-2).
+         *
+         *     Single call for all Projects — the Overview screen never does N
+         *     sequential per-Project fetches. Projects with no jobs at all are still
+         *     included, with all-zero counts.
+         */
+        get: operations["get_projects_summary_api_settings_projects_summary_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/settings/projects/{project_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Project
+         * @description Get a single Project by ID.
+         */
+        get: operations["get_project_api_settings_projects__project_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Update Project
+         * @description Rename a Project and/or replace its repo membership.
+         */
+        patch: operations["update_project_api_settings_projects__project_id__patch"];
+        trace?: never;
+    };
+    "/api/settings/projects/{project_id}/ingest-tasks": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Ingest Project Tasks
+         * @description Ingest BMAD stories / spec-kit tasks for every member repo of a Project (CAP-9).
+         *
+         *     Stateless, on-demand, read-only against every source repo; re-running
+         *     upserts existing TaskLinks rather than duplicating them.
+         */
+        post: operations["ingest_project_tasks_api_settings_projects__project_id__ingest_tasks_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/settings/projects/{project_id}/task-links": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Project Task Links
+         * @description List a Project's currently persisted TaskLinks.
+         */
+        get: operations["list_project_task_links_api_settings_projects__project_id__task_links_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tracker-links": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Tracker Links */
+        get: operations["list_tracker_links_api_projects__project_id__tracker_links_get"];
+        put?: never;
+        /** Create Tracker Link */
+        post: operations["create_tracker_link_api_projects__project_id__tracker_links_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -2748,6 +3033,16 @@ export interface components {
              * @default 30
              */
             periodDays: number;
+        };
+        /**
+         * AddChatMessageRequest
+         * @description Append a message to a Chat's transcript.
+         */
+        AddChatMessageRequest: {
+            /** Role */
+            role: string;
+            /** Content */
+            content: string;
         };
         /** AnalyticsJobsResponse */
         AnalyticsJobsResponse: {
@@ -3103,6 +3398,48 @@ export interface components {
              */
             jobCount: number;
         };
+        /** ChatListResponse */
+        ChatListResponse: {
+            /** Items */
+            items: components["schemas"]["ChatResponse"][];
+        };
+        /** ChatMessageResponse */
+        ChatMessageResponse: {
+            /** Id */
+            id: string;
+            /** Chatid */
+            chatId: string;
+            /** Role */
+            role: string;
+            /** Content */
+            content: string;
+            /**
+             * Createdat
+             * Format: date-time
+             */
+            createdAt: string;
+        };
+        /** ChatResponse */
+        ChatResponse: {
+            /** Id */
+            id: string;
+            /** Projectid */
+            projectId: string | null;
+            /** Title */
+            title: string;
+            /**
+             * Createdat
+             * Format: date-time
+             */
+            createdAt: string;
+            /**
+             * Lastmessageat
+             * Format: date-time
+             */
+            lastMessageAt: string;
+            /** Status */
+            status: string;
+        };
         /** CleanupWorktreesResponse */
         CleanupWorktreesResponse: {
             /** Removed */
@@ -3323,6 +3660,27 @@ export interface components {
                 [key: string]: components["schemas"]["CoveringTestCandidate"][];
             };
         };
+        /**
+         * CreateChatRequest
+         * @description Create a new Chat. ``project_id`` is always user-overridable at creation.
+         */
+        CreateChatRequest: {
+            /** Title */
+            title: string;
+            /** Projectid */
+            projectId?: string | null;
+        };
+        /** CreateCredentialRequest */
+        CreateCredentialRequest: {
+            /** Provider */
+            provider: string;
+            /** Label */
+            label: string;
+            /** Baseurl */
+            baseUrl: string;
+            /** Pat */
+            pat: string;
+        };
         /** CreateJobRequest */
         CreateJobRequest: {
             /** Repo */
@@ -3384,6 +3742,13 @@ export interface components {
              */
             createdAt: string;
         };
+        /** CreateProjectRequest */
+        CreateProjectRequest: {
+            /** Name */
+            name: string;
+            /** Repopaths */
+            repoPaths: string[];
+        };
         /** CreateRepoRequest */
         CreateRepoRequest: {
             /** Path */
@@ -3430,6 +3795,31 @@ export interface components {
             jobId?: string | null;
             /** Pid */
             pid: number;
+        };
+        /** CreateTrackerLinkRequest */
+        CreateTrackerLinkRequest: {
+            /** Credentialid */
+            credentialId: string;
+            /** Externalref */
+            externalRef: string;
+        };
+        /** CredentialListResponse */
+        CredentialListResponse: {
+            /** Credentials */
+            credentials?: components["schemas"]["CredentialResponse"][];
+        };
+        /** CredentialResponse */
+        CredentialResponse: {
+            /** Id */
+            id: string;
+            /** Provider */
+            provider: string;
+            /** Label */
+            label: string;
+            /** Baseurl */
+            baseUrl: string;
+            /** Createdat */
+            createdAt: string;
         };
         /** CustomMetricResponse */
         CustomMetricResponse: {
@@ -4129,6 +4519,14 @@ export interface components {
             /** Stale */
             stale?: boolean | null;
         };
+        /**
+         * IngestTaskGraphResponse
+         * @description Result of an ingestion run — the full upserted TaskLink set for the Project.
+         */
+        IngestTaskGraphResponse: {
+            /** Items */
+            items: components["schemas"]["TaskLinkResponse"][];
+        };
         /** JobContextFlag */
         JobContextFlag: {
             /** Type */
@@ -4629,6 +5027,22 @@ export interface components {
              * @default []
              */
             sidecarSessions: components["schemas"]["SidecarSessionSummary"][];
+        };
+        /**
+         * LaunchJobFromChatRequest
+         * @description Launch a Job from a Chat, seeded from its transcript (CAP-12/AD-12, Story 5.2).
+         */
+        LaunchJobFromChatRequest: {
+            /** Repo */
+            repo: string;
+            /** Baseref */
+            baseRef?: string | null;
+            /** Branch */
+            branch?: string | null;
+            /** Model */
+            model?: string | null;
+            /** Sdk */
+            sdk?: string | null;
         };
         /**
          * LineCoverageResponse
@@ -5412,6 +5826,74 @@ export interface components {
              */
             replacesCount: number;
         };
+        /** ProjectListResponse */
+        ProjectListResponse: {
+            /** Items */
+            items: components["schemas"]["ProjectResponse"][];
+        };
+        /** ProjectListSummaryResponse */
+        ProjectListSummaryResponse: {
+            /** Items */
+            items: components["schemas"]["ProjectSummaryResponse"][];
+        };
+        /**
+         * ProjectResponse
+         * @description A Project — the sole entity that owns repo-path membership (AD-5).
+         */
+        ProjectResponse: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Repopaths */
+            repoPaths: string[];
+            /**
+             * Createdat
+             * Format: date-time
+             */
+            createdAt: string;
+            /**
+             * Updatedat
+             * Format: date-time
+             */
+            updatedAt: string;
+        };
+        /**
+         * ProjectSummaryResponse
+         * @description Batch Overview summary for one Project (Story 2.2 / CAP-2).
+         */
+        ProjectSummaryResponse: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /** Repopaths */
+            repoPaths: string[];
+            /**
+             * Activejobcount
+             * @default 0
+             */
+            activeJobCount: number;
+            /**
+             * Awaitinginputcount
+             * @default 0
+             */
+            awaitingInputCount: number;
+            /**
+             * Failedcount
+             * @default 0
+             */
+            failedCount: number;
+            /** Lastactivityat */
+            lastActivityAt?: string | null;
+        };
+        /** ProviderGuidanceResponse */
+        ProviderGuidanceResponse: {
+            /** Guidance */
+            guidance?: {
+                [key: string]: string;
+            };
+        };
         /** RegisterRepoRequest */
         RegisterRepoRequest: {
             /** Source */
@@ -5466,43 +5948,6 @@ export interface components {
             activeJobCount: number;
             /** Platform */
             platform?: string | null;
-        };
-        /**
-         * ProjectSummaryResponse
-         * @description Batch Overview summary for one Project (Story 2.2 / CAP-2).
-         */
-        ProjectSummaryResponse: {
-            /** Id */
-            id: string;
-            /** Name */
-            name: string;
-            /** Repopaths */
-            repoPaths: string[];
-            /**
-             * Activejobcount
-             * @default 0
-             */
-            activeJobCount: number;
-            /**
-             * Awaitinginputcount
-             * @default 0
-             */
-            awaitingInputCount: number;
-            /**
-             * Failedcount
-             * @default 0
-             */
-            failedCount: number;
-            /**
-             * Lastactivityat
-             * Format: date-time
-             */
-            lastActivityAt?: string | null;
-        };
-        /** ProjectListSummaryResponse */
-        ProjectListSummaryResponse: {
-            /** Items */
-            items: components["schemas"]["ProjectSummaryResponse"][];
         };
         /**
          * RepoHealthResponse
@@ -6603,6 +7048,45 @@ export interface components {
             /** Worktreename */
             worktreeName: string;
         };
+        /** TaskLinkListResponse */
+        TaskLinkListResponse: {
+            /** Items */
+            items: components["schemas"]["TaskLinkResponse"][];
+        };
+        /**
+         * TaskLinkResponse
+         * @description A TaskLink — a thin, Project-scoped correlation row (Story 4.2, AD-9).
+         */
+        TaskLinkResponse: {
+            /** Id */
+            id: string;
+            /** Projectid */
+            projectId: string;
+            /** Repopath */
+            repoPath: string;
+            /** Storynodeid */
+            storyNodeId: string | null;
+            /** Dependson */
+            dependsOn: string[];
+            /** Jobid */
+            jobId: string | null;
+            /** Trackerticketref */
+            trackerTicketRef: string | null;
+            /** Promptoverride */
+            promptOverride: string | null;
+            /** Epicid */
+            epicId: string | null;
+            /**
+             * Createdat
+             * Format: date-time
+             */
+            createdAt: string;
+            /**
+             * Updatedat
+             * Format: date-time
+             */
+            updatedAt: string;
+        };
         /** TelemetryCostBucket */
         TelemetryCostBucket: {
             /**
@@ -7123,6 +7607,24 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** TrackerLinkListResponse */
+        TrackerLinkListResponse: {
+            /** Trackerlinks */
+            trackerLinks?: components["schemas"]["TrackerLinkResponse"][];
+        };
+        /** TrackerLinkResponse */
+        TrackerLinkResponse: {
+            /** Id */
+            id: string;
+            /** Projectid */
+            projectId: string;
+            /** Credentialid */
+            credentialId: string;
+            /** Externalref */
+            externalRef: string;
+            /** Createdat */
+            createdAt: string;
+        };
         /**
          * TrailBacktrack
          * @description A backtrack from the trail summary.
@@ -7518,6 +8020,13 @@ export interface components {
         UpdatePresetRequest: {
             /** Preset */
             preset: string;
+        };
+        /** UpdateProjectRequest */
+        UpdateProjectRequest: {
+            /** Name */
+            name?: string | null;
+            /** Repopaths */
+            repoPaths?: string[] | null;
         };
         /**
          * UpdateSettingsRequest
@@ -8411,6 +8920,41 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["RestoreResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    reenrich_job_api_jobs__job_id__reenrich_post: {
+        parameters: {
+            query?: {
+                force?: boolean;
+            };
+            header?: never;
+            path: {
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
                 };
             };
             /** @description Validation Error */
@@ -9594,26 +10138,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_projects_summary_api_settings_projects_summary_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProjectListSummaryResponse"];
                 };
             };
         };
@@ -10968,7 +11492,7 @@ export interface operations {
             };
         };
     };
-    preview_proxy_api_preview__port___path__delete: {
+    preview_proxy_api_preview__port___path__post: {
         parameters: {
             query?: never;
             header?: never;
@@ -10998,7 +11522,7 @@ export interface operations {
             };
         };
     };
-    preview_proxy_api_preview__port___path__delete: {
+    preview_proxy_api_preview__port___path__post: {
         parameters: {
             query?: never;
             header?: never;
@@ -11028,7 +11552,7 @@ export interface operations {
             };
         };
     };
-    preview_proxy_api_preview__port___path__delete: {
+    preview_proxy_api_preview__port___path__post: {
         parameters: {
             query?: never;
             header?: never;
@@ -11058,7 +11582,7 @@ export interface operations {
             };
         };
     };
-    preview_proxy_api_preview__port___path__delete: {
+    preview_proxy_api_preview__port___path__post: {
         parameters: {
             query?: never;
             header?: never;
@@ -11088,7 +11612,7 @@ export interface operations {
             };
         };
     };
-    preview_proxy_api_preview__port___path__delete: {
+    preview_proxy_api_preview__port___path__post: {
         parameters: {
             query?: never;
             header?: never;
@@ -11118,7 +11642,7 @@ export interface operations {
             };
         };
     };
-    preview_proxy_api_preview__port___path__delete: {
+    preview_proxy_api_preview__port___path__post: {
         parameters: {
             query?: never;
             header?: never;
@@ -11692,6 +12216,108 @@ export interface operations {
             };
         };
     };
+    list_credentials_api_settings_credentials_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CredentialListResponse"];
+                };
+            };
+        };
+    };
+    create_credential_api_settings_credentials_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateCredentialRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CredentialResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_provider_guidance_api_settings_credentials_guidance_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProviderGuidanceResponse"];
+                };
+            };
+        };
+    };
+    delete_credential_api_settings_credentials__credential_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                credential_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     chat_ask_api_metrics_chat_post: {
         parameters: {
             query?: never;
@@ -12097,6 +12723,427 @@ export interface operations {
                     "application/json": {
                         [key: string]: string;
                     };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_chats_api_chats_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChatListResponse"];
+                };
+            };
+        };
+    };
+    create_chat_api_chats_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateChatRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChatResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_chat_api_chats__chat_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                chat_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChatResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    add_chat_message_api_chats__chat_id__messages_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                chat_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AddChatMessageRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChatMessageResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    launch_job_from_chat_api_chats__chat_id__launch_job_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                chat_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LaunchJobFromChatRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CreateJobResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_projects_api_settings_projects_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectListResponse"];
+                };
+            };
+        };
+    };
+    create_project_api_settings_projects_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateProjectRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_projects_summary_api_settings_projects_summary_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectListSummaryResponse"];
+                };
+            };
+        };
+    };
+    get_project_api_settings_projects__project_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_project_api_settings_projects__project_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateProjectRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    ingest_project_tasks_api_settings_projects__project_id__ingest_tasks_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["IngestTaskGraphResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_project_task_links_api_settings_projects__project_id__task_links_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TaskLinkListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_tracker_links_api_projects__project_id__tracker_links_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TrackerLinkListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_tracker_link_api_projects__project_id__tracker_links_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateTrackerLinkRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TrackerLinkResponse"];
                 };
             };
             /** @description Validation Error */

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -20,6 +20,10 @@ export type RepoListResponse = components["schemas"]["RepoListResponse"];
 export type RepoDetailResponse = components["schemas"]["RepoDetailResponse"];
 export type ProjectSummaryResponse = components["schemas"]["ProjectSummaryResponse"];
 export type ProjectListSummaryResponse = components["schemas"]["ProjectListSummaryResponse"];
+export type ProjectResponse = components["schemas"]["ProjectResponse"];
+export type ProjectListResponse = components["schemas"]["ProjectListResponse"];
+export type TaskLinkResponse = components["schemas"]["TaskLinkResponse"];
+export type TaskLinkListResponse = components["schemas"]["TaskLinkListResponse"];
 export type CompletionStrategy = "auto_merge" | "pr_only" | "manual";
 
 // Sidecar template types

--- a/frontend/src/components/KanbanColumn.tsx
+++ b/frontend/src/components/KanbanColumn.tsx
@@ -9,6 +9,8 @@ interface KanbanColumnProps {
   jobs: JobSummary[];
   onLoadMore?: () => void;
   hasMore?: boolean;
+  /** Non-job cards (e.g. TaskLink recipe cards, Story 4.4) rendered after the job list. */
+  extraCards?: React.ReactNode;
 }
 
 export const KanbanColumn = memo(function KanbanColumn({
@@ -16,6 +18,7 @@ export const KanbanColumn = memo(function KanbanColumn({
   jobs,
   onLoadMore,
   hasMore,
+  extraCards,
 }: KanbanColumnProps) {
   return (
     <div className="flex flex-col overflow-hidden h-full rounded-lg border border-border bg-card" role="region" aria-label={title}>
@@ -27,7 +30,7 @@ export const KanbanColumn = memo(function KanbanColumn({
       </div>
 
       <div className="flex flex-col gap-2 flex-1 min-h-0 overflow-y-auto p-2">
-        {jobs.length === 0 ? (
+        {jobs.length === 0 && !extraCards ? (
           (() => {
             if (title === "In Progress") {
               return (
@@ -77,6 +80,7 @@ export const KanbanColumn = memo(function KanbanColumn({
         ) : (
           jobs.map((job) => <JobCard key={job.id} job={job} />)
         )}
+        {extraCards}
         {hasMore && onLoadMore && (
           <Button variant="ghost" size="sm" className="w-full" onClick={onLoadMore}>
             Load more

--- a/frontend/src/components/RepoBoard.tsx
+++ b/frontend/src/components/RepoBoard.tsx
@@ -10,11 +10,47 @@ import {
   selectAttentionJobsForRepo,
 } from "../store";
 import type { JobSummary } from "../store";
-import { fetchJobs } from "../api/client";
+import { fetchJobs, fetchProjects, fetchProjectTaskLinks } from "../api/client";
+import type { TaskLinkResponse } from "../api/types";
 import { KanbanColumn } from "./KanbanColumn";
 import { KanbanSkeleton } from "./KanbanSkeleton";
+import { TaskLinkCard } from "./TaskLinkCard";
 import { KANBAN_COLUMNS } from "../constants/kanban";
 import { pathBasename } from "../lib/paths";
+
+/**
+ * Determine whether a TaskLink's `dependsOn` list is fully satisfied (Story 4.4 / CAP-10).
+ *
+ * A composite `"{repoPath}::{storyNodeId}"` entry is satisfied when its target
+ * TaskLink is found within the full Project TaskLink set (so cross-repo
+ * dependencies resolve) and that target has a `jobId` whose Job has reached
+ * the `completed` state. An unresolvable target, or one whose Job hasn't
+ * completed, is unsatisfied. Empty `dependsOn` is trivially satisfied. This is
+ * read-only render logic — it never triggers a spawn (Story 4.5's concern).
+ */
+function computeSatisfaction(
+  taskLink: TaskLinkResponse,
+  allTaskLinks: TaskLinkResponse[],
+  jobs: Record<string, JobSummary>,
+): { satisfied: boolean; blockingLabel: string | null } {
+  if (taskLink.dependsOn.length === 0) return { satisfied: true, blockingLabel: null };
+
+  const byKey = new Map<string, TaskLinkResponse>();
+  for (const t of allTaskLinks) {
+    if (t.storyNodeId) byKey.set(`${t.repoPath}::${t.storyNodeId}`, t);
+  }
+
+  for (const dep of taskLink.dependsOn) {
+    const target = byKey.get(dep);
+    const targetJob = target?.jobId ? jobs[target.jobId] : undefined;
+    const depSatisfied = !!target && !!targetJob && targetJob.state === "completed";
+    if (!depSatisfied) {
+      const label = target?.storyNodeId ?? dep.split("::").pop() ?? dep;
+      return { satisfied: false, blockingLabel: label };
+    }
+  }
+  return { satisfied: true, blockingLabel: null };
+}
 
 /**
  * Project-scoped Kanban board (Story 2.3 / CAP-1). Child route of the existing
@@ -25,6 +61,11 @@ import { pathBasename } from "../lib/paths";
  * story file); once Story 2.2 wires multi-repo Project membership into the
  * frontend, only the repo-scoped selectors' filter needs to widen — this route and
  * component shape are unaffected.
+ *
+ * Story 4.4 / CAP-10: also fetches the owning Project's TaskLinks (a second,
+ * independent call — `GET /settings/projects/:id/task-links`, AD-11) and renders
+ * them as chained-recipe cards in the "In Progress" column, alongside job cards,
+ * in this same rendering pass.
  */
 export function RepoBoard() {
   const { repoPath } = useParams<{ repoPath: string }>();
@@ -32,7 +73,9 @@ export function RepoBoard() {
   const repoName = pathBasename(decoded) || decoded;
 
   const [loading, setLoading] = useState(true);
+  const [taskLinks, setTaskLinks] = useState<TaskLinkResponse[]>([]);
   const hasJobs = useStore((state) => Object.keys(state.jobs).length > 0);
+  const jobs = useStore((state) => state.jobs);
 
   const activeJobs = useStore(useShallow(selectActiveJobsForRepo(decoded)));
   const signoffJobs = useStore(useShallow(selectSignoffJobsForRepo(decoded)));
@@ -59,7 +102,25 @@ export function RepoBoard() {
     return () => { cancelled = true; };
   }, [decoded]);
 
+  useEffect(() => {
+    if (!decoded) return;
+    let cancelled = false;
+    fetchProjects()
+      .then(async ({ items }) => {
+        const owningProject = items.find((p) => p.repoPaths.includes(decoded));
+        if (!owningProject) return;
+        const { items: links } = await fetchProjectTaskLinks(owningProject.id);
+        if (!cancelled) setTaskLinks(links);
+      })
+      .catch((err) => {
+        if (!cancelled) console.error("Failed to fetch TaskLinks", err);
+      });
+    return () => { cancelled = true; };
+  }, [decoded]);
+
   if (loading && !hasJobs) return <KanbanSkeleton />;
+
+  const boardTaskLinks = taskLinks.filter((t) => t.repoPath === decoded);
 
   return (
     <div>
@@ -81,10 +142,31 @@ export function RepoBoard() {
       </div>
 
       <div className="grid grid-cols-3 gap-3 h-[calc(100dvh-200px)] max-lg:grid-cols-2 max-sm:grid-cols-1">
-        <KanbanColumn title={KANBAN_COLUMNS.IN_PROGRESS} jobs={activeJobs} />
+        <KanbanColumn
+          title={KANBAN_COLUMNS.IN_PROGRESS}
+          jobs={activeJobs}
+          extraCards={
+            boardTaskLinks.length > 0 ? (
+              <>
+                {boardTaskLinks.map((taskLink) => {
+                  const { satisfied, blockingLabel } = computeSatisfaction(taskLink, taskLinks, jobs);
+                  return (
+                    <TaskLinkCard
+                      key={taskLink.id}
+                      taskLink={taskLink}
+                      satisfied={satisfied}
+                      blockingLabel={blockingLabel}
+                    />
+                  );
+                })}
+              </>
+            ) : undefined
+          }
+        />
         <KanbanColumn title={KANBAN_COLUMNS.AWAITING_INPUT} jobs={signoffJobs} />
         <KanbanColumn title={KANBAN_COLUMNS.FAILED} jobs={attentionJobs} />
       </div>
     </div>
   );
 }
+

--- a/frontend/src/components/TaskLinkCard.tsx
+++ b/frontend/src/components/TaskLinkCard.tsx
@@ -1,0 +1,63 @@
+import { memo } from "react";
+import { Link2, Clock3, CheckCircle2 } from "lucide-react";
+import type { TaskLinkResponse } from "../api/types";
+import { pathBasename } from "../lib/paths";
+import { Tooltip } from "./ui/tooltip";
+
+interface TaskLinkCardProps {
+  taskLink: TaskLinkResponse;
+  /** True when every `dependsOn` entry is satisfied (empty list counts as satisfied). */
+  satisfied: boolean;
+  /** Human-readable label for the first unsatisfied dependency, when `satisfied` is false. */
+  blockingLabel?: string | null;
+}
+
+/**
+ * A TaskLink recipe-chain card (Story 4.4 / CAP-10). Rendered alongside regular
+ * `JobCard`s in the same column grid — never a separate screen. Greyed out with
+ * a "waiting on …" badge when its `dependsOn` list has unsatisfied entries;
+ * normal styling once every dependency is satisfied (ready to spawn, or already
+ * linked to a running `jobId`).
+ */
+export const TaskLinkCard = memo(function TaskLinkCard({ taskLink, satisfied, blockingLabel }: TaskLinkCardProps) {
+  const repoName = pathBasename(taskLink.repoPath) || taskLink.repoPath;
+  const label = taskLink.storyNodeId ?? taskLink.trackerTicketRef ?? taskLink.id;
+
+  return (
+    <div
+      className={`w-full shrink-0 text-left rounded-lg border border-border bg-background p-3 overflow-hidden transition-opacity ${
+        satisfied ? "" : "opacity-60"
+      }`}
+      aria-label={`Task recipe: ${label} — ${satisfied ? "dependencies satisfied" : "waiting on dependencies"}`}
+    >
+      <div className="flex justify-between items-start gap-2 mb-1.5">
+        <span className="text-sm font-semibold text-primary flex-1 min-w-0 break-words line-clamp-2 flex items-center gap-1.5" title={label}>
+          <Link2 size={13} className="text-muted-foreground shrink-0" aria-hidden="true" />
+          {label}
+        </span>
+        {satisfied ? (
+          <Tooltip content="Every dependency is satisfied — ready to spawn or already linked to a running job">
+            <span className="inline-flex items-center gap-1 rounded-full border border-emerald-500/30 bg-emerald-500/15 text-emerald-600 px-1.5 py-0.5 text-xs font-medium">
+              <CheckCircle2 size={10} />
+              deps satisfied
+            </span>
+          </Tooltip>
+        ) : (
+          <Tooltip content={blockingLabel ? `Waiting on "${blockingLabel}"` : "Waiting on an unsatisfied dependency"}>
+            <span className="inline-flex items-center gap-1 rounded-full border border-amber-500/30 bg-amber-500/15 text-amber-600 px-1.5 py-0.5 text-xs font-medium">
+              <Clock3 size={10} />
+              {blockingLabel ? `waiting on ${blockingLabel}` : "waiting"}
+            </span>
+          </Tooltip>
+        )}
+      </div>
+
+      <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+        <span className="inline-flex items-center rounded-full border border-border px-1.5 py-0.5 uppercase tracking-wide text-[10px] font-semibold">
+          chained
+        </span>
+        <span className="font-mono truncate" title={taskLink.repoPath}>{repoName}</span>
+      </div>
+    </div>
+  );
+});

--- a/frontend/src/components/__tests__/RepoBoard.test.tsx
+++ b/frontend/src/components/__tests__/RepoBoard.test.tsx
@@ -8,9 +8,11 @@ import type { JobSummary } from "../../store";
 // Mock the API client
 vi.mock("../../api/client", () => ({
   fetchJobs: vi.fn(),
+  fetchProjects: vi.fn(),
+  fetchProjectTaskLinks: vi.fn(),
 }));
 
-import { fetchJobs } from "../../api/client";
+import { fetchJobs, fetchProjects, fetchProjectTaskLinks } from "../../api/client";
 import { RepoBoard } from "../RepoBoard";
 
 vi.mock("../KanbanSkeleton", () => ({
@@ -34,6 +36,23 @@ function makeJob(overrides: Partial<JobSummary> = {}): JobSummary {
   };
 }
 
+function makeTaskLink(overrides: Partial<any> = {}) {
+  return {
+    id: "tl-1",
+    projectId: "proj-1",
+    repoPath: "/repos/test",
+    storyNodeId: "add-sca",
+    dependsOn: [],
+    jobId: null,
+    trackerTicketRef: null,
+    promptOverride: null,
+    epicId: null,
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
 function renderBoard(repoPath = "/repos/test") {
   return render(
     <MemoryRouter initialEntries={[`/repos/${encodeURIComponent(repoPath)}/board`]}>
@@ -46,6 +65,10 @@ function renderBoard(repoPath = "/repos/test") {
 
 beforeEach(() => {
   vi.mocked(fetchJobs).mockReset();
+  vi.mocked(fetchProjects).mockReset();
+  vi.mocked(fetchProjectTaskLinks).mockReset();
+  vi.mocked(fetchProjects).mockResolvedValue({ items: [] });
+  vi.mocked(fetchProjectTaskLinks).mockResolvedValue({ items: [] });
   useStore.setState({
     jobs: {},
     approvals: {},
@@ -108,5 +131,73 @@ describe("RepoBoard", () => {
     expect(screen.getByText("In Progress")).toBeInTheDocument();
     expect(screen.getByText("Awaiting Input")).toBeInTheDocument();
     expect(screen.getByRole("region", { name: "Failed" })).toBeInTheDocument();
+  });
+
+  it("renders TaskLink cards for the resolved Project in the In Progress column", async () => {
+    vi.mocked(fetchJobs).mockResolvedValueOnce({ items: [], cursor: null } as any);
+    vi.mocked(fetchProjects).mockResolvedValueOnce({
+      items: [{ id: "proj-1", name: "payments", repoPaths: ["/repos/test"], createdAt: "", updatedAt: "" }],
+    } as any);
+    vi.mocked(fetchProjectTaskLinks).mockResolvedValueOnce({
+      items: [makeTaskLink({ id: "tl-1", storyNodeId: "add-sca" })],
+    } as any);
+    renderBoard("/repos/test");
+    await waitFor(() => expect(screen.getByText("add-sca")).toBeInTheDocument());
+    expect(screen.getByText("deps satisfied")).toBeInTheDocument();
+  });
+
+  it("greys out a TaskLink card whose dependency's linked job has not completed", async () => {
+    vi.mocked(fetchJobs).mockResolvedValueOnce({ items: [], cursor: null } as any);
+    vi.mocked(fetchProjects).mockResolvedValueOnce({
+      items: [{ id: "proj-1", name: "payments", repoPaths: ["/repos/test"], createdAt: "", updatedAt: "" }],
+    } as any);
+    vi.mocked(fetchProjectTaskLinks).mockResolvedValueOnce({
+      items: [
+        makeTaskLink({ id: "tl-1", storyNodeId: "add-sca", jobId: "job-running" }),
+        makeTaskLink({ id: "tl-2", storyNodeId: "sca-tests", dependsOn: ["/repos/test::add-sca"] }),
+      ],
+    } as any);
+    useStore.setState({
+      jobs: { "job-running": makeJob({ id: "job-running", state: "running" }) },
+    });
+    renderBoard("/repos/test");
+    await waitFor(() => expect(screen.getByText("sca-tests")).toBeInTheDocument());
+    expect(screen.getByText("waiting on add-sca")).toBeInTheDocument();
+    expect(screen.getByLabelText(/waiting on dependencies/)).toHaveClass("opacity-60");
+  });
+
+  it("renders a TaskLink card as satisfied once its dependency's job has completed", async () => {
+    vi.mocked(fetchJobs).mockResolvedValueOnce({ items: [], cursor: null } as any);
+    vi.mocked(fetchProjects).mockResolvedValueOnce({
+      items: [{ id: "proj-1", name: "payments", repoPaths: ["/repos/test"], createdAt: "", updatedAt: "" }],
+    } as any);
+    vi.mocked(fetchProjectTaskLinks).mockResolvedValueOnce({
+      items: [
+        makeTaskLink({ id: "tl-1", storyNodeId: "add-sca", jobId: "job-done" }),
+        makeTaskLink({ id: "tl-2", storyNodeId: "sca-tests", dependsOn: ["/repos/test::add-sca"] }),
+      ],
+    } as any);
+    useStore.setState({
+      jobs: { "job-done": makeJob({ id: "job-done", state: "completed" }) },
+    });
+    renderBoard("/repos/test");
+    await waitFor(() => expect(screen.getByText("sca-tests")).toBeInTheDocument());
+    expect(screen.getAllByText("deps satisfied")).toHaveLength(2);
+  });
+
+  it("only renders TaskLink cards whose own repoPath matches the scoped board", async () => {
+    vi.mocked(fetchJobs).mockResolvedValueOnce({ items: [], cursor: null } as any);
+    vi.mocked(fetchProjects).mockResolvedValueOnce({
+      items: [{ id: "proj-1", name: "payments", repoPaths: ["/repos/test", "/repos/other"], createdAt: "", updatedAt: "" }],
+    } as any);
+    vi.mocked(fetchProjectTaskLinks).mockResolvedValueOnce({
+      items: [
+        makeTaskLink({ id: "tl-1", repoPath: "/repos/test", storyNodeId: "add-sca" }),
+        makeTaskLink({ id: "tl-2", repoPath: "/repos/other", storyNodeId: "other-task" }),
+      ],
+    } as any);
+    renderBoard("/repos/test");
+    await waitFor(() => expect(screen.getByText("add-sca")).toBeInTheDocument());
+    expect(screen.queryByText("other-task")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/__tests__/TaskLinkCard.test.tsx
+++ b/frontend/src/components/__tests__/TaskLinkCard.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { TaskLinkResponse } from "../../api/types";
+import { TaskLinkCard } from "../TaskLinkCard";
+
+function makeTaskLink(overrides: Partial<TaskLinkResponse> = {}): TaskLinkResponse {
+  return {
+    id: "tl-1",
+    projectId: "proj-1",
+    repoPath: "/repos/frontend",
+    storyNodeId: "4-4-see-tasklink-cards",
+    dependsOn: [],
+    jobId: null,
+    trackerTicketRef: null,
+    promptOverride: null,
+    epicId: "epic-4",
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("TaskLinkCard", () => {
+  it("renders the story node id and repo name", () => {
+    render(<TaskLinkCard taskLink={makeTaskLink()} satisfied />);
+    expect(screen.getByText("4-4-see-tasklink-cards")).toBeInTheDocument();
+    expect(screen.getByText("frontend")).toBeInTheDocument();
+    expect(screen.getByText("chained")).toBeInTheDocument();
+  });
+
+  it("falls back to the tracker ticket ref when there is no story node id", () => {
+    render(
+      <TaskLinkCard
+        taskLink={makeTaskLink({ storyNodeId: null, trackerTicketRef: "JIRA-123" })}
+        satisfied
+      />,
+    );
+    expect(screen.getByText("JIRA-123")).toBeInTheDocument();
+  });
+
+  it("renders a satisfied badge and normal styling when dependencies are satisfied", () => {
+    render(<TaskLinkCard taskLink={makeTaskLink()} satisfied />);
+    expect(screen.getByText("deps satisfied")).toBeInTheDocument();
+    expect(screen.getByLabelText(/dependencies satisfied/)).not.toHaveClass("opacity-60");
+  });
+
+  it("renders a greyed-out waiting badge naming the blocking dependency when unsatisfied", () => {
+    render(
+      <TaskLinkCard
+        taskLink={makeTaskLink({ dependsOn: ["/repos/frontend::add-sca"] })}
+        satisfied={false}
+        blockingLabel="add-sca"
+      />,
+    );
+    expect(screen.getByText("waiting on add-sca")).toBeInTheDocument();
+    expect(screen.getByLabelText(/waiting on dependencies/)).toHaveClass("opacity-60");
+  });
+
+  it("renders a generic waiting badge when no blocking label is provided", () => {
+    render(
+      <TaskLinkCard
+        taskLink={makeTaskLink({ dependsOn: ["/repos/frontend::add-sca"] })}
+        satisfied={false}
+        blockingLabel={null}
+      />,
+    );
+    expect(screen.getByText("waiting")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Implements Story 4.4 from Epic 4 (`_bmad-output/planning-artifacts/epics.md`): renders already-ingested TaskLinks (Story 4.2, merged) as cards on the existing per-Project `RepoBoard` (Story 2.3, merged), in the same column grid as job cards.

- `RepoBoard` resolves the Project owning its `repoPath` (via `GET /settings/projects`), fetches that Project's TaskLinks (`GET /settings/projects/{id}/task-links`), and renders them in the "In Progress" column via a new optional `KanbanColumn.extraCards` prop — matching the CAP-8–11 wireframe in `ui-flows.md` exactly.
- New `TaskLinkCard` component shows a satisfied vs. greyed-out "waiting" state based on `dependsOn` satisfaction: a `depends_on` entry is satisfied when its target TaskLink exists and that target's linked job is `completed`. Empty `dependsOn` is trivially satisfied.
- TaskLink cards are scoped to the board's own `repoPath` only, consistent with `RepoBoard`'s existing single-repo-Project job-filtering reduction.

## No backend changes

Confirmed by direct inspection of `backend/models/db.py`, `backend/models/api_schemas.py`, `backend/api/projects.py` that `TaskLinkRow`/`TaskLink`/`TaskLinkResponse` and both required endpoints already shipped in Story 4.2 (PR #60) and Story 2.1. This is a frontend-only consumer implementation. `frontend/src/api/schema.d.ts` was stale (missing the Project/TaskLink types) and has been regenerated from a live OpenAPI dump — no functional backend change.

Story 4.3 (manual assignment, PR #63) merged mid-implementation. Confirmed via diff that it only adds a new `CreateManualTaskLinkRequest` schema/POST endpoint — `TaskLinkResponse` is unchanged, so this story is not blocked by it and required no rework after rebasing.

**Alembic:** verified head is still `0063_add_chat_messages.py` on `origin/main` immediately before opening this PR — no migration needed or added, and this branch is rebased onto the latest `origin/main`.

## Explicitly out of scope (deferred to other stories)

- Story 4.3's manual-assignment UI/flow
- Story 4.5's auto-spawn-on-completion (`spawn_task`) behavior
- Story 4.6's tracker-write routing
- Any Epic 5/6 (Chat, MCP tools) work
- CAP-5's name-filter integration (Story 1.5)

## Testing

- New: `frontend/src/components/__tests__/TaskLinkCard.test.tsx` (5 tests)
- Extended: `frontend/src/components/__tests__/RepoBoard.test.tsx` (+4 tests: TaskLink cards render for resolved Project, greyed when dependency incomplete, satisfied once dependency completes, scoped to board's own repo only)
- All 22 relevant tests pass (`RepoBoard`, `TaskLinkCard`, `DashboardScreen` regression check for the `KanbanColumn.extraCards` prop addition)
- `eslint` and `tsc --noEmit` pass clean on all changed files

## Story tracking

- `_bmad-output/implementation-artifacts/4-4-see-tasklink-cards-on-the-board.md` — new story file, driven through `ready-for-dev → in-progress → review` via `bmad-dev-story`
- `sprint-status.yaml` updated to `review`

🤖 Generated with [Copilot CLI](https://githubnext.com/projects/copilot-cli)