### PR TITLE
feat: auto-spawn the next task on completion (Story 4.5, CAP-9/AD-9)

### DIFF
--- a/_bmad-output/implementation-artifacts/4-5-auto-spawn-the-next-task-on-completion.md
+++ b/_bmad-output/implementation-artifacts/4-5-auto-spawn-the-next-task-on-completion.md
@@ -1,0 +1,124 @@
+---
+baseline_commit: ddd1edb9
+---
+
+# Story 4.5: Auto-spawn the next task on completion
+
+Status: review
+
+## Story
+
+As a CodePlane user running a task chain,
+I want the next dependent task to start automatically when its prerequisite completes,
+so that I don't have to manually start every step of a planned sequence.
+
+## Acceptance Criteria
+
+1. **Given** a TaskLink's linked Job completes successfully, **when** a dependent TaskLink's remaining dependencies are now all satisfied, **then** its `spawn_task` output route fires, calling the same job-creation service function used by `codeplane_job create` (same worktree/branch provisioning), and the resulting `job_id` is written onto that TaskLink.
+2. **Given** a TaskLink with multiple unsatisfied dependencies, **when** only some of them complete, **then** `spawn_task` does not fire until every dependency is satisfied.
+3. **Given** a TaskLink that already has a `job_id`, **when** its dependencies become satisfied again for any reason, **then** it is never spawned a second time — one TaskLink points at zero-or-one real Job, never more.
+
+## Tasks / Subtasks
+
+- [x] Add `TaskLinkRepository.set_job_id` (AC: #1, #3)
+  - [ ] `async def set_job_id(self, task_link_id: str, job_id: str) -> TaskLink | None` in `backend/persistence/task_link_repo.py`: guarded conditional `UPDATE ... WHERE id = :id AND job_id IS NULL` (rows-affected check), so it's safe under concurrent completions. Returns the updated domain object, or `None` if the row doesn't exist or already had a `job_id` (AC #3). No new schema/migration — reuses the existing `job_id` column from Story 4.2.
+- [x] Add a project-wide TaskLink lookup by `job_id` (AC: #1)
+  - [ ] `async def get_by_job_id(self, job_id: str) -> TaskLink | None` in `TaskLinkRepository` — used to resolve "which TaskLink just completed" from the completed Job's id.
+- [x] Implement dependency-satisfaction + spawn orchestration in `RecipeService` (AC: #1, #2, #3)
+  - [ ] `async def handle_job_completed(self, job_id: str, *, resolution: str | None) -> list[TaskLink]` in `backend/services/recipe/recipe_service.py`:
+    - Look up the TaskLink whose `job_id == job_id` (via `get_by_job_id`); if none, return `[]` (the completed job wasn't linked to any TaskLink — a plain ad-hoc job, not part of a chain).
+    - If `resolution` is not `"merged"` or `"pr_created"` (e.g. `"discarded"`), return `[]` — a discarded job never satisfies a dependency even though it still reaches `job.completed`.
+    - Compute the just-completed TaskLink's composite key `f"{task_link.repo_path}::{task_link.story_node_id}"` (skip entirely — return `[]` — if `story_node_id` is null; a manually-assigned TaskLink is never itself a valid `depends_on` target since composite keys are always `repo_path::story_node_id`).
+    - Load every other TaskLink in the same `project_id` (`list_by_project`).
+    - For each: **skip immediately if its `job_id` is already set** (AC #3 — idempotency guard, checked before any dependency computation).
+    - Otherwise check full satisfaction: for every entry in its `depends_on`, resolve the target TaskLink by composite key against the full Project TaskLink set, and require the target to have a non-null `job_id` whose Job is `completed` with `resolution` in `("merged", "pr_created")` (query via `JobRepository.get`). An unresolvable target, or one whose Job isn't in that success state, makes the entry unsatisfied. Empty `depends_on` is trivially satisfied.
+    - If **all** entries satisfied → build `JobSpec(repo=dependent.repo_path, prompt=<derived prompt, see Dev Notes>, parent_job_id=job_id)`, call the injected `JobService.create_job(spec)`, then `task_link_repo.set_job_id(dependent.id, new_job.id)`.
+    - If job creation raises `RepoNotAllowedError`/`SDKModelMismatchError`, log and skip that dependent (never raise out of the handler — one bad dependent must not block others or crash the event-bus subscriber).
+    - Return the list of TaskLinks that were actually spawned (for logging/testability).
+- [x] Wire `RecipeService` with a `JobService` dependency for spawning (AC: #1)
+  - [ ] Add an optional `job_service: JobService | None` constructor parameter to `RecipeService` (defaults `None` so existing DI wiring / Story 4.2-4.4 call sites requiring only ingestion/listing keep working unchanged); `handle_job_completed` is a no-op (`return []`) when `job_service` is `None`.
+  - [ ] `backend/di.py`: leave the request-scoped `recipe_service` provider as-is (API routes never call `handle_job_completed`) — the job-completion path is wired independently in `backend/lifespan.py`, not through per-request DI.
+- [x] Register a job-completion subscriber in `backend/lifespan.py` (AC: #1, #2, #3)
+  - [ ] New `_spawn_dependent_task_links(event: SessionEvent) -> None` closure (same style as the existing `_persist_structural_analytics`/`_persist_review_story_on_resolve` subscribers already in `lifespan.py`): returns early unless `event.kind == EventKind.job_completed`; extracts `job_id = event.session_id` and `resolution = event.payload.get("resolution")`; opens a fresh session via `session_factory` inside `serialized_write(...)`, constructs `TaskLinkRepository`, `JobRepository`, `JobService.from_session(...)`, `ProjectRepository`/`ProjectService`, `RecipeService(task_link_repo, project_service, job_service=job_service)`, calls `await recipe_service.handle_job_completed(job_id, resolution=resolution)`; for every newly spawned Job, calls `await runtime.setup_and_start(job)` in a fire-and-forget background task (mirroring the MCP `codeplane_job create` handler's own `_setup_and_start` pattern) so the new job's worktree/agent actually starts. Wrap the whole handler body in `try/except Exception: log.warning(..., exc_info=True)` so a spawn failure never breaks the event bus fan-out for other subscribers.
+  - [ ] `event_bus.subscribe(_spawn_dependent_task_links)`, added in `create_app`'s lifespan function after `services = await _wire_core_services(...)` (so `services.runtime_service`/`config`/`session_factory`/`event_bus` are already in scope).
+- [x] Tests (AC: #1, #2, #3)
+  - [ ] `backend/tests/unit/test_task_link_repo.py`: `set_job_id` persists and returns updated TaskLink; `set_job_id` returns `None` and leaves `job_id` unchanged when called a second time on the same row (AC #3 guard); `get_by_job_id` finds the right row / returns `None` when absent.
+  - [ ] `backend/tests/unit/test_recipe_service.py`: extend with `handle_job_completed` cases —
+    - completed job with no linked TaskLink → returns `[]`, no job created.
+    - dependent with single dependency, now satisfied (`resolution="merged"`) → `JobService.create_job` called once with expected `JobSpec`, `set_job_id` called with the new job id.
+    - dependent with two dependencies, only one completed → not spawned (AC #2).
+    - dependent that already has a `job_id` → never spawned again even though dependencies are (re-)satisfied (AC #3).
+    - dependency's Job in `review`/`failed`/`canceled` state → dependent not spawned.
+    - completed job's own `resolution == "discarded"` → returns `[]`, nothing spawned.
+    - `job_service is None` → no-op, returns `[]`.
+  - [ ] New `backend/tests/integration/test_job_completion_spawns_tasklinks.py`: end-to-end through the event bus — publish a `job_completed` event (resolution `merged`) for a job linked to TaskLink A; assert dependent TaskLink B (whose sole dependency is A) gets a `job_id` written and a new job row exists.
+  - [ ] Run targeted `pytest` on changed files + `ruff check` + `mypy` on changed backend files.
+
+## Dev Notes
+
+- **Prerequisites already merged to `main`:** Story 4.2 (`TaskLinkRow`/`TaskLinkRepository`/ingestion, PR #60), Story 4.3 (manual TaskLink assignment, PR #63), Story 4.4 (TaskLink cards on the board, PR #66). Confirmed via `git log origin/main -1` → `ddd1edb9` at story-draft time.
+- **Scope discipline — do NOT implement:** Story 4.6 (tracker-write routing to a paired ticket), Story 5.3/5.4 (Chat attach-to-chain, approval-gated auto-spawn), or any Epic 6 (MCP-exposed chain controls) work. This story is scoped strictly to the three ACs above: detect completion → check full dependency satisfaction → spawn once → persist `job_id`.
+- **What "the linked Job completes successfully" means (AC #1), precisely:** `backend/services/runtime/service.py` (~line 1119-1124) only emits `EventKind.job_completed` when a job's final `Resolution` is `merged`, `pr_created`, **or** `discarded` (all three transition `JobState` to `completed`, as opposed to landing in `review` awaiting a human). `discarded` means the user explicitly threw the work away — that is not "success" in the chaining sense, so `handle_job_completed`'s dependency-satisfaction check must additionally read the payload's `resolution` field and only treat `merged`/`pr_created` as satisfying a dependency. Read `event.payload.get("resolution")` in the subscriber and pass it into `handle_job_completed` explicitly — do not rely on event *kind* alone.
+- **Dependency-satisfaction query shape:** `depends_on` is a JSON list of composite `"{repo_path}::{story_node_id}"` strings (existing convention from Story 4.2, AD-9). There is no indexed/SQL-side lookup for "which TaskLinks depend on X" — `TaskLinkRow.depends_on` is an opaque JSON `Text` column (same as the frontend's Story 4.4 approach, which also loads the full per-Project TaskLink set and computes satisfaction in-memory rather than via SQL `LIKE`). Follow that same precedent server-side: `list_by_project` + Python-side JSON-list membership checks, not a `LIKE` query (a `LIKE '%X%'` on a JSON-serialized list is a substring-matching correctness trap once two composite keys share a prefix — e.g. `"repo::t1"` vs `"repo::t10"` — so avoid it entirely).
+- **What counts as a dependency target's Job being "satisfied":** the target TaskLink must have a non-null `job_id`, and that Job's persisted state/resolution must indicate success (`JobState.completed` with `resolution` in `("merged", "pr_created")` — same success set as this story's own trigger condition above, for consistency). Query the target's Job row via `JobRepository.get` rather than re-deriving state from more events — the Job row is the single source of truth for current state.
+- **Prompt for the spawned job:** `JobSpec.prompt` is required and non-empty. TaskLinks created via manual assignment (Story 4.3) always have `prompt_override` set — use it verbatim. TaskLinks created via ingestion (Story 4.2) have `story_node_id` but **no persisted task description/prompt** (the parser only captures id/depends_on/epic_id, never body text — see `backend/services/recipe/parsers.py`). For an ingested dependent with no `prompt_override`, synthesize a prompt that directs the agent to the source file itself, e.g.: `f"Implement task '{dependent.story_node_id}' in this repo. Locate and follow its full task/story definition (BMAD story file under _bmad-output/implementation-artifacts/, or the matching spec-kit tasks.md entry) for complete requirements — this prompt only identifies which task to implement."` This keeps the source-of-truth read-only and in the repo (consistent with Story 4.2's "source files are read-only" constraint) rather than trying to duplicate/parse full story bodies into the TaskLink row (a larger, out-of-scope change). Document this fallback clearly in code comments since it's a load-bearing design choice not spelled out in the AC text.
+- **`spawn_task` output route fields:** Story 4.1 only added `spawn_task` to `_ALLOWED_OUTPUT_ROUTES` in the sidecar schema (`backend/services/sidecar/template_service.py`) as a recipe-authoring vocabulary word — it does not yet wire any sidecar dispatch to this story's spawn logic, and this story does not need it to. This story's trigger is the **domain event bus** (`EventKind.job_completed`), directly, per the epics.md AC's own parenthetical ("likely hooking into job-completion events on the event bus") — not a sidecar/recipe dispatch pathway. No sidecar dispatcher change is needed or in scope; `spawn_task` "firing" in AC #1's language is satisfied by this event-driven code path performing the same effect (calling job creation, writing `job_id`), not by adding a new sidecar output-route handler.
+- **Job-creation service function reuse (AC #1's explicit requirement):** must be the *same* function `codeplane_job create` uses — `JobService.create_job(JobSpec(...))`, immediately followed by `RuntimeService.setup_and_start(job)` in the background, exactly mirroring `backend/mcp/server.py`'s `codeplane_job` tool handler (`_register_job_tool`, `action == "create"` branch, and its `_make_job_service` helper). Do not reimplement worktree/branch provisioning — call the existing service, don't duplicate it.
+- **Idempotency (AC #3) is a hard guard:** check `dependent.job_id is not None` and skip *before* doing any dependency-satisfaction computation. Implement `set_job_id` as a guarded conditional `UPDATE ... WHERE id = :id AND job_id IS NULL` (rows-affected check) rather than a read-then-write from an ORM object, so it's correct even if the subscriber runs concurrently for two sibling dependencies completing near-simultaneously.
+- **Where the subscriber is wired:** follow the exact style of the existing job-lifecycle subscribers already in `backend/lifespan.py` (`_persist_structural_analytics`, `_persist_review_story_on_resolve`, `_prefetch_review_story` — all closures defined inline in `create_app`'s lifespan function, each opening its own session via `session_factory`, each subscribed via `event_bus.subscribe(...)`, each using `_fire_and_forget` for any background work). Add the new subscriber in the same section, after `services = await _wire_core_services(...)` (so `services.runtime_service` and `config` are already in scope) and after `event_bus`/`session_factory` are available.
+- **Follow existing conventions:** thin route/handler pattern — no orchestration logic lives directly in `lifespan.py` beyond wiring; all decision logic (satisfaction check, spawn) lives in `RecipeService.handle_job_completed`, matching the "route handlers are thin, service layer decides" convention. Repository methods stay narrow persistence operations (`set_job_id`, `get_by_job_id`), no query logic beyond simple `WHERE`/`UPDATE`.
+- **Alembic:** none expected — `job_id` already exists on `TaskLinkRow` from Story 4.2 (nullable FK to `jobs.id`); this story only ever writes into that existing column, no new column/table. **Verify the true current alembic head via `git log origin/main -- alembic/versions/` immediately before opening the PR** (known head at story-draft time: `0063_add_chat_messages.py`, but Story 5.3 may have landed a new migration in the interim per standing instruction) and rebase onto latest `origin/main` before opening the PR.
+- **No frontend changes required or in scope.** Story 4.4 already renders `job_id`-linked TaskLink cards in their satisfied/normal state once a `job_id` is present (via the existing `fetchProjectTaskLinks` poll/refetch) — this story only needs to *write* `job_id` server-side; the board already reflects it on next fetch. Do not touch `frontend/`.
+
+### Project Structure Notes
+
+- `backend/persistence/task_link_repo.py` — extended (new `set_job_id`, `get_by_job_id` methods).
+- `backend/services/recipe/recipe_service.py` — extended (new `handle_job_completed` method, optional `job_service` constructor param).
+- `backend/lifespan.py` — extended (new job-completion subscriber, subscribed to the shared `EventBus`).
+- `backend/di.py` — unchanged (the per-request `recipe_service` DI provider doesn't need `job_service`; the completion-subscriber path constructs its own `RecipeService` instance directly in `lifespan.py`, same as other lifespan-level subscribers that don't go through Dishka).
+
+### References
+
+- `_bmad-output/planning-artifacts/epics.md` — Epic 4, Story 4.5 (source of the ACs above).
+- `_bmad-output/implementation-artifacts/4-2-ingest-a-task-graph-into-a-project.md` — `TaskLinkRow`/`TaskLinkRepository`/`RecipeService` foundation.
+- `_bmad-output/implementation-artifacts/4-3-manually-assign-a-task-to-an-existing-ticket.md` — `prompt_override`/`tracker_ticket_ref` semantics.
+- `_bmad-output/implementation-artifacts/4-4-see-tasklink-cards-on-the-board.md` — frontend dependency-satisfaction precedent (`computeSatisfaction`), confirms this story does not touch the frontend.
+- `_bmad-output/implementation-artifacts/4-1-widen-the-task-recipe-vocabulary.md` — `spawn_task`/`chained` schema vocabulary (naming only; no dispatch wiring exists yet).
+- `backend/services/runtime/service.py` (~line 1119-1124) — where `EventKind.job_completed` is published and the `resolution`-to-`JobState.completed` mapping.
+- `backend/mcp/server.py` (`_register_job_tool`, `_make_job_service`) — the exact `create_job` + `setup_and_start` pattern to mirror.
+- `backend/lifespan.py` (`_persist_structural_analytics`, `_persist_review_story_on_resolve`) — existing job-lifecycle-subscriber style to follow.
+
+## Dev Agent Record
+
+### Debug Log
+
+- `ruff check` on all 6 changed/new files: passed (no errors).
+- `mypy --ignore-missing-imports` on the 3 changed backend source files: 0 new errors (the only reported error, `lifespan.py:922`, is pre-existing/unrelated — a missing type annotation on `_on_title_update`'s parameter from an earlier subscriber this story did not touch).
+- `mypy` on the 3 test files: 0 errors.
+- Targeted `pytest` run — `test_task_link_repo.py` + `test_recipe_service.py` + `test_job_completion_spawns_tasklinks.py`: **31 passed**, 0 failed.
+- One implementation bug caught by mypy and fixed: `Result.rowcount` isn't on the generic `Result[Any]` stub — added the same `# type: ignore[attr-defined]` pattern already used elsewhere in the repo (`approval_repo.py`, `job_repo.py`) for this exact SQLAlchemy stub gap.
+- One test-authoring bug caught while writing the integration test: seeded `JobRow`s must have `resolution="merged"` set explicitly (it isn't implied by `state=JobState.completed`) for `RecipeService._is_satisfied` to treat a dependency as satisfied — the unit tests mock `job_repo.get`, but the integration test needed a real row with `resolution` populated.
+
+### Completion Notes
+
+- Implemented all 3 ACs via a new event-bus subscriber (`_spawn_dependent_task_links` in `backend/lifespan.py`) that reacts to `EventKind.job_completed`, checks `resolution` (only `merged`/`pr_created` count — `discarded` is explicitly excluded even though it also reaches `job.completed`), and delegates all satisfaction/spawn/idempotency logic to `RecipeService.handle_job_completed` (new method).
+- `handle_job_completed` reuses `JobService.create_job` (same function `codeplane_job create` uses) and `RuntimeService.setup_and_start`, mirroring the MCP tool's own pattern — no worktree/branch logic duplicated.
+- Idempotency (AC #3) is enforced at the DB layer via `TaskLinkRepository.set_job_id`'s guarded `UPDATE ... WHERE job_id IS NULL`, safe under concurrent sibling-dependency completions.
+- Dependency satisfaction (AC #1/#2) is computed in-Python over the full Project TaskLink set (mirrors Story 4.4's frontend `computeSatisfaction`), never via SQL `LIKE`, to avoid composite-key substring-match bugs.
+- Full test coverage added at unit (repo + service) and integration (real event bus, real sqlite session, mocked `GitService`/`RuntimeService`) levels — all 3 ACs and the "never spawns twice" / "discarded doesn't satisfy" / "no-op without job_service" edge cases are covered.
+- Confirmed alembic head against `origin/main` immediately before opening the PR (see below) — no new migration needed; `job_id` column already existed from Story 4.2.
+- **Excluded per scope instructions:** Story 4.6 (tracker-write routing), Story 5.3/5.4 (chat attach-to-chain / approval-gated spawn), any Epic 6 (MCP-exposed chain controls) work, and any sidecar/recipe dispatch wiring for `spawn_task` as a template output route (the trigger is the domain event bus directly, per the epics.md AC's own hint — no sidecar dispatcher was added or needed).
+
+## File List
+
+- `backend/persistence/task_link_repo.py` (modified) — added `get_by_job_id`, `set_job_id`.
+- `backend/services/recipe/recipe_service.py` (modified) — added `handle_job_completed`, `_composite_key`, `_derive_prompt`, `_is_satisfied`, `_SUCCESSFUL_RESOLUTIONS`, optional `job_service`/`job_repo` constructor params.
+- `backend/lifespan.py` (modified) — added `_spawn_dependent_task_links` event-bus subscriber.
+- `backend/tests/unit/test_task_link_repo.py` (modified) — added `TestSetJobIdAndGetByJobId` (5 tests).
+- `backend/tests/unit/test_recipe_service.py` (modified) — added `TestHandleJobCompleted` (9 tests) + `_make_task_link`/`_make_job` helpers.
+- `backend/tests/integration/test_job_completion_spawns_tasklinks.py` (new) — end-to-end event-bus integration test (1 test).
+
+## Change Log
+
+- 2026-08-10: Story drafted from epics.md Epic 4 / Story 4.5 (bmad-create-story), following Story 4.4's completed precedent. Status → ready-for-dev.
+- 2026-08-11: Implemented all 3 ACs (repository methods, `RecipeService.handle_job_completed`, `lifespan.py` event-bus subscriber), full unit + integration test coverage added, `ruff`/`mypy`/targeted `pytest` all clean. Status → review.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -41,7 +41,7 @@
 # - Retrospective appends its action items to action_items; sprint-status surfaces open ones
 
 generated: 2026-08-10
-last_updated: 2026-08-10T21:10:00-04:00
+last_updated: 2026-08-11T00:00:00-04:00
 project: codeplane
 project_key: NOKEY
 tracking_system: file-system
@@ -79,7 +79,7 @@ development_status:
   4-2-ingest-a-task-graph-into-a-project: review
   4-3-manually-assign-a-task-to-an-existing-ticket: review
   4-4-see-tasklink-cards-on-the-board: review
-  4-5-auto-spawn-the-next-task-on-completion: backlog
+  4-5-auto-spawn-the-next-task-on-completion: review
   4-6-route-recipe-tracker-writes-to-the-paired-ticket: backlog
   epic-4-retrospective: optional
 

--- a/backend/lifespan.py
+++ b/backend/lifespan.py
@@ -1296,6 +1296,61 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     event_bus.subscribe(_persist_structural_analytics)
 
+    # --- Story 4.5: auto-spawn a dependent TaskLink's job on completion ---
+    # Fires only on EventKind.job_completed (a job reaching JobState.completed —
+    # merged/pr_created/discarded all land here, see backend/services/runtime/service.py).
+    # `resolution` is read from the payload so a "discarded" completion never
+    # satisfies a dependency (see RecipeService._SUCCESSFUL_RESOLUTIONS). All
+    # decision logic (satisfaction check, spawn, idempotency) lives in
+    # RecipeService.handle_job_completed — this closure only wires the event,
+    # opens a session, and starts any newly-spawned job's agent, mirroring the
+    # `codeplane_job create` MCP handler's own setup/start pattern.
+    async def _spawn_dependent_task_links(event: SessionEvent) -> None:
+        if event.kind != EventKind.job_completed:
+            return
+        job_id = event.session_id
+        if not job_id:
+            return
+        resolution = event.payload.get("resolution")
+
+        async def _run_spawn() -> None:
+            try:
+                from backend.persistence.job_repo import JobRepository
+                from backend.persistence.project_repo import ProjectRepository
+                from backend.persistence.task_link_repo import TaskLinkRepository
+                from backend.services.job.job_service import JobService
+                from backend.services.project.project_service import ProjectService
+                from backend.services.recipe.recipe_service import RecipeService
+
+                async with serialized_write(session_factory) as session:
+                    task_link_repo = TaskLinkRepository(session)
+                    job_repo = JobRepository(session)
+                    project_service = ProjectService(ProjectRepository(session), config)
+                    job_service = JobService.from_session(session, config)
+                    recipe_service = RecipeService(
+                        task_link_repo,
+                        project_service,
+                        job_service=job_service,
+                        job_repo=job_repo,
+                    )
+                    spawned_jobs = await recipe_service.handle_job_completed(job_id, resolution=resolution)
+
+                for spawned_job in spawned_jobs:
+
+                    async def _setup_and_start(job: Any = spawned_job) -> None:
+                        try:
+                            await services.runtime_service.setup_and_start(job)
+                        except Exception:
+                            log.warning("task_link_spawn_setup_failed", job_id=job.id, exc_info=True)
+
+                    _fire_and_forget(_setup_and_start(), name=f"task-link-spawn-{spawned_job.id[:8]}")
+            except Exception:
+                log.warning("task_link_spawn_handler_failed", job_id=job_id, exc_info=True)
+
+        _fire_and_forget(_run_spawn(), name=f"task-link-spawn-check-{job_id[:8]}")
+
+    event_bus.subscribe(_spawn_dependent_task_links)
+
     # --- IngestService (operator message routing) ---
     from backend.services.events.ingest_service import IngestService
 

--- a/backend/persistence/task_link_repo.py
+++ b/backend/persistence/task_link_repo.py
@@ -6,7 +6,7 @@ import json
 import uuid
 from datetime import UTC, datetime
 
-from sqlalchemy import select
+from sqlalchemy import select, update
 
 from backend.models.db import TaskLinkRow
 from backend.models.domain import TaskLink
@@ -133,3 +133,34 @@ class TaskLinkRepository(BaseRepository):
         result = await self._session.execute(stmt)
         row = result.scalar_one_or_none()
         return self._to_domain(row) if row else None
+
+    async def get_by_job_id(self, job_id: str) -> TaskLink | None:
+        """Find the TaskLink whose ``job_id`` matches, or ``None`` if none does."""
+        stmt = select(TaskLinkRow).where(TaskLinkRow.job_id == job_id)
+        result = await self._session.execute(stmt)
+        row = result.scalar_one_or_none()
+        return self._to_domain(row) if row is not None else None
+
+    async def set_job_id(self, task_link_id: str, job_id: str) -> TaskLink | None:
+        """Set ``job_id`` on a TaskLink, guarded against double-spawn (Story 4.5, AC #3).
+
+        Implemented as a conditional ``UPDATE ... WHERE job_id IS NULL`` (not a
+        read-then-write) so it is safe even if two sibling dependencies complete
+        near-simultaneously and both trigger a spawn attempt for the same
+        dependent TaskLink — only the first write wins, the second observes
+        zero rows affected and returns ``None``.
+        """
+        stmt = (
+            update(TaskLinkRow)
+            .where(TaskLinkRow.id == task_link_id, TaskLinkRow.job_id.is_(None))
+            .values(job_id=job_id, updated_at=datetime.now(UTC))
+        )
+        result = await self._session.execute(stmt)
+        await self._session.flush()
+        if result.rowcount == 0:  # type: ignore[attr-defined]  # CursorResult.rowcount not in generic stub
+            return None
+
+        fetch_stmt = select(TaskLinkRow).where(TaskLinkRow.id == task_link_id)
+        fetched = await self._session.execute(fetch_stmt)
+        row = fetched.scalar_one_or_none()
+        return self._to_domain(row) if row is not None else None

--- a/backend/services/recipe/recipe_service.py
+++ b/backend/services/recipe/recipe_service.py
@@ -15,21 +15,47 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from backend.models.domain import RepoNotAllowedError
+import structlog
+
+from backend.models.domain import JobSpec, RepoNotAllowedError, SDKModelMismatchError
 from backend.services.recipe.parsers import ParsedTask, parse_bmad_stories, parse_spec_kit_tasks
 
 if TYPE_CHECKING:
-    from backend.models.domain import TaskLink
+    from backend.models.domain import Job, TaskLink
+    from backend.persistence.job_repo import JobRepository
     from backend.persistence.task_link_repo import TaskLinkRepository
+    from backend.services.job.job_service import JobService
     from backend.services.project.project_service import ProjectService
+
+log = structlog.get_logger()
+
+# Resolutions that count as a job "completing successfully" for the purpose of
+# satisfying a dependent TaskLink's dependency (Story 4.5, AC #1). A job that
+# reaches ``JobState.completed`` with resolution "discarded" still fires
+# ``EventKind.job_completed`` (see backend/services/runtime/service.py), but
+# discarding means the user threw the work away — that must never satisfy a
+# dependency or spawn the next task in the chain.
+_SUCCESSFUL_RESOLUTIONS = frozenset({"merged", "pr_created"})
 
 
 class RecipeService:
     """Orchestrates Project-scoped TaskLink creation and ingestion."""
 
-    def __init__(self, task_link_repo: TaskLinkRepository, project_service: ProjectService) -> None:
+    def __init__(
+        self,
+        task_link_repo: TaskLinkRepository,
+        project_service: ProjectService,
+        *,
+        job_service: JobService | None = None,
+        job_repo: JobRepository | None = None,
+    ) -> None:
         self._task_link_repo = task_link_repo
         self._project_service = project_service
+        # Both optional: request-scoped DI call sites (ingestion/listing, Story
+        # 4.2-4.4) never spawn jobs and don't need them. Only the job-completion
+        # subscriber wired in backend/lifespan.py supplies them (Story 4.5).
+        self._job_service = job_service
+        self._job_repo = job_repo
 
     @staticmethod
     def _resolve_dependency(raw: str, *, current_repo_path: str, repo_path_by_folder: dict[str, str]) -> str:
@@ -115,3 +141,114 @@ class RecipeService:
         # Ensure the Project exists (raises ProjectNotFoundError otherwise).
         await self._project_service.get(project_id)
         return await self._task_link_repo.list_by_project(project_id)
+
+    @staticmethod
+    def _composite_key(task_link: TaskLink) -> str | None:
+        """The ``"{repo_path}::{story_node_id}"`` key other TaskLinks' ``depends_on``
+        entries reference. ``None`` for a manually-assigned TaskLink (no
+        ``story_node_id``) — those are never valid dependency targets.
+        """
+        if task_link.story_node_id is None:
+            return None
+        return f"{task_link.repo_path}::{task_link.story_node_id}"
+
+    @staticmethod
+    def _derive_prompt(task_link: TaskLink) -> str:
+        """Prompt for a task link's spawned job.
+
+        Manually-assigned TaskLinks (Story 4.3) always carry a `prompt_override`
+        — used verbatim. Ingested TaskLinks (Story 4.2) have no persisted task
+        body (the parser only captures id/depends_on/epic_id — see
+        ``backend/services/recipe/parsers.py``), so a prompt is synthesized
+        that points the agent at the source story/task file by id, keeping the
+        source-of-truth read-only and in the repo rather than duplicating it.
+        """
+        if task_link.prompt_override:
+            return task_link.prompt_override
+        return (
+            f"Implement task '{task_link.story_node_id}' in this repo. Locate and follow "
+            "its full task/story definition (BMAD story file under "
+            "_bmad-output/implementation-artifacts/, or the matching spec-kit tasks.md "
+            "entry) for complete requirements — this prompt only identifies which task "
+            "to implement."
+        )
+
+    async def _is_satisfied(self, dep_key: str, links_by_key: dict[str, TaskLink]) -> bool:
+        """Whether the TaskLink identified by composite key ``dep_key`` has a
+        successfully-completed linked Job (Story 4.5, AC #1/#2)."""
+        target = links_by_key.get(dep_key)
+        if target is None or target.job_id is None or self._job_repo is None:
+            return False
+        job = await self._job_repo.get(target.job_id)
+        if job is None:
+            return False
+        return str(job.state) == "completed" and str(job.resolution or "") in _SUCCESSFUL_RESOLUTIONS
+
+    async def handle_job_completed(self, job_id: str, *, resolution: str | None) -> list[Job]:
+        """React to a Job reaching ``JobState.completed`` (Story 4.5, AC #1-#3).
+
+        Finds the TaskLink whose linked Job just completed, and for every other
+        TaskLink in the same Project that depends on it and has no `job_id` of
+        its own yet, checks whether *all* of its dependencies are now satisfied.
+        If so, spawns the dependent's job via the same `JobService.create_job`
+        path used by `codeplane_job create`, and persists the new `job_id`.
+
+        Returns the newly-created Jobs (so callers, e.g. the `lifespan.py`
+        event-bus subscriber, can start each one via `RuntimeService.setup_and_start`).
+
+        Never raises: a bad dependent (disallowed repo, mismatched SDK/model)
+        is logged and skipped so it never blocks other dependents or crashes
+        the caller (an event-bus subscriber).
+        """
+        if self._job_service is None or self._job_repo is None:
+            return []
+
+        if resolution not in _SUCCESSFUL_RESOLUTIONS:
+            return []
+
+        completed_link = await self._task_link_repo.get_by_job_id(job_id)
+        if completed_link is None:
+            return []
+
+        completed_key = self._composite_key(completed_link)
+        if completed_key is None:
+            return []
+
+        project_links = await self._task_link_repo.list_by_project(completed_link.project_id)
+        links_by_key = {
+            key: link for link in project_links if (key := self._composite_key(link)) is not None
+        }
+
+        spawned: list[Job] = []
+        for candidate in project_links:
+            if candidate.job_id is not None:
+                # Already spawned — never spawn a second time (AC #3).
+                continue
+            if completed_key not in candidate.depends_on:
+                continue
+
+            satisfied = all(
+                [await self._is_satisfied(dep_key, links_by_key) for dep_key in candidate.depends_on]
+            )
+            if not satisfied:
+                continue
+
+            prompt = self._derive_prompt(candidate)
+            try:
+                new_job = await self._job_service.create_job(
+                    JobSpec(repo=candidate.repo_path, prompt=prompt, parent_job_id=job_id)
+                )
+            except (RepoNotAllowedError, SDKModelMismatchError) as exc:
+                log.warning(
+                    "task_link_spawn_failed",
+                    task_link_id=candidate.id,
+                    repo_path=candidate.repo_path,
+                    error=str(exc),
+                )
+                continue
+
+            updated = await self._task_link_repo.set_job_id(candidate.id, new_job.id)
+            if updated is not None:
+                spawned.append(new_job)
+
+        return spawned

--- a/backend/tests/integration/test_job_completion_spawns_tasklinks.py
+++ b/backend/tests/integration/test_job_completion_spawns_tasklinks.py
@@ -1,0 +1,140 @@
+"""Integration test for Story 4.5: auto-spawn on job completion, end-to-end
+through the real ``EventBus``.
+
+Wires the same subscriber shape as ``backend/lifespan.py``'s
+``_spawn_dependent_task_links`` (event bus -> RecipeService.handle_job_completed
+-> RuntimeService.setup_and_start) against real repositories and a real
+in-memory sqlite session, asserting the dependent TaskLink's ``job_id`` is
+persisted and a new ``jobs`` row exists after the dependency's job completes.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from backend.config import CPLConfig
+from backend.models.db import JobRow
+from backend.models.domain import JobState
+from backend.models.events import EventKind, new_event
+from backend.persistence.job_repo import JobRepository
+from backend.persistence.project_repo import ProjectRepository
+from backend.persistence.task_link_repo import TaskLinkRepository
+from backend.services.job.job_service import JobService
+from backend.services.project.project_service import ProjectService
+from backend.services.recipe.recipe_service import RecipeService
+
+if TYPE_CHECKING:
+    from unittest.mock import AsyncMock
+
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    from backend.services.events.event_bus import EventBus
+
+
+async def _seed_completed_job(session: AsyncSession, job_id: str, repo: str) -> None:
+    now = datetime.now(UTC)
+    session.add(
+        JobRow(
+            id=job_id,
+            repo=repo,
+            prompt="do the first task",
+            state=JobState.completed,
+            base_ref="main",
+            permission_mode="full_auto",
+            preset="autonomous",
+            sdk="copilot",
+            resolution="merged",
+            created_at=now,
+            updated_at=now,
+        )
+    )
+    await session.commit()
+
+
+class TestJobCompletionSpawnsTaskLinks:
+    @pytest.mark.asyncio
+    async def test_dependent_task_link_is_spawned_when_dependency_job_completes(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        event_bus: EventBus,
+        mock_git_service: AsyncMock,
+        mock_runtime_service: AsyncMock,
+        tmp_path: object,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        repo_path = str(Path(str(tmp_path)).resolve())
+        config = CPLConfig(repos=[repo_path])
+        monkeypatch.setattr("backend.services.job.job_service.load_config", lambda: config)
+
+        async with session_factory() as session:
+            project = await ProjectRepository(session).create("proj-1", "Test Project", [repo_path])
+            task_link_repo = TaskLinkRepository(session)
+            created = await task_link_repo.upsert_many(
+                project.id,
+                [
+                    {
+                        "repo_path": repo_path,
+                        "story_node_id": "1-1-first",
+                        "depends_on": [],
+                        "epic_id": "epic-1",
+                    },
+                    {
+                        "repo_path": repo_path,
+                        "story_node_id": "1-2-second",
+                        "depends_on": [f"{repo_path}::1-1-first"],
+                        "epic_id": "epic-1",
+                    },
+                ],
+            )
+            await session.commit()
+            first_link = next(link for link in created if link.story_node_id == "1-1-first")
+            second_link = next(link for link in created if link.story_node_id == "1-2-second")
+
+            await _seed_completed_job(session, "job-first", repo_path)
+            await task_link_repo.set_job_id(first_link.id, "job-first")
+            await session.commit()
+
+        async def _spawn_dependent_task_links(event: object) -> None:
+            if event.kind != EventKind.job_completed:  # type: ignore[union-attr]
+                return
+            job_id = event.session_id  # type: ignore[union-attr]
+            resolution = event.payload.get("resolution")  # type: ignore[union-attr]
+            async with session_factory() as session:
+                task_link_repo = TaskLinkRepository(session)
+                job_repo = JobRepository(session)
+                project_service = ProjectService(ProjectRepository(session), config)
+                job_service = JobService.from_session(session, config, git_service=mock_git_service)
+                recipe_service = RecipeService(
+                    task_link_repo, project_service, job_service=job_service, job_repo=job_repo
+                )
+                spawned_jobs = await recipe_service.handle_job_completed(job_id, resolution=resolution)
+                await session.commit()
+            for job in spawned_jobs:
+                await mock_runtime_service.setup_and_start(job)
+
+        event_bus.subscribe(_spawn_dependent_task_links)
+
+        await event_bus.publish(
+            new_event(
+                session_id="job-first",
+                kind=EventKind.job_completed,
+                payload={"resolution": "merged"},
+            )
+        )
+
+        async with session_factory() as session:
+            refreshed = await TaskLinkRepository(session).list_by_project(project.id)
+            refreshed_second = next(link for link in refreshed if link.id == second_link.id)
+
+        assert refreshed_second.job_id is not None
+        mock_runtime_service.setup_and_start.assert_awaited_once()
+
+        async with session_factory() as session:
+            spawned_job = await JobRepository(session).get(refreshed_second.job_id)
+        assert spawned_job is not None
+        assert spawned_job.repo == repo_path
+        assert spawned_job.parent_job_id == "job-first"

--- a/backend/tests/unit/test_recipe_service.py
+++ b/backend/tests/unit/test_recipe_service.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from backend.models.domain import Project, RepoNotAllowedError, TaskLink
+from backend.models.domain import Job, JobState, Project, RepoNotAllowedError, TaskLink
 from backend.services.recipe.recipe_service import RecipeService
 
 if TYPE_CHECKING:
@@ -249,3 +249,277 @@ class TestCreateManualTaskLink:
             )
 
         mock_task_link_repo.create_manual.assert_not_awaited()
+
+
+def _make_task_link(
+    *,
+    id: str,  # noqa: A002
+    project_id: str = "proj-1",
+    repo_path: str = "/repo/a",
+    story_node_id: str | None = None,
+    depends_on: list[str] | None = None,
+    job_id: str | None = None,
+    tracker_ticket_ref: str | None = None,
+    prompt_override: str | None = None,
+) -> TaskLink:
+    now = datetime.now(UTC)
+    return TaskLink(
+        id=id,
+        project_id=project_id,
+        repo_path=repo_path,
+        story_node_id=story_node_id,
+        depends_on=depends_on or [],
+        job_id=job_id,
+        tracker_ticket_ref=tracker_ticket_ref,
+        prompt_override=prompt_override,
+        epic_id=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _make_job(*, id: str, state: JobState, resolution: str | None = None) -> Job:  # noqa: A002
+    now = datetime.now(UTC)
+    return Job(
+        id=id,
+        repo="/repo/a",
+        prompt="do the thing",
+        state=state,
+        base_ref="main",
+        branch="feature",
+        worktree_path="/tmp/wt",
+        session_id=None,
+        created_at=now,
+        updated_at=now,
+        resolution=resolution,
+    )
+
+
+@pytest.fixture
+def mock_job_repo() -> AsyncMock:
+    return AsyncMock()
+
+
+@pytest.fixture
+def mock_job_service() -> AsyncMock:
+    return AsyncMock()
+
+
+class TestHandleJobCompleted:
+    """Story 4.5: auto-spawn a dependent TaskLink's job on completion."""
+
+    @pytest.mark.asyncio
+    async def test_no_op_when_job_service_not_configured(
+        self, mock_task_link_repo: AsyncMock, mock_project_service: AsyncMock
+    ) -> None:
+        service = RecipeService(mock_task_link_repo, mock_project_service)
+        result = await service.handle_job_completed("job-1", resolution="merged")
+        assert result == []
+        mock_task_link_repo.get_by_job_id.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_op_when_resolution_is_discarded(
+        self,
+        mock_task_link_repo: AsyncMock,
+        mock_project_service: AsyncMock,
+        mock_job_repo: AsyncMock,
+        mock_job_service: AsyncMock,
+    ) -> None:
+        service = RecipeService(
+            mock_task_link_repo, mock_project_service, job_service=mock_job_service, job_repo=mock_job_repo
+        )
+        result = await service.handle_job_completed("job-1", resolution="discarded")
+        assert result == []
+        mock_task_link_repo.get_by_job_id.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_op_when_completed_job_has_no_linked_task_link(
+        self,
+        mock_task_link_repo: AsyncMock,
+        mock_project_service: AsyncMock,
+        mock_job_repo: AsyncMock,
+        mock_job_service: AsyncMock,
+    ) -> None:
+        mock_task_link_repo.get_by_job_id.return_value = None
+        service = RecipeService(
+            mock_task_link_repo, mock_project_service, job_service=mock_job_service, job_repo=mock_job_repo
+        )
+        result = await service.handle_job_completed("job-1", resolution="merged")
+        assert result == []
+        mock_job_service.create_job.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_spawns_dependent_whose_single_dependency_is_now_satisfied(
+        self,
+        mock_task_link_repo: AsyncMock,
+        mock_project_service: AsyncMock,
+        mock_job_repo: AsyncMock,
+        mock_job_service: AsyncMock,
+    ) -> None:
+        completed_link = _make_task_link(id="link-a", story_node_id="1-1-a", job_id="job-1")
+        dependent = _make_task_link(
+            id="link-b", story_node_id="1-2-b", depends_on=["/repo/a::1-1-a"]
+        )
+        mock_task_link_repo.get_by_job_id.return_value = completed_link
+        mock_task_link_repo.list_by_project.return_value = [completed_link, dependent]
+        mock_job_repo.get.return_value = _make_job(
+            id="job-1", state=JobState.completed, resolution="merged"
+        )
+        new_job = _make_job(id="job-2", state=JobState.preparing)
+        mock_job_service.create_job.return_value = new_job
+        mock_task_link_repo.set_job_id.return_value = _make_task_link(
+            id="link-b", story_node_id="1-2-b", depends_on=["/repo/a::1-1-a"], job_id="job-2"
+        )
+
+        service = RecipeService(
+            mock_task_link_repo, mock_project_service, job_service=mock_job_service, job_repo=mock_job_repo
+        )
+        result = await service.handle_job_completed("job-1", resolution="merged")
+
+        assert result == [new_job]
+        mock_job_service.create_job.assert_awaited_once()
+        spec = mock_job_service.create_job.call_args.args[0]
+        assert spec.repo == "/repo/a"
+        assert spec.parent_job_id == "job-1"
+        mock_task_link_repo.set_job_id.assert_awaited_once_with("link-b", "job-2")
+
+    @pytest.mark.asyncio
+    async def test_does_not_spawn_until_all_dependencies_satisfied(
+        self,
+        mock_task_link_repo: AsyncMock,
+        mock_project_service: AsyncMock,
+        mock_job_repo: AsyncMock,
+        mock_job_service: AsyncMock,
+    ) -> None:
+        completed_link = _make_task_link(id="link-a", story_node_id="1-1-a", job_id="job-1")
+        other_dep = _make_task_link(id="link-c", story_node_id="1-1-c", job_id=None)
+        dependent = _make_task_link(
+            id="link-b",
+            story_node_id="1-2-b",
+            depends_on=["/repo/a::1-1-a", "/repo/a::1-1-c"],
+        )
+        mock_task_link_repo.get_by_job_id.return_value = completed_link
+        mock_task_link_repo.list_by_project.return_value = [completed_link, other_dep, dependent]
+        mock_job_repo.get.return_value = _make_job(
+            id="job-1", state=JobState.completed, resolution="merged"
+        )
+
+        service = RecipeService(
+            mock_task_link_repo, mock_project_service, job_service=mock_job_service, job_repo=mock_job_repo
+        )
+        result = await service.handle_job_completed("job-1", resolution="merged")
+
+        assert result == []
+        mock_job_service.create_job.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_never_spawns_a_dependent_twice(
+        self,
+        mock_task_link_repo: AsyncMock,
+        mock_project_service: AsyncMock,
+        mock_job_repo: AsyncMock,
+        mock_job_service: AsyncMock,
+    ) -> None:
+        completed_link = _make_task_link(id="link-a", story_node_id="1-1-a", job_id="job-1")
+        dependent = _make_task_link(
+            id="link-b",
+            story_node_id="1-2-b",
+            depends_on=["/repo/a::1-1-a"],
+            job_id="job-already-spawned",
+        )
+        mock_task_link_repo.get_by_job_id.return_value = completed_link
+        mock_task_link_repo.list_by_project.return_value = [completed_link, dependent]
+
+        service = RecipeService(
+            mock_task_link_repo, mock_project_service, job_service=mock_job_service, job_repo=mock_job_repo
+        )
+        result = await service.handle_job_completed("job-1", resolution="merged")
+
+        assert result == []
+        mock_job_service.create_job.assert_not_awaited()
+        mock_task_link_repo.set_job_id.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_dependency_target_job_in_review_state_is_not_satisfied(
+        self,
+        mock_task_link_repo: AsyncMock,
+        mock_project_service: AsyncMock,
+        mock_job_repo: AsyncMock,
+        mock_job_service: AsyncMock,
+    ) -> None:
+        completed_link = _make_task_link(id="link-a", story_node_id="1-1-a", job_id="job-1")
+        dependent = _make_task_link(
+            id="link-b", story_node_id="1-2-b", depends_on=["/repo/a::1-1-a"]
+        )
+        mock_task_link_repo.get_by_job_id.return_value = completed_link
+        mock_task_link_repo.list_by_project.return_value = [completed_link, dependent]
+        # The dependency target's own job is only in `review`, not `completed`.
+        mock_job_repo.get.return_value = _make_job(id="job-1", state=JobState.review)
+
+        service = RecipeService(
+            mock_task_link_repo, mock_project_service, job_service=mock_job_service, job_repo=mock_job_repo
+        )
+        result = await service.handle_job_completed("job-1", resolution="merged")
+
+        assert result == []
+        mock_job_service.create_job.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_manually_assigned_dependent_uses_prompt_override(
+        self,
+        mock_task_link_repo: AsyncMock,
+        mock_project_service: AsyncMock,
+        mock_job_repo: AsyncMock,
+        mock_job_service: AsyncMock,
+    ) -> None:
+        completed_link = _make_task_link(id="link-a", story_node_id="1-1-a", job_id="job-1")
+        dependent = _make_task_link(
+            id="link-b",
+            story_node_id=None,
+            depends_on=["/repo/a::1-1-a"],
+            tracker_ticket_ref="JIRA-9",
+            prompt_override="Do exactly this",
+        )
+        mock_task_link_repo.get_by_job_id.return_value = completed_link
+        mock_task_link_repo.list_by_project.return_value = [completed_link, dependent]
+        mock_job_repo.get.return_value = _make_job(
+            id="job-1", state=JobState.completed, resolution="merged"
+        )
+        new_job = _make_job(id="job-2", state=JobState.preparing)
+        mock_job_service.create_job.return_value = new_job
+        mock_task_link_repo.set_job_id.return_value = dependent
+
+        service = RecipeService(
+            mock_task_link_repo, mock_project_service, job_service=mock_job_service, job_repo=mock_job_repo
+        )
+        await service.handle_job_completed("job-1", resolution="merged")
+
+        spec = mock_job_service.create_job.call_args.args[0]
+        assert spec.prompt == "Do exactly this"
+
+    @pytest.mark.asyncio
+    async def test_spawn_failure_for_one_dependent_does_not_raise_or_block(
+        self,
+        mock_task_link_repo: AsyncMock,
+        mock_project_service: AsyncMock,
+        mock_job_repo: AsyncMock,
+        mock_job_service: AsyncMock,
+    ) -> None:
+        completed_link = _make_task_link(id="link-a", story_node_id="1-1-a", job_id="job-1")
+        dependent = _make_task_link(
+            id="link-b", story_node_id="1-2-b", depends_on=["/repo/a::1-1-a"]
+        )
+        mock_task_link_repo.get_by_job_id.return_value = completed_link
+        mock_task_link_repo.list_by_project.return_value = [completed_link, dependent]
+        mock_job_repo.get.return_value = _make_job(
+            id="job-1", state=JobState.completed, resolution="merged"
+        )
+        mock_job_service.create_job.side_effect = RepoNotAllowedError("nope")
+
+        service = RecipeService(
+            mock_task_link_repo, mock_project_service, job_service=mock_job_service, job_repo=mock_job_repo
+        )
+        result = await service.handle_job_completed("job-1", resolution="merged")
+
+        assert result == []
+        mock_task_link_repo.set_job_id.assert_not_awaited()

--- a/backend/tests/unit/test_task_link_repo.py
+++ b/backend/tests/unit/test_task_link_repo.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 import pytest
 from sqlalchemy import event as sa_event
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
-from backend.models.db import Base
+from backend.models.db import Base, JobRow
+from backend.models.domain import JobState
 from backend.persistence.database import _set_sqlite_pragmas
 from backend.persistence.project_repo import ProjectRepository
 from backend.persistence.task_link_repo import TaskLinkRepository
@@ -34,6 +36,25 @@ async def _make_project(session: AsyncSession) -> str:
     project = await project_repo.create("proj-1", "Test Project", ["/repo/a", "/repo/b"])
     await session.commit()
     return project.id
+
+
+async def _make_job(session: AsyncSession, job_id: str) -> None:
+    now = datetime.now(UTC)
+    session.add(
+        JobRow(
+            id=job_id,
+            repo="/repo/a",
+            prompt="do the thing",
+            state=JobState.completed,
+            base_ref="main",
+            permission_mode="full_auto",
+            preset="autonomous",
+            sdk="copilot",
+            created_at=now,
+            updated_at=now,
+        )
+    )
+    await session.commit()
 
 
 class TestTaskLinkRepoUpsert:
@@ -170,3 +191,86 @@ class TestCreateManual:
         assert [task.tracker_ticket_ref for task in listed] == ["JIRA-123", "JIRA-123"]
         assert [task.prompt_override for task in listed] == ["Implement part one", "Implement part two"]
         assert all(task.story_node_id is None for task in listed)
+
+
+class TestSetJobIdAndGetByJobId:
+    """Story 4.5: guarded job_id assignment (AC #3) and completion lookup (AC #1)."""
+
+    @pytest.mark.asyncio
+    async def test_set_job_id_persists_and_returns_updated_task_link(self, session: AsyncSession) -> None:
+        project_id = await _make_project(session)
+        repo = TaskLinkRepository(session)
+
+        created = await repo.upsert_many(
+            project_id,
+            [{"repo_path": "/repo/a", "story_node_id": "1-1-task", "depends_on": [], "epic_id": None}],
+        )
+        await session.commit()
+        task_link_id = created[0].id
+        await _make_job(session, "job-123")
+
+        updated = await repo.set_job_id(task_link_id, "job-123")
+        await session.commit()
+
+        assert updated is not None
+        assert updated.job_id == "job-123"
+
+        listed = await repo.list_by_project(project_id)
+        assert listed[0].job_id == "job-123"
+
+    @pytest.mark.asyncio
+    async def test_set_job_id_is_a_no_op_once_already_set(self, session: AsyncSession) -> None:
+        project_id = await _make_project(session)
+        repo = TaskLinkRepository(session)
+
+        created = await repo.upsert_many(
+            project_id,
+            [{"repo_path": "/repo/a", "story_node_id": "1-1-task", "depends_on": [], "epic_id": None}],
+        )
+        await session.commit()
+        task_link_id = created[0].id
+        await _make_job(session, "job-123")
+        await _make_job(session, "job-456")
+
+        first = await repo.set_job_id(task_link_id, "job-123")
+        await session.commit()
+        assert first is not None and first.job_id == "job-123"
+
+        # Second attempt with a different job id must be rejected — a
+        # TaskLink is never spawned a second time (Story 4.5, AC #3).
+        second = await repo.set_job_id(task_link_id, "job-456")
+        await session.commit()
+        assert second is None
+
+        listed = await repo.list_by_project(project_id)
+        assert listed[0].job_id == "job-123"
+
+    @pytest.mark.asyncio
+    async def test_set_job_id_returns_none_for_missing_row(self, session: AsyncSession) -> None:
+        repo = TaskLinkRepository(session)
+        result = await repo.set_job_id("does-not-exist", "job-1")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_by_job_id_finds_matching_row(self, session: AsyncSession) -> None:
+        project_id = await _make_project(session)
+        repo = TaskLinkRepository(session)
+
+        created = await repo.upsert_many(
+            project_id,
+            [{"repo_path": "/repo/a", "story_node_id": "1-1-task", "depends_on": [], "epic_id": None}],
+        )
+        await session.commit()
+        await _make_job(session, "job-123")
+        await repo.set_job_id(created[0].id, "job-123")
+        await session.commit()
+
+        found = await repo.get_by_job_id("job-123")
+        assert found is not None
+        assert found.id == created[0].id
+
+    @pytest.mark.asyncio
+    async def test_get_by_job_id_returns_none_when_absent(self, session: AsyncSession) -> None:
+        repo = TaskLinkRepository(session)
+        assert await repo.get_by_job_id("does-not-exist") is None
+


### PR DESCRIPTION
## Summary

Implements Story 4.5 exactly per `_bmad-output/planning-artifacts/epics.md` Epic 4: when a TaskLink's linked Job completes successfully, any dependent TaskLink whose remaining dependencies are now all satisfied has its next job auto-spawned via the same `JobService.create_job` path `codeplane_job create` uses, and the resulting `job_id` is written back onto the TaskLink — never spawning twice.

Trigger mechanism: hooks directly into the domain **event bus** (`EventKind.job_completed`), per the epics.md AC's own parenthetical hint — no sidecar/recipe dispatch machinery was built.

### Acceptance Criteria
1. ✅ Dependent TaskLink's job is spawned via `JobService.create_job` (same function `codeplane_job create` uses), `job_id` persisted.
2. ✅ A TaskLink with multiple dependencies is not spawned until *all* are satisfied.
3. ✅ A TaskLink is never spawned a second time — enforced via a DB-level guarded `UPDATE ... WHERE job_id IS NULL`, safe under concurrent sibling completions.

### Key design decisions (documented in the story's Dev Notes)
- "Completes successfully" = `JobState.completed` **and** `resolution` in `(merged, pr_created)` — `discarded` also reaches `job.completed` but is explicitly excluded from satisfying a dependency.
- Dependency satisfaction resolved in-Python over the full Project's TaskLink set (mirrors Story 4.4's frontend `computeSatisfaction`), never SQL `LIKE`, to avoid composite-key substring-match bugs (e.g. `repo::t1` vs `repo::t10`).
- Spawned-job prompt: `prompt_override` verbatim for manually-assigned TaskLinks (Story 4.3); for ingested TaskLinks (no persisted task body), a prompt is synthesized pointing the agent at the source BMAD story/spec-kit task file by id.
- No new alembic migration — reuses the existing `job_id` column from Story 4.2. Verified true alembic head against `origin/main` immediately before opening this PR (Story 5.3 had since landed `0064_add_chat_task_link.py`) and rebased cleanly onto it.
- No frontend changes — Story 4.4 already renders `job_id` once present.

### Explicitly out of scope
- Story 4.6 (tracker-write routing to a paired ticket)
- Story 5.3/5.4 (chat attach-to-chain, approval-gated auto-spawn)
- Any Epic 6 (MCP-exposed chain controls) work
- Any sidecar/recipe dispatch wiring for `spawn_task` as a template output route

## Changes
- `backend/persistence/task_link_repo.py` — `get_by_job_id`, `set_job_id` (idempotency guard).
- `backend/services/recipe/recipe_service.py` — `RecipeService.handle_job_completed` + helpers, optional `job_service`/`job_repo` constructor params.
- `backend/lifespan.py` — new `_spawn_dependent_task_links` event-bus subscriber.
- Tests: `backend/tests/unit/test_task_link_repo.py` (+5), `backend/tests/unit/test_recipe_service.py` (+9), new `backend/tests/integration/test_job_completion_spawns_tasklinks.py` (end-to-end through the real event bus).
- `_bmad-output/implementation-artifacts/4-5-auto-spawn-the-next-task-on-completion.md` (new story file) + `sprint-status.yaml` moved to `review`.

## Validation
- `ruff check` on all changed/new files: clean.
- `mypy --ignore-missing-imports` on all changed/new files: 0 new errors (one pre-existing, unrelated error at `lifespan.py:922` untouched by this change).
- Targeted `pytest`: **31 passed**, 0 failed (`test_task_link_repo.py`, `test_recipe_service.py`, `test_job_completion_spawns_tasklinks.py`).
- Rebased onto latest `origin/main` (confirmed alembic head `0064_add_chat_task_link.py` via `git log origin/main -- alembic/versions/`; no migration needed for this story).