### PR TITLE
feat: gate tracker writes on approval

### DIFF
--- a/backend/di.py
+++ b/backend/di.py
@@ -58,6 +58,7 @@ from backend.services.sidecar.template_service import SidecarTemplateService
 from backend.services.steps.diff_service import StepDiffService
 from backend.services.story.service import StoryService
 from backend.services.terminal.terminal_service import TerminalService
+from backend.services.tracker_write_service import TrackerWriteService
 from backend.services.trail import TrailService
 
 # NewType wrappers for plain values that need unique DI keys
@@ -99,6 +100,10 @@ class AppProvider(Provider):
     @provide
     def git_service(self, config: CPLConfig) -> GitService:
         return GitService(config)
+
+    @provide
+    def tracker_write_service(self, approval_service: ApprovalService) -> TrackerWriteService:
+        return TrackerWriteService(approval_service)
 
     @provide
     def diff_service(self, git_service: GitService, event_bus: EventBus, coderecon: CodeReconService) -> DiffService:

--- a/backend/services/tracker_write_service.py
+++ b/backend/services/tracker_write_service.py
@@ -1,0 +1,96 @@
+"""Approval gate for outbound tracker writes."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+import structlog
+
+from backend.models.domain import ApprovalResolution
+
+if TYPE_CHECKING:
+    from backend.services.job.approval_service import ApprovalService
+
+log = structlog.get_logger()
+
+
+class TrackerWriteAction(StrEnum):
+    """Outbound tracker operations supported by the approval gate."""
+
+    comment = "comment"
+    transition = "transition"
+
+
+@dataclass(frozen=True)
+class TrackerWriteRequest:
+    """Provider-independent description of a proposed tracker write."""
+
+    tracker_link_id: str
+    ticket_ref: str
+    action: TrackerWriteAction
+    value: str
+
+    def approval_description(self) -> str:
+        return f"{self.action.value.capitalize()} on tracker ticket {self.ticket_ref}?"
+
+    def proposed_action(self) -> str:
+        return json.dumps(
+            {
+                "action": self.action.value,
+                "ticketRef": self.ticket_ref,
+                "trackerLinkId": self.tracker_link_id,
+                "value": self.value,
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+
+
+TrackerWriteDispatcher = Callable[[TrackerWriteRequest], Awaitable[None]]
+
+
+class TrackerWriteService:
+    """Execute tracker writes only after an explicit CodePlane approval."""
+
+    def __init__(self, approval_service: ApprovalService) -> None:
+        self._approval_service = approval_service
+
+    async def execute(
+        self,
+        job_id: str,
+        request: TrackerWriteRequest,
+        dispatch: TrackerWriteDispatcher,
+    ) -> bool:
+        """Request approval and dispatch the write only when approved."""
+        approval = await self._approval_service.create_request(
+            job_id,
+            request.approval_description(),
+            proposed_action=request.proposed_action(),
+            requires_explicit_approval=True,
+        )
+        resolution = await self._approval_service.wait_for_resolution(approval.id)
+        if resolution == ApprovalResolution.rejected:
+            log.info(
+                "tracker_write_rejected",
+                approval_id=approval.id,
+                job_id=job_id,
+                tracker_link_id=request.tracker_link_id,
+                ticket_ref=request.ticket_ref,
+                action=request.action,
+            )
+            return False
+
+        await dispatch(request)
+        log.info(
+            "tracker_write_dispatched",
+            approval_id=approval.id,
+            job_id=job_id,
+            tracker_link_id=request.tracker_link_id,
+            ticket_ref=request.ticket_ref,
+            action=request.action,
+        )
+        return True

--- a/backend/tests/unit/test_tracker_write_service.py
+++ b/backend/tests/unit/test_tracker_write_service.py
@@ -1,0 +1,137 @@
+"""Tests for approval-gated tracker writes (Story 3.4)."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from backend.models.db import Base, JobRow
+from backend.services.job.approval_service import ApprovalService
+from backend.services.tracker_write_service import (
+    TrackerWriteAction,
+    TrackerWriteRequest,
+    TrackerWriteService,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+
+@pytest.fixture
+async def session_factory() -> AsyncGenerator[async_sessionmaker[AsyncSession], None]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as session:
+        session.add(
+            JobRow(
+                id="job-1",
+                repo="/test",
+                prompt="test",
+                state="running",
+                base_ref="main",
+                created_at=datetime.now(UTC),
+                updated_at=datetime.now(UTC),
+            )
+        )
+        await session.commit()
+    yield factory
+    await engine.dispose()
+
+
+@pytest.fixture
+def approval_service(session_factory: async_sessionmaker[AsyncSession]) -> ApprovalService:
+    return ApprovalService(session_factory)
+
+
+@pytest.fixture
+def tracker_write_service(approval_service: ApprovalService) -> TrackerWriteService:
+    return TrackerWriteService(approval_service)
+
+
+async def _pending_approval(approval_service: ApprovalService):
+    for _ in range(20):
+        pending = await approval_service.list_pending("job-1")
+        if pending:
+            return pending[0]
+        await asyncio.sleep(0)
+    pytest.fail("Tracker write did not create an approval")
+
+
+@pytest.mark.asyncio
+async def test_rejected_write_uses_existing_approval_and_is_never_dispatched(
+    approval_service: ApprovalService,
+    tracker_write_service: TrackerWriteService,
+) -> None:
+    request = TrackerWriteRequest(
+        tracker_link_id="link-1",
+        ticket_ref="ABC-123",
+        action=TrackerWriteAction.comment,
+        value="Ready for review",
+    )
+    dispatch = AsyncMock()
+
+    execution = asyncio.create_task(tracker_write_service.execute("job-1", request, dispatch))
+    approval = await _pending_approval(approval_service)
+
+    assert approval.requires_explicit_approval is True
+    assert approval.description == "Comment on tracker ticket ABC-123?"
+    assert approval.proposed_action == (
+        '{"action":"comment","ticketRef":"ABC-123","trackerLinkId":"link-1","value":"Ready for review"}'
+    )
+
+    await approval_service.resolve(approval.id, "rejected")
+
+    assert await execution is False
+    dispatch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_approved_write_is_dispatched_once(
+    approval_service: ApprovalService,
+    tracker_write_service: TrackerWriteService,
+) -> None:
+    request = TrackerWriteRequest(
+        tracker_link_id="link-1",
+        ticket_ref="ABC-123",
+        action=TrackerWriteAction.transition,
+        value="Done",
+    )
+    dispatch = AsyncMock()
+
+    execution = asyncio.create_task(tracker_write_service.execute("job-1", request, dispatch))
+    approval = await _pending_approval(approval_service)
+    await approval_service.resolve(approval.id, "approved")
+
+    assert await execution is True
+    dispatch.assert_awaited_once_with(request)
+
+
+@pytest.mark.asyncio
+async def test_blanket_job_trust_cannot_auto_approve_tracker_write(
+    approval_service: ApprovalService,
+    tracker_write_service: TrackerWriteService,
+) -> None:
+    request = TrackerWriteRequest(
+        tracker_link_id="link-1",
+        ticket_ref="ABC-123",
+        action=TrackerWriteAction.comment,
+        value="Ready for review",
+    )
+    dispatch = AsyncMock()
+
+    execution = asyncio.create_task(tracker_write_service.execute("job-1", request, dispatch))
+    approval = await _pending_approval(approval_service)
+
+    assert await approval_service.trust_job("job-1") == 0
+    assert not execution.done()
+
+    await approval_service.resolve(approval.id, "rejected")
+    assert await execution is False
+    dispatch.assert_not_awaited()


### PR DESCRIPTION
## Summary
- add a provider-independent tracker write request and execution service
- create tracker writes through the existing `ApprovalService` with explicit approval required
- discard rejected writes without invoking the provider dispatcher
- dispatch approved writes exactly once
- register the service through application DI

## Scope
Implements Story 3.4 only. This does not duplicate Story 3.3's tracker read model or add provider/polling behavior.

## Verification
- 47 focused approval unit/integration tests pass
- Ruff passes for changed files
- mypy passes for changed files
- rebased onto current `origin/main`
- confirmed current Alembic head file is `0064_add_chat_task_link.py`; this change adds no migration