### PR TITLE
feat: view synced ticket state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,9 @@ jobs:
           CI: true
           CODEPLANE_E2E_FAKE_AGENT: "1"
 
+      - name: Run tracker synchronization E2E test
+        run: cd frontend && npm run lint:e2e:tracker && npm run test:e2e:tracker
+
       - name: Upload Playwright report
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,4 @@ scorecard.png
 *.tsbuildinfo
 site/
 .playwright-mcp/
+.tracker-e2e-*/

--- a/_bmad-output/implementation-artifacts/3-3-view-synced-ticket-state.md
+++ b/_bmad-output/implementation-artifacts/3-3-view-synced-ticket-state.md
@@ -1,0 +1,154 @@
+---
+baseline_commit: 4e6628050b88b5caac51fb0e0377fc2819c9c32c
+---
+
+# Story 3.3: View Synced Ticket State
+
+Status: review
+
+## Story
+
+As a CodePlane user,
+I want to see my linked tracker's ticket/board state inside CodePlane,
+so that I don't have to leave CodePlane to check status.
+
+## Acceptance Criteria
+
+1. **Given** a Project with an attached TrackerLink, **when** the poll interval elapses or I trigger a manual refresh, **then** ticket/board state is fetched and rendered, with no inbound webhook endpoint involved at any point (NFR2).
+2. **Given** the configured poll interval, **when** I change it in settings, **then** subsequent polls honor the new interval.
+
+## Tasks / Subtasks
+
+- [x] Task 1: Add the tracker sync read model and configuration (AC: 1, 2)
+  - [x] Add `TrackerSummaryRow`, keyed by `tracker_link_id`, with normalized ticket-state JSON, last-sync timestamp, and last error; keep it separate from `JobRow`.
+  - [x] Add the Alembic migration on the current `origin/main` head and update `backend/config.py`, settings schemas/API, and frontend `Settings` type with a bounded `tracker_poll_interval_seconds` value.
+  - [x] Ensure settings updates mutate the app-scoped config used by the running poller and persist to `config.yaml`.
+- [x] Task 2: Implement provider-isolated ticket fetching (AC: 1)
+  - [x] Add `TrackerAdapterInterface` and normalized ticket models in `backend/services/tracker_adapter.py`.
+  - [x] Implement GitHub Projects, Jira, and Azure DevOps read adapters using the existing `httpx` dependency and server-side decrypted credentials; never return or log a PAT.
+  - [x] Keep all provider SDK/REST response shapes behind the adapter boundary and surface explicit provider/transport/response errors.
+- [x] Task 3: Implement scheduled and manual tracker sync (AC: 1, 2)
+  - [x] Add `TrackerSummaryRepository` and `TrackerSyncService`; iterate every TrackerLink, fetch through the matching adapter, and upsert the separate read model.
+  - [x] Start and stop the poller with FastAPI lifespan; isolate per-link failures so one provider/link cannot stop later links or future poll cycles.
+  - [x] Make interval changes wake/reconfigure the running poll loop so the next wait uses the new value.
+  - [x] Add a thin manual-refresh endpoint and include summary state in the project-scoped TrackerLink read response; add no webhook route.
+- [x] Task 4: Render synced ticket state and manual refresh in CodePlane (AC: 1, 2)
+  - [x] Add typed API client functions for Projects, TrackerLinks, summaries, and manual refresh.
+  - [x] Add a reusable project-grouped tracker-state panel to Settings, showing provider/link identity, ticket title/status, last-sync/error/never-synced states, and a per-link Refresh action.
+  - [x] Add the poll-interval field to Settings and preserve existing credential registration behavior.
+- [x] Task 5: Author comprehensive tests (AC: 1, 2)
+  - [x] Unit-test adapter normalization/error handling, summary persistence, per-link failure isolation, manual refresh, and live interval changes.
+  - [x] Integration-test project-scoped summary reads/manual refresh, settings persistence, secret-free responses, and absence of any inbound tracker webhook surface.
+  - [x] Component-test rendered ticket/error/empty states, manual refresh, and poll-interval editing.
+  - [x] Execute the critical browser flow against a running CodePlane instance: view persisted synced state, trigger manual refresh, and change the interval.
+
+## Dev Notes
+
+### Implementation Boundary
+
+- Story 3.3 is read-only tracker integration. Do not implement outbound comments/transitions or approvals (Story 3.4), TrackerLink detach, Project overview/board replacement, TaskLinks, or agent-facing tracker tools.
+- The current branch already contains Story 3.1 (`CredentialRow`, encrypted PAT, `CredentialRepository.resolve_secret()`, Integrations UI) and Story 3.2 (`TrackerLinkRepository`, project-scoped attach/list API). Extend those surfaces; do not duplicate them.
+- Project overview and Project board UI stories are not implemented yet. Render a reusable project-grouped tracker-state panel in the existing Settings screen so AC1 is demonstrable now; keep its API/types/component reusable by later overview/board work.
+- No inbound webhook route, webhook secret, webhook event model, or webhook dependency may be added. Polling plus manual refresh is the complete inbound mechanism.
+
+### Architecture Compliance
+
+- Follow AD-7: a background poller calls providers only through `TrackerAdapterInterface`, once per `TrackerLinkRow`, and writes a separate `TrackerSummaryRow`; never write tracker data into `JobRow` or the job-status store.
+- Keep FastAPI routes thin. Database access belongs in repositories under `backend/persistence/`; orchestration belongs in `TrackerSyncService`.
+- The decrypted PAT remains server-side inside the adapter call boundary. API responses, structured logs, errors, frontend state, and job prompts must remain secret-free.
+- Use the existing app-scoped `CPLConfig` singleton and settings mutation path. A changed interval must affect the running poller without restart.
+- Start/stop the poller through `backend/lifespan.py` and close its `httpx.AsyncClient` during shutdown. Do not leave orphan tasks.
+- Use `CamelModel` for wire models and camelCase on the frontend.
+- Provider HTTP behavior should follow the current official APIs: GitHub GraphQL ProjectsV2 items, Jira REST v3 issue search, and Azure DevOps Work Item Tracking WIQL 7.1. Normalize all provider output to one internal ticket shape.
+
+### Existing Files to Preserve
+
+- `backend/api/tracker_links.py`: currently provides secret-free project-scoped attach/list and maps missing Project/Credential to 404. Preserve those contracts while adding summary/manual refresh.
+- `backend/persistence/tracker_link_repo.py`: currently validates Project/Credential existence and orders links by `created_at`. Reuse it for link enumeration rather than querying TrackerLink rows in routes.
+- `backend/persistence/credential_repo.py`: `resolve_secret()` is the only permitted PAT-decryption entry point for sync.
+- `backend/config.py`, `backend/api/settings.py`, `backend/models/api_schemas.py`: preserve partial settings updates and persisted app-scoped mutation.
+- `backend/lifespan.py`: preserve reverse-order shutdown and ensure tracker sync stops before DB engine disposal.
+- `frontend/src/components/SettingsScreen.tsx`: preserve existing settings dirty/save/reset behavior and Credential UI.
+- `frontend/src/components/IntegrationsSettings.tsx`: preserve global Credential registration/deletion; TrackerLink state is Project-scoped and should be a sibling panel, not folded into credential rows.
+
+### Testing Requirements
+
+- Use fake adapters and in-memory SQLite for deterministic unit/integration tests; automated tests must never call real tracker services.
+- Prove a failed link does not prevent another link from syncing and does not terminate the poll loop.
+- Prove the manual endpoint refreshes only the requested link and rejects a link outside the requested Project.
+- Prove changing the interval wakes/reconfigures the existing service rather than requiring process restart.
+- Assert API payloads and logs contain no plaintext or encrypted credential material.
+- Because AC1 explicitly requires rendered state and manual refresh, run the real browser flow; component tests alone do not satisfy completion.
+
+### Project Structure Notes
+
+- New backend files: `backend/services/tracker_adapter.py`, `backend/services/tracker_sync_service.py`, `backend/persistence/tracker_summary_repo.py`, one Alembic migration.
+- New frontend component: `frontend/src/components/TrackerSyncPanel.tsx`, mounted from `SettingsScreen.tsx`.
+- Reuse existing `httpx`, FastAPI, SQLAlchemy, React, and Vitest/Playwright dependencies; add no package.
+
+### References
+
+- [Source: `_bmad-output/planning-artifacts/epics.md#Story-33-View-synced-ticket-state`]
+- [Source: `_bmad-output/specs/spec-project-boards/SPEC.md` CAP-7, NFR2]
+- [Source: `_bmad-output/specs/spec-project-boards/ui-flows.md#CAP-7-Global-Credentials--per-Project-TrackerLinks`]
+- [Source: `_bmad-output/planning-artifacts/architecture/architecture-codeplane-2026-08-10/ARCHITECTURE-SPINE.md#AD-7`]
+- [Source: `_bmad-output/implementation-artifacts/3-2-attach-a-trackerlink-to-a-project.md`]
+- [Source: GitHub GraphQL API reference, Jira REST API v3 issue search, Azure DevOps WIQL REST API 7.1]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5.6 Sol (GitHub Copilot CLI).
+
+### Debug Log References
+
+- `uv run --no-sync pytest backend/tests/unit/test_config.py backend/tests/integration/test_api_settings.py backend/tests/integration/test_api_tracker_links.py backend/tests/unit/test_tracker_adapter.py backend/tests/unit/test_tracker_sync_service.py`
+- `uv run --no-sync ruff check backend`
+- `uv run --no-sync mypy backend/services/tracker_adapter.py backend/services/tracker_sync_service.py backend/persistence/tracker_summary_repo.py backend/api/tracker_links.py`
+- `npx vitest run`
+- `npm run typecheck && npm run build`
+- Live Playwright acceptance against isolated CodePlane and fake Jira services; screenshot: `story-3-3-e2e.png` in the session artifacts directory.
+
+### Completion Notes List
+
+- Ultimate context engine analysis completed - comprehensive developer guide created.
+- Added an AD-7-compliant tracker summary read model and migration, resequenced to the current mainline migration head (`0065 -> 0064`).
+- Added normalized GitHub Projects, Jira, and Azure DevOps adapters behind `TrackerAdapterInterface`, with server-side credential resolution and sanitized errors.
+- Added scheduled and manual synchronization with project scoping, per-link locking, failure isolation, lifecycle shutdown, and live interval wakeups.
+- Added secret-free summary responses, a project-grouped Settings panel, per-link refresh, and persisted interval editing.
+- Verified the required production browser flow: scheduled polling rendered a persisted Jira ticket, manual refresh completed, and a changed interval survived reload with no browser console errors.
+- Frontend regression result: 24 files passed, 247 tests passed, 1 skipped. Story-specific backend result: 69 tests passed; the backend-wide Windows run terminated at 63% on the existing async timeout after unrelated platform-path failures.
+
+### File List
+
+- `_bmad-output/implementation-artifacts/3-3-view-synced-ticket-state.md`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `alembic/versions/0065_add_tracker_summaries.py`
+- `backend/api/settings.py`
+- `backend/api/tracker_links.py`
+- `backend/config.py`
+- `backend/di.py`
+- `backend/lifespan.py`
+- `backend/models/api_schemas.py`
+- `backend/models/db.py`
+- `backend/persistence/tracker_summary_repo.py`
+- `backend/services/tracker_adapter.py`
+- `backend/services/tracker_sync_service.py`
+- `backend/tests/integration/conftest.py`
+- `backend/tests/integration/test_api_settings.py`
+- `backend/tests/integration/test_api_tracker_links.py`
+- `backend/tests/unit/test_config.py`
+- `backend/tests/unit/test_tracker_adapter.py`
+- `backend/tests/unit/test_tracker_sync_service.py`
+- `frontend/src/api/client.ts`
+- `frontend/src/api/types.ts`
+- `frontend/src/components/SettingsScreen.tsx`
+- `frontend/src/components/TrackerSyncPanel.tsx`
+- `frontend/src/components/__tests__/SettingsScreen.test.tsx`
+- `frontend/src/components/__tests__/TrackerSyncPanel.test.tsx`
+
+## Change Log
+
+- 2026-08-10: Created comprehensive Story 3.3 implementation context; status set to ready-for-dev.
+- 2026-08-12: Implemented persisted tracker synchronization, manual refresh, live interval updates, and rendered ticket state; status set to review.

--- a/_bmad-output/implementation-artifacts/3-3-view-synced-ticket-state.md
+++ b/_bmad-output/implementation-artifacts/3-3-view-synced-ticket-state.md
@@ -158,6 +158,7 @@ GPT-5.6 Sol (GitHub Copilot CLI).
 - `frontend/tracker-e2e/tracker-sync.spec.ts`
 - `frontend/package.json`
 - `frontend/playwright.tracker.config.ts`
+- `frontend/vite.config.ts`
 
 ## Change Log
 

--- a/_bmad-output/implementation-artifacts/3-3-view-synced-ticket-state.md
+++ b/_bmad-output/implementation-artifacts/3-3-view-synced-ticket-state.md
@@ -118,7 +118,7 @@ GPT-5.6 Sol (GitHub Copilot CLI).
 - Added scheduled and manual synchronization with project scoping, per-link locking, failure isolation, lifecycle shutdown, and live interval wakeups.
 - Added secret-free summary responses, a project-grouped Settings panel, per-link refresh, and persisted interval editing.
 - Verified the required production browser flow: scheduled polling rendered a persisted Jira ticket, manual refresh completed, and a changed interval survived reload with no browser console errors.
-- Frontend regression result: 24 files passed, 247 tests passed, 1 skipped. Story-specific backend result: 69 tests passed; the backend-wide Windows run terminated at 63% on the existing async timeout after unrelated platform-path failures.
+- Post-rebase frontend regression result: 29 files passed, 290 tests passed, 1 skipped. Post-rebase Story 3.3 backend result: 40 tests passed; the backend-wide Windows run terminated at 63% on the existing async timeout after unrelated platform-path failures.
 
 ### File List
 
@@ -142,6 +142,7 @@ GPT-5.6 Sol (GitHub Copilot CLI).
 - `backend/tests/unit/test_tracker_adapter.py`
 - `backend/tests/unit/test_tracker_sync_service.py`
 - `frontend/src/api/client.ts`
+- `frontend/src/api/schema.d.ts`
 - `frontend/src/api/types.ts`
 - `frontend/src/components/SettingsScreen.tsx`
 - `frontend/src/components/TrackerSyncPanel.tsx`

--- a/_bmad-output/implementation-artifacts/3-3-view-synced-ticket-state.md
+++ b/_bmad-output/implementation-artifacts/3-3-view-synced-ticket-state.md
@@ -17,30 +17,34 @@ so that I don't have to leave CodePlane to check status.
 1. **Given** a Project with an attached TrackerLink, **when** the poll interval elapses or I trigger a manual refresh, **then** ticket/board state is fetched and rendered, with no inbound webhook endpoint involved at any point (NFR2).
 2. **Given** the configured poll interval, **when** I change it in settings, **then** subsequent polls honor the new interval.
 
+### Approved Scope Change (2026-08-12)
+
+The approved follow-up spec supersedes AC2's configurable interval: tracker synchronization now uses one non-configurable 60-second production cadence. The settings API, persisted configuration, generated OpenAPI contract, frontend type, and Settings UI no longer expose an interval. AC1 remains satisfied by scheduled polling plus manual refresh, and the repository live-service Playwright scenario proves both paths.
+
 ## Tasks / Subtasks
 
-- [x] Task 1: Add the tracker sync read model and configuration (AC: 1, 2)
+- [x] Task 1: Add the tracker sync read model (AC: 1)
   - [x] Add `TrackerSummaryRow`, keyed by `tracker_link_id`, with normalized ticket-state JSON, last-sync timestamp, and last error; keep it separate from `JobRow`.
-  - [x] Add the Alembic migration on the current `origin/main` head and update `backend/config.py`, settings schemas/API, and frontend `Settings` type with a bounded `tracker_poll_interval_seconds` value.
-  - [x] Ensure settings updates mutate the app-scoped config used by the running poller and persist to `config.yaml`.
+  - [x] Add the Alembic migration on the current `origin/main` head.
+  - [x] Keep tracker cadence out of `CPLConfig`, `config.yaml`, settings schemas/API, generated OpenAPI, and the frontend `Settings` type.
 - [x] Task 2: Implement provider-isolated ticket fetching (AC: 1)
   - [x] Add `TrackerAdapterInterface` and normalized ticket models in `backend/services/tracker_adapter.py`.
   - [x] Implement GitHub Projects, Jira, and Azure DevOps read adapters using the existing `httpx` dependency and server-side decrypted credentials; never return or log a PAT.
   - [x] Keep all provider SDK/REST response shapes behind the adapter boundary and surface explicit provider/transport/response errors.
-- [x] Task 3: Implement scheduled and manual tracker sync (AC: 1, 2)
+- [x] Task 3: Implement scheduled and manual tracker sync (AC: 1)
   - [x] Add `TrackerSummaryRepository` and `TrackerSyncService`; iterate every TrackerLink, fetch through the matching adapter, and upsert the separate read model.
   - [x] Start and stop the poller with FastAPI lifespan; isolate per-link failures so one provider/link cannot stop later links or future poll cycles.
-  - [x] Make interval changes wake/reconfigure the running poll loop so the next wait uses the new value.
+  - [x] Use an exact fixed 60-second scheduled cadence and wake the running wait promptly during shutdown.
   - [x] Add a thin manual-refresh endpoint and include summary state in the project-scoped TrackerLink read response; add no webhook route.
-- [x] Task 4: Render synced ticket state and manual refresh in CodePlane (AC: 1, 2)
+- [x] Task 4: Render synced ticket state and manual refresh in CodePlane (AC: 1)
   - [x] Add typed API client functions for Projects, TrackerLinks, summaries, and manual refresh.
   - [x] Add a reusable project-grouped tracker-state panel to Settings, showing provider/link identity, ticket title/status, last-sync/error/never-synced states, and a per-link Refresh action.
-  - [x] Add the poll-interval field to Settings and preserve existing credential registration behavior.
-- [x] Task 5: Author comprehensive tests (AC: 1, 2)
-  - [x] Unit-test adapter normalization/error handling, summary persistence, per-link failure isolation, manual refresh, and live interval changes.
-  - [x] Integration-test project-scoped summary reads/manual refresh, settings persistence, secret-free responses, and absence of any inbound tracker webhook surface.
-  - [x] Component-test rendered ticket/error/empty states, manual refresh, and poll-interval editing.
-  - [x] Execute the critical browser flow against a running CodePlane instance: view persisted synced state, trigger manual refresh, and change the interval.
+  - [x] Preserve existing credential registration behavior without adding tracker cadence controls.
+- [x] Task 5: Author comprehensive tests (AC: 1)
+  - [x] Unit-test adapter normalization/error handling, summary persistence, per-link failure isolation, manual refresh, fixed 60-second cadence, and prompt shutdown.
+  - [x] Integration-test project-scoped summary reads/manual refresh, secret-free settings responses, and absence of any inbound tracker webhook surface.
+  - [x] Component-test rendered ticket/error/empty states and manual refresh.
+  - [x] Add and execute the critical repository browser flow against an isolated migrated CodePlane backend and local fake Jira: wait for scheduled persistence/rendering, change Jira state, trigger manual refresh, and assert zero browser console errors.
 
 ## Dev Notes
 
@@ -56,7 +60,7 @@ so that I don't have to leave CodePlane to check status.
 - Follow AD-7: a background poller calls providers only through `TrackerAdapterInterface`, once per `TrackerLinkRow`, and writes a separate `TrackerSummaryRow`; never write tracker data into `JobRow` or the job-status store.
 - Keep FastAPI routes thin. Database access belongs in repositories under `backend/persistence/`; orchestration belongs in `TrackerSyncService`.
 - The decrypted PAT remains server-side inside the adapter call boundary. API responses, structured logs, errors, frontend state, and job prompts must remain secret-free.
-- Use the existing app-scoped `CPLConfig` singleton and settings mutation path. A changed interval must affect the running poller without restart.
+- Tracker synchronization has one code-owned 60-second cadence; do not add it to `CPLConfig`, persisted settings, API contracts, or UI state.
 - Start/stop the poller through `backend/lifespan.py` and close its `httpx.AsyncClient` during shutdown. Do not leave orphan tasks.
 - Use `CamelModel` for wire models and camelCase on the frontend.
 - Provider HTTP behavior should follow the current official APIs: GitHub GraphQL ProjectsV2 items, Jira REST v3 issue search, and Azure DevOps Work Item Tracking WIQL 7.1. Normalize all provider output to one internal ticket shape.
@@ -76,7 +80,7 @@ so that I don't have to leave CodePlane to check status.
 - Use fake adapters and in-memory SQLite for deterministic unit/integration tests; automated tests must never call real tracker services.
 - Prove a failed link does not prevent another link from syncing and does not terminate the poll loop.
 - Prove the manual endpoint refreshes only the requested link and rejects a link outside the requested Project.
-- Prove changing the interval wakes/reconfigures the existing service rather than requiring process restart.
+- Prove the fixed cadence is exactly 60 seconds and service shutdown wakes the active wait promptly.
 - Assert API payloads and logs contain no plaintext or encrypted credential material.
 - Because AC1 explicitly requires rendered state and manual refresh, run the real browser flow; component tests alone do not satisfy completion.
 
@@ -108,22 +112,25 @@ GPT-5.6 Sol (GitHub Copilot CLI).
 - `uv run --no-sync mypy backend/services/tracker_adapter.py backend/services/tracker_sync_service.py backend/persistence/tracker_summary_repo.py backend/api/tracker_links.py`
 - `npx vitest run`
 - `npm run typecheck && npm run build`
-- Live Playwright acceptance against isolated CodePlane and fake Jira services; screenshot: `story-3-3-e2e.png` in the session artifacts directory.
+- `npm --prefix frontend run test:e2e:tracker` (production build plus committed Chromium scenario): 1 passed; isolated migrated `CODEPLANE_HOME`, local fake Jira, real 60-second scheduled sync, manual refresh, zero browser console errors, and verified teardown.
+- `npm --prefix frontend run typecheck`
+- `npm --prefix frontend run lint:e2e:tracker`
 
 ### Completion Notes List
 
 - Ultimate context engine analysis completed - comprehensive developer guide created.
 - Added an AD-7-compliant tracker summary read model and migration, resequenced to the current mainline migration head (`0065 -> 0064`).
 - Added normalized GitHub Projects, Jira, and Azure DevOps adapters behind `TrackerAdapterInterface`, with server-side credential resolution and sanitized errors.
-- Added scheduled and manual synchronization with project scoping, per-link locking, failure isolation, lifecycle shutdown, and live interval wakeups.
-- Added secret-free summary responses, a project-grouped Settings panel, per-link refresh, and persisted interval editing.
-- Verified the required production browser flow: scheduled polling rendered a persisted Jira ticket, manual refresh completed, and a changed interval survived reload with no browser console errors.
+- Added scheduled and manual synchronization with project scoping, per-link locking, failure isolation, a fixed 60-second cadence, and prompt lifecycle shutdown.
+- Added secret-free summary responses, a project-grouped Settings panel, and per-link refresh; removed the retired interval from configuration, API, generated types, and UI.
+- Added a deterministic Playwright scenario and dedicated config. The passing command built production assets, migrated isolated state, rendered a Jira ticket after the actual scheduled wait, refreshed changed status through the real backend/provider path, observed zero console errors, and left no listener or temporary state.
 - Post-rebase frontend regression result: 29 files passed, 290 tests passed, 1 skipped. Post-rebase Story 3.3 backend result: 40 tests passed; the backend-wide Windows run terminated at 63% on the existing async timeout after unrelated platform-path failures.
 
 ### File List
 
 - `_bmad-output/implementation-artifacts/3-3-view-synced-ticket-state.md`
 - `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `.gitignore`
 - `alembic/versions/0065_add_tracker_summaries.py`
 - `backend/api/settings.py`
 - `backend/api/tracker_links.py`
@@ -148,8 +155,12 @@ GPT-5.6 Sol (GitHub Copilot CLI).
 - `frontend/src/components/TrackerSyncPanel.tsx`
 - `frontend/src/components/__tests__/SettingsScreen.test.tsx`
 - `frontend/src/components/__tests__/TrackerSyncPanel.test.tsx`
+- `frontend/tracker-e2e/tracker-sync.spec.ts`
+- `frontend/package.json`
+- `frontend/playwright.tracker.config.ts`
 
 ## Change Log
 
 - 2026-08-10: Created comprehensive Story 3.3 implementation context; status set to ready-for-dev.
-- 2026-08-12: Implemented persisted tracker synchronization, manual refresh, live interval updates, and rendered ticket state; status set to review.
+- 2026-08-12: Initial implementation included persisted tracker synchronization, manual refresh, live interval updates, and rendered ticket state; the interval portion was later superseded.
+- 2026-08-12: Approved scope change removed interval configuration, fixed scheduled sync at 60 seconds, and added reproducible live-service Playwright coverage.

--- a/_bmad-output/implementation-artifacts/spec-3-3-committed-tracker-e2e.md
+++ b/_bmad-output/implementation-artifacts/spec-3-3-committed-tracker-e2e.md
@@ -38,6 +38,7 @@ baseline_commit: '8fb32f54'
 
 - `frontend/tracker-e2e/tracker-sync.spec.ts` -- isolated live-service orchestration and Story 3.3 browser assertions.
 - `frontend/playwright.tracker.config.ts` -- dedicated base URL and timeout without the shared development server.
+- `frontend/vite.config.ts` -- keep the dedicated Playwright spec outside Vitest discovery.
 - `frontend/package.json` -- repeatable production-build plus tracker E2E command.
 - `backend/services/tracker_sync_service.py` -- fixed 60-second scheduled poll cadence and shutdown wakeup.
 - `backend/config.py` -- remove tracker interval persistence and defaults.

--- a/_bmad-output/implementation-artifacts/spec-3-3-committed-tracker-e2e.md
+++ b/_bmad-output/implementation-artifacts/spec-3-3-committed-tracker-e2e.md
@@ -1,0 +1,115 @@
+---
+title: 'Fix Story 3.3 polling policy and commit E2E coverage'
+type: 'chore'
+created: '2026-08-12'
+status: 'done'
+review_loop_iteration: 0
+baseline_commit: '8fb32f54'
+---
+
+<frozen-after-approval reason="human-owned intent — do not modify unless human renegotiates">
+
+## Intent
+
+**Problem:** PR #74 exposes an unnecessary configurable polling interval and reports a live Playwright flow without committing a repeatable E2E spec.
+
+**Approach:** Remove the interval configuration surface, poll every tracker link on a fixed 60-second cadence, and commit a dedicated Playwright scenario that launches isolated production assets with a fake Jira service to prove scheduled polling and manual refresh through real backend APIs.
+
+## Boundaries & Constraints
+
+**Always:** Use a single fixed 60-second production interval; keep manual refresh; use an isolated temporary `CODEPLANE_HOME`; migrate it to the current Alembic head; use a real CodePlane backend and production frontend build; keep Jira local and deterministic; assert zero browser console errors; terminate spawned processes and remove temporary state after the run.
+
+**Ask First:** Any polling cadence other than 60 seconds, change to shared E2E runner defaults, or external network access.
+
+**Never:** Retain a user-facing or persisted poll-interval setting; use the user's normal CodePlane database; contact a real tracker; replace backend behavior with Playwright route mocks; weaken the existing Story 3.3 assertions; or claim scheduled polling based only on pre-seeded browser responses.
+
+## I/O & Edge-Case Matrix
+
+| Scenario | Input / State | Expected Output / Behavior | Error Handling |
+|----------|--------------|---------------------------|----------------|
+| Fixed cadence | Running tracker service | Poll loop waits 60 seconds between scheduled refresh cycles | Unit test verifies the fixed constant is used; shutdown wakes the wait immediately |
+| Scheduled poll | Project, Jira credential, TrackerLink, fixed 60-second wait | Fake Jira ticket is fetched, persisted, and rendered in Settings | Poll API is retried until a bounded deadline, then the test fails with the last observed summary |
+| Manual refresh | Fake Jira changes ticket status after initial poll | Refresh button causes a real backend provider call and updates rendered status | Provider/request failure fails the visible status assertion |
+| Browser diagnostics | Any page interaction | No console error messages | Collected console errors are reported in the final assertion |
+
+</frozen-after-approval>
+
+## Code Map
+
+- `frontend/tracker-e2e/tracker-sync.spec.ts` -- isolated live-service orchestration and Story 3.3 browser assertions.
+- `frontend/playwright.tracker.config.ts` -- dedicated base URL and timeout without the shared development server.
+- `frontend/package.json` -- repeatable production-build plus tracker E2E command.
+- `backend/services/tracker_sync_service.py` -- fixed 60-second scheduled poll cadence and shutdown wakeup.
+- `backend/config.py` -- remove tracker interval persistence and defaults.
+- `backend/api/settings.py` -- remove tracker interval response/update wiring.
+- `backend/models/api_schemas.py` -- remove tracker interval wire fields.
+- `frontend/src/components/SettingsScreen.tsx` -- remove tracker interval control.
+- `frontend/src/api/types.ts` and `frontend/src/api/schema.d.ts` -- remove the retired setting from generated/client contracts.
+- `backend/tests/unit/test_config.py`, `backend/tests/integration/test_api_settings.py`, `backend/tests/unit/test_tracker_sync_service.py`, `frontend/src/components/__tests__/SettingsScreen.test.tsx` -- replace configurable-interval assertions with fixed-cadence coverage.
+- `_bmad-output/implementation-artifacts/3-3-view-synced-ticket-state.md` -- committed E2E evidence and file inventory.
+
+## Tasks & Acceptance
+
+**Execution:**
+- [x] `backend/config.py`, `backend/api/settings.py`, `backend/models/api_schemas.py` -- remove persisted/API interval configuration.
+- [x] `backend/services/tracker_sync_service.py` -- replace mutable interval and interval-change wakeup with a fixed 60-second cadence while retaining prompt shutdown.
+- [x] `frontend/src/components/SettingsScreen.tsx`, `frontend/src/api/types.ts`, `frontend/src/api/schema.d.ts` -- remove the settings control and contract field.
+- [x] Backend and frontend Story 3.3 tests -- remove interval-editing cases and prove the fixed service cadence.
+- [x] `frontend/playwright.tracker.config.ts` -- define a Chromium-only config for the isolated tracker acceptance server.
+- [x] `frontend/tracker-e2e/tracker-sync.spec.ts` -- start fake Jira and CodePlane, seed through APIs, verify scheduled rendering, manual refresh, console diagnostics, and teardown.
+- [x] `frontend/package.json` -- add a discoverable command that builds production assets and runs only the tracker E2E spec.
+- [x] `_bmad-output/implementation-artifacts/3-3-view-synced-ticket-state.md` -- record the committed spec and final command.
+
+**Acceptance Criteria:**
+- Given a running tracker sync service, when it schedules refreshes, then the production cadence is fixed at 60 seconds and is not exposed through configuration, API, or UI.
+- Given an isolated migrated CodePlane home and local fake Jira, when the fixed 60-second scheduled wait elapses, then the fetched ticket is persisted and rendered from the live backend.
+- Given the rendered ticket and a changed fake Jira response, when Refresh is clicked, then the new status is visible after a real provider request.
+- Given the full browser flow, when it completes, then no console errors occurred and all spawned resources are stopped.
+
+## Spec Change Log
+
+## Design Notes
+
+The dedicated config avoids the shared `cpl up` runner because this scenario must control its own database and provider endpoint. The E2E test intentionally waits for the real fixed 60-second cadence so it proves the production scheduling path rather than a test-only override. The spec owns its local HTTP server and backend subprocess so the command is reproducible on Windows and CI without mutating developer state.
+
+## Verification
+
+**Commands:**
+- `npm --prefix frontend run test:e2e:tracker` -- expected: production build succeeds and the dedicated Chromium spec passes.
+- `npm --prefix frontend run typecheck` -- expected: no TypeScript errors in frontend source.
+- `npm --prefix frontend run lint:e2e:tracker` -- expected: no lint findings in the dedicated config/spec.
+
+## Suggested Review Order
+
+**Fixed scheduling policy**
+
+- Start with the single code-owned cadence and shutdown-safe wait.
+  [`tracker_sync_service.py:23`](../../backend/services/tracker_sync_service.py#L23)
+
+- Verify retired persisted cadence is removed during configuration saves.
+  [`config.py:398`](../../backend/config.py#L398)
+
+- Confirm settings updates reject the retired field instead of ignoring it.
+  [`api_schemas.py:119`](../../backend/models/api_schemas.py#L119)
+
+**Live acceptance boundary**
+
+- Review deterministic Jira request validation and isolated provider behavior.
+  [`tracker-sync.spec.ts:54`](../../frontend/tracker-e2e/tracker-sync.spec.ts#L54)
+
+- Check process termination and failure-resilient temporary-state cleanup.
+  [`tracker-sync.spec.ts:143`](../../frontend/tracker-e2e/tracker-sync.spec.ts#L143)
+
+- Follow scheduled persistence, rendering, manual refresh, and browser diagnostics.
+  [`tracker-sync.spec.ts:334`](../../frontend/tracker-e2e/tracker-sync.spec.ts#L334)
+
+- Confirm dedicated Chromium timing supports startup plus the real cadence.
+  [`playwright.tracker.config.ts:4`](../../frontend/playwright.tracker.config.ts#L4)
+
+**Supporting evidence**
+
+- Verify CI runs the isolated tracker acceptance command explicitly.
+  [`ci.yml:149`](../../.github/workflows/ci.yml#L149)
+
+- Check fixed-cadence and prompt-shutdown unit coverage.
+  [`test_tracker_sync_service.py:160`](../../backend/tests/unit/test_tracker_sync_service.py#L160)

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-08-10
-# last_updated: 2026-08-10
+# last_updated: 2026-08-12
 # project: codeplane
 # project_key: NOKEY
 # tracking_system: file-system
@@ -66,10 +66,10 @@ development_status:
   2-5-filter-projects-by-name: review
   epic-2-retrospective: optional
 
-  epic-3: backlog
+  epic-3: in-progress
   3-1-register-a-credential: review
   3-2-attach-a-trackerlink-to-a-project: backlog
-  3-3-view-synced-ticket-state: backlog
+  3-3-view-synced-ticket-state: review
   3-4-approve-a-tracker-write-back: backlog
   3-5-see-per-provider-pat-scope-guidance: review
   epic-3-retrospective: optional

--- a/alembic/versions/0065_add_tracker_summaries.py
+++ b/alembic/versions/0065_add_tracker_summaries.py
@@ -1,0 +1,33 @@
+"""Add tracker summary read model (Story 3.3, AD-7).
+
+Revision ID: 0065
+Revises: 0064
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0065"
+down_revision = "0064"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "tracker_summaries",
+        sa.Column(
+            "tracker_link_id",
+            sa.String(),
+            sa.ForeignKey("tracker_links.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column("tickets_json", sa.Text(), nullable=False, server_default="[]"),
+        sa.Column("last_synced_at", sa.Text(), nullable=True),
+        sa.Column("last_error", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("tracker_summaries")

--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -47,7 +47,6 @@ from backend.models.db import JobRow
 from backend.services.adapters.platform_adapter import PlatformRegistry, detect_platform
 from backend.services.coderecon.coderecon_service import CodeReconService
 from backend.services.git.git_service import GitError, GitService
-from backend.services.tracker_sync_service import TrackerSyncService
 
 router = APIRouter(tags=["settings"], route_class=DishkaRoute)
 
@@ -69,7 +68,6 @@ def _config_to_response(config: CPLConfig) -> SettingsResponse:
         cli_sidecars=config.runtime.cli_sidecars,
         coderecon_splade=config.coderecon.splade,
         coderecon_cross_encoder=config.coderecon.cross_encoder,
-        tracker_poll_interval_seconds=config.tracker.poll_interval_seconds,
     )
 
 
@@ -85,7 +83,6 @@ def get_settings(
 async def update_settings(
     body: UpdateSettingsRequest,
     config: FromDishka[CPLConfig],
-    tracker_sync_service: FromDishka[TrackerSyncService],
 ) -> SettingsResponse:
     """Update settings. Only provided fields are changed.
 
@@ -113,7 +110,6 @@ async def update_settings(
         "cli_sidecars": ("runtime", "cli_sidecars"),
         "coderecon_splade": ("coderecon", "splade"),
         "coderecon_cross_encoder": ("coderecon", "cross_encoder"),
-        "tracker_poll_interval_seconds": ("tracker", "poll_interval_seconds"),
     }
 
     for field, (section, attr) in _FIELD_MAP.items():
@@ -121,8 +117,6 @@ async def update_settings(
             setattr(getattr(config, section), attr, updates[field])
 
     save_config(config)
-    if "tracker_poll_interval_seconds" in updates:
-        tracker_sync_service.notify_interval_changed()
 
     # Keep env vars in sync so new coderecon ReviewKit instances use fresh values.
     if "coderecon_splade" in updates or "coderecon_cross_encoder" in updates:

--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -47,6 +47,7 @@ from backend.models.db import JobRow
 from backend.services.adapters.platform_adapter import PlatformRegistry, detect_platform
 from backend.services.coderecon.coderecon_service import CodeReconService
 from backend.services.git.git_service import GitError, GitService
+from backend.services.tracker_sync_service import TrackerSyncService
 
 router = APIRouter(tags=["settings"], route_class=DishkaRoute)
 
@@ -68,6 +69,7 @@ def _config_to_response(config: CPLConfig) -> SettingsResponse:
         cli_sidecars=config.runtime.cli_sidecars,
         coderecon_splade=config.coderecon.splade,
         coderecon_cross_encoder=config.coderecon.cross_encoder,
+        tracker_poll_interval_seconds=config.tracker.poll_interval_seconds,
     )
 
 
@@ -80,9 +82,10 @@ def get_settings(
 
 
 @router.put("/settings", response_model=SettingsResponse)
-def update_settings(
+async def update_settings(
     body: UpdateSettingsRequest,
     config: FromDishka[CPLConfig],
+    tracker_sync_service: FromDishka[TrackerSyncService],
 ) -> SettingsResponse:
     """Update settings. Only provided fields are changed.
 
@@ -110,6 +113,7 @@ def update_settings(
         "cli_sidecars": ("runtime", "cli_sidecars"),
         "coderecon_splade": ("coderecon", "splade"),
         "coderecon_cross_encoder": ("coderecon", "cross_encoder"),
+        "tracker_poll_interval_seconds": ("tracker", "poll_interval_seconds"),
     }
 
     for field, (section, attr) in _FIELD_MAP.items():
@@ -117,6 +121,8 @@ def update_settings(
             setattr(getattr(config, section), attr, updates[field])
 
     save_config(config)
+    if "tracker_poll_interval_seconds" in updates:
+        tracker_sync_service.notify_interval_changed()
 
     # Keep env vars in sync so new coderecon ReviewKit instances use fresh values.
     if "coderecon_splade" in updates or "coderecon_cross_encoder" in updates:

--- a/backend/api/tracker_links.py
+++ b/backend/api/tracker_links.py
@@ -24,9 +24,29 @@ from backend.persistence.tracker_link_repo import (
     TrackerLinkProjectNotFoundError,
     TrackerLinkRepository,
 )
+from backend.persistence.tracker_summary_repo import TrackerSummaryRepository
+from backend.services.tracker_sync_service import (
+    TrackerLinkNotFoundError,
+    TrackerSyncError,
+    TrackerSyncService,
+)
 
 router = APIRouter(prefix="/projects/{project_id}/tracker-links", tags=["tracker-links"], route_class=DishkaRoute)
 log = structlog.get_logger()
+
+
+class TrackerTicketResponse(CamelModel):
+    id: str
+    title: str
+    status: str
+    url: str | None = None
+
+
+class TrackerSummaryResponse(CamelModel):
+    tracker_link_id: str
+    tickets: list[TrackerTicketResponse] = Field(default_factory=list)
+    last_synced_at: str | None = None
+    last_error: str | None = None
 
 
 class TrackerLinkResponse(CamelModel):
@@ -35,6 +55,7 @@ class TrackerLinkResponse(CamelModel):
     credential_id: str
     external_ref: str
     created_at: str
+    summary: TrackerSummaryResponse | None = None
 
 
 class TrackerLinkListResponse(CamelModel):
@@ -46,8 +67,11 @@ class CreateTrackerLinkRequest(CamelModel):
     external_ref: str = Field(min_length=1)
 
 
-def _to_response(data: dict[str, Any]) -> TrackerLinkResponse:
-    return TrackerLinkResponse(**data)
+def _to_response(
+    data: dict[str, Any],
+    summary: dict[str, Any] | None = None,
+) -> TrackerLinkResponse:
+    return TrackerLinkResponse(**data, summary=TrackerSummaryResponse(**summary) if summary else None)
 
 
 @router.get("", response_model=TrackerLinkListResponse)
@@ -58,7 +82,10 @@ async def list_tracker_links(
     async with sf() as session:
         repo = TrackerLinkRepository(session)
         rows = await repo.list_for_project(project_id)
-    return TrackerLinkListResponse(tracker_links=[_to_response(r) for r in rows])
+        summaries = await TrackerSummaryRepository(session).list_for_project(project_id)
+    return TrackerLinkListResponse(
+        tracker_links=[_to_response(row, summaries.get(row["id"])) for row in rows]
+    )
 
 
 @router.post("", response_model=TrackerLinkResponse, status_code=201)
@@ -84,3 +111,24 @@ async def create_tracker_link(
         await session.commit()
     log.info("tracker_link.created", tracker_link_id=link_id, project_id=project_id, credential_id=body.credential_id)
     return _to_response(result)
+
+
+@router.post(
+    "/{link_id}/refresh",
+    response_model=TrackerSummaryResponse,
+)
+async def refresh_tracker_link(
+    project_id: str,
+    link_id: str,
+    tracker_sync_service: FromDishka[TrackerSyncService],
+) -> TrackerSummaryResponse:
+    try:
+        summary = await tracker_sync_service.refresh_link(
+            project_id=project_id,
+            link_id=link_id,
+        )
+    except TrackerLinkNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except TrackerSyncError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+    return TrackerSummaryResponse(**summary)

--- a/backend/config.py
+++ b/backend/config.py
@@ -89,9 +89,6 @@ runtime:
     default_sdk: copilot
     suppressed_preflight_agent_prompts: []
 
-tracker:
-  poll_interval_seconds: 300
-
 retention:
   artifact_retention_days: 30
   max_artifact_size_mb: 100
@@ -248,13 +245,6 @@ class PricingConfig:
 
 
 @dataclass
-class TrackerConfig:
-    """External tracker synchronization configuration."""
-
-    poll_interval_seconds: int = 300
-
-
-@dataclass
 class TrailConfig:
     """Agent audit trail enrichment tuning."""
 
@@ -284,7 +274,6 @@ class CPLConfig:
     verification: VerificationConfig = field(default_factory=VerificationConfig)
     telemetry: TelemetryConfig = field(default_factory=TelemetryConfig)
     pricing: PricingConfig = field(default_factory=PricingConfig)
-    tracker: TrackerConfig = field(default_factory=TrackerConfig)
     trail: TrailConfig = field(default_factory=TrailConfig)
     coderecon: CodeReconConfig = field(default_factory=CodeReconConfig)
     platforms: dict[str, PlatformConfig] = field(default_factory=dict)
@@ -334,7 +323,6 @@ def load_config(path: Path | None = None) -> CPLConfig:
         verification=_parse_section(raw, VerificationConfig, "verification"),
         telemetry=_parse_section(raw, TelemetryConfig, "telemetry"),
         pricing=_parse_section(raw, PricingConfig, "pricing"),
-        tracker=_parse_section(raw, TrackerConfig, "tracker"),
         trail=_parse_section(raw, TrailConfig, "trail"),
         coderecon=_parse_section(raw, CodeReconConfig, "coderecon"),
         platforms=platforms,
@@ -351,6 +339,11 @@ def load_config(path: Path | None = None) -> CPLConfig:
             save_config(cfg, path)
         except (OSError, yaml.YAMLError):
             log.warning("instance_id_persist_failed", exc_info=True)
+    elif "tracker" in raw:
+        try:
+            save_config(cfg, path)
+        except (OSError, yaml.YAMLError):
+            log.warning("retired_tracker_config_removal_failed", exc_info=True)
 
     return cfg
 
@@ -402,7 +395,9 @@ def save_config(config: CPLConfig, path: Path | None = None) -> None:
     # repos is intentionally omitted — managed by register_repo / unregister_repo
     existing["verification"] = _to_dict(config.verification)
     existing["telemetry"] = _to_dict(config.telemetry)
-    existing["tracker"] = _to_dict(config.tracker)
+    # Tracker synchronization uses a fixed production cadence. Remove the
+    # retired persisted section when any settings save occurs.
+    existing.pop("tracker", None)
     existing["coderecon"] = _to_dict(config.coderecon)
     if config.platforms:
         existing["platforms"] = {name: _to_dict(pc) for name, pc in config.platforms.items()}

--- a/backend/config.py
+++ b/backend/config.py
@@ -89,6 +89,9 @@ runtime:
     default_sdk: copilot
     suppressed_preflight_agent_prompts: []
 
+tracker:
+  poll_interval_seconds: 300
+
 retention:
   artifact_retention_days: 30
   max_artifact_size_mb: 100
@@ -245,6 +248,13 @@ class PricingConfig:
 
 
 @dataclass
+class TrackerConfig:
+    """External tracker synchronization configuration."""
+
+    poll_interval_seconds: int = 300
+
+
+@dataclass
 class TrailConfig:
     """Agent audit trail enrichment tuning."""
 
@@ -274,6 +284,7 @@ class CPLConfig:
     verification: VerificationConfig = field(default_factory=VerificationConfig)
     telemetry: TelemetryConfig = field(default_factory=TelemetryConfig)
     pricing: PricingConfig = field(default_factory=PricingConfig)
+    tracker: TrackerConfig = field(default_factory=TrackerConfig)
     trail: TrailConfig = field(default_factory=TrailConfig)
     coderecon: CodeReconConfig = field(default_factory=CodeReconConfig)
     platforms: dict[str, PlatformConfig] = field(default_factory=dict)
@@ -323,6 +334,7 @@ def load_config(path: Path | None = None) -> CPLConfig:
         verification=_parse_section(raw, VerificationConfig, "verification"),
         telemetry=_parse_section(raw, TelemetryConfig, "telemetry"),
         pricing=_parse_section(raw, PricingConfig, "pricing"),
+        tracker=_parse_section(raw, TrackerConfig, "tracker"),
         trail=_parse_section(raw, TrailConfig, "trail"),
         coderecon=_parse_section(raw, CodeReconConfig, "coderecon"),
         platforms=platforms,
@@ -390,6 +402,7 @@ def save_config(config: CPLConfig, path: Path | None = None) -> None:
     # repos is intentionally omitted — managed by register_repo / unregister_repo
     existing["verification"] = _to_dict(config.verification)
     existing["telemetry"] = _to_dict(config.telemetry)
+    existing["tracker"] = _to_dict(config.tracker)
     existing["coderecon"] = _to_dict(config.coderecon)
     if config.platforms:
         existing["platforms"] = {name: _to_dict(pc) for name, pc in config.platforms.items()}

--- a/backend/di.py
+++ b/backend/di.py
@@ -58,6 +58,7 @@ from backend.services.sidecar.template_service import SidecarTemplateService
 from backend.services.steps.diff_service import StepDiffService
 from backend.services.story.service import StoryService
 from backend.services.terminal.terminal_service import TerminalService
+from backend.services.tracker_sync_service import TrackerSyncService
 from backend.services.tracker_write_service import TrackerWriteService
 from backend.services.trail import TrailService
 
@@ -96,6 +97,7 @@ class AppProvider(Provider):
     ingest_service = from_context(provides=IngestService)
     model_pricing = from_context(provides=ModelPricingService)
     claude_session_watcher = from_context(provides=ClaudeSessionStateWatcher)
+    tracker_sync_service = from_context(provides=TrackerSyncService)
 
     @provide
     def git_service(self, config: CPLConfig) -> GitService:

--- a/backend/lifespan.py
+++ b/backend/lifespan.py
@@ -1474,6 +1474,14 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # --- Share service ---
     share_service = ShareService()
 
+    from backend.services.tracker_sync_service import TrackerSyncService
+
+    tracker_sync_service = TrackerSyncService(
+        session_factory=session_factory,
+        config=config,
+    )
+    tracker_sync_service.start()
+
     # Build the dishka DI container with all services as context values
     container = make_async_container(
         AppProvider(),
@@ -1502,6 +1510,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             ModelPricingService: model_pricing_service,
             SessionStateWatcher: session_state_watcher,
             ClaudeSessionStateWatcher: claude_session_watcher,
+            TrackerSyncService: tracker_sync_service,
         },
     )
     app.state.dishka_container = container
@@ -1560,6 +1569,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     async def _quiet_shutdown() -> None:
         """Run teardown steps, suppressing noisy exceptions."""
+        await tracker_sync_service.stop()
         await container.close()
         optional.mcp_stop_event.set()
         await optional.mcp_task

--- a/backend/lifespan.py
+++ b/backend/lifespan.py
@@ -1478,7 +1478,6 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     tracker_sync_service = TrackerSyncService(
         session_factory=session_factory,
-        config=config,
     )
     tracker_sync_service.start()
 

--- a/backend/models/api_schemas.py
+++ b/backend/models/api_schemas.py
@@ -119,6 +119,8 @@ class ResolveBatchResponse(CamelModel):
 class UpdateSettingsRequest(CamelModel):
     """Structured settings update — only include fields to change."""
 
+    model_config = ConfigDict(extra="forbid")
+
     max_concurrent_jobs: int | None = Field(None, ge=1, le=10)
     auto_push: bool | None = None
     cleanup_worktree: bool | None = None
@@ -137,7 +139,6 @@ class UpdateSettingsRequest(CamelModel):
     )
     coderecon_splade: bool | None = None
     coderecon_cross_encoder: bool | None = None
-    tracker_poll_interval_seconds: int | None = Field(None, ge=5, le=86_400)
 
 
 class SettingsResponse(CamelModel):
@@ -156,7 +157,6 @@ class SettingsResponse(CamelModel):
     cli_sidecars: list[str] | None
     coderecon_splade: bool
     coderecon_cross_encoder: bool
-    tracker_poll_interval_seconds: int
 
 
 class RegisterRepoRequest(CamelModel):

--- a/backend/models/api_schemas.py
+++ b/backend/models/api_schemas.py
@@ -137,6 +137,7 @@ class UpdateSettingsRequest(CamelModel):
     )
     coderecon_splade: bool | None = None
     coderecon_cross_encoder: bool | None = None
+    tracker_poll_interval_seconds: int | None = Field(None, ge=5, le=86_400)
 
 
 class SettingsResponse(CamelModel):
@@ -155,6 +156,7 @@ class SettingsResponse(CamelModel):
     cli_sidecars: list[str] | None
     coderecon_splade: bool
     coderecon_cross_encoder: bool
+    tracker_poll_interval_seconds: int
 
 
 class RegisterRepoRequest(CamelModel):

--- a/backend/models/db.py
+++ b/backend/models/db.py
@@ -601,6 +601,21 @@ class TaskLinkRow(Base):
     updated_at: Mapped[datetime] = mapped_column(TZDateTime, nullable=False)
 
 
+class TrackerSummaryRow(Base):
+    """Latest normalized external ticket state for one TrackerLink (AD-7)."""
+
+    __tablename__ = "tracker_summaries"
+
+    tracker_link_id: Mapped[str] = mapped_column(
+        String,
+        ForeignKey("tracker_links.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    tickets_json: Mapped[str] = mapped_column(Text, nullable=False, default="[]", server_default="[]")
+    last_synced_at: Mapped[str | None] = mapped_column(Text, nullable=True)
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+
 class SidecarTemplateRow(Base):
     __tablename__ = "sidecar_templates"
 

--- a/backend/persistence/tracker_summary_repo.py
+++ b/backend/persistence/tracker_summary_repo.py
@@ -1,0 +1,104 @@
+"""Persistence for the latest normalized state of each TrackerLink."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import select
+
+from backend.models.db import CredentialRow, TrackerLinkRow, TrackerSummaryRow
+from backend.persistence.repository import BaseRepository
+
+if TYPE_CHECKING:
+    from backend.services.tracker_adapter import TrackerTicket
+
+
+class TrackerSummaryRepository(BaseRepository):
+    async def list_targets(self) -> list[dict[str, str]]:
+        result = await self._session.execute(
+            select(TrackerLinkRow, CredentialRow)
+            .join(CredentialRow, CredentialRow.id == TrackerLinkRow.credential_id)
+            .order_by(TrackerLinkRow.created_at)
+        )
+        return [_target_to_dict(link, credential) for link, credential in result.all()]
+
+    async def get_target(self, *, project_id: str, link_id: str) -> dict[str, str] | None:
+        result = await self._session.execute(
+            select(TrackerLinkRow, CredentialRow)
+            .join(CredentialRow, CredentialRow.id == TrackerLinkRow.credential_id)
+            .where(
+                TrackerLinkRow.id == link_id,
+                TrackerLinkRow.project_id == project_id,
+            )
+        )
+        row = result.one_or_none()
+        return _target_to_dict(*row) if row else None
+
+    async def get(self, tracker_link_id: str) -> dict[str, Any] | None:
+        row = await self._session.get(TrackerSummaryRow, tracker_link_id)
+        return _summary_to_dict(row) if row else None
+
+    async def list_for_project(self, project_id: str) -> dict[str, dict[str, Any]]:
+        result = await self._session.execute(
+            select(TrackerSummaryRow)
+            .join(TrackerLinkRow, TrackerLinkRow.id == TrackerSummaryRow.tracker_link_id)
+            .where(TrackerLinkRow.project_id == project_id)
+        )
+        return {row.tracker_link_id: _summary_to_dict(row) for row in result.scalars()}
+
+    async def record_success(
+        self,
+        tracker_link_id: str,
+        tickets: list[TrackerTicket],
+    ) -> dict[str, Any]:
+        row = await self._get_or_create(tracker_link_id)
+        row.tickets_json = json.dumps([asdict(ticket) for ticket in tickets])
+        row.last_synced_at = datetime.now(UTC).isoformat()
+        row.last_error = None
+        await self._session.flush()
+        return _summary_to_dict(row)
+
+    async def record_error(self, tracker_link_id: str, error: str) -> dict[str, Any]:
+        row = await self._get_or_create(tracker_link_id)
+        row.last_error = error
+        await self._session.flush()
+        return _summary_to_dict(row)
+
+    async def _get_or_create(self, tracker_link_id: str) -> TrackerSummaryRow:
+        row = await self._session.get(TrackerSummaryRow, tracker_link_id)
+        if row is None:
+            row = TrackerSummaryRow(
+                tracker_link_id=tracker_link_id,
+                tickets_json="[]",
+                last_synced_at=None,
+                last_error=None,
+            )
+            self._session.add(row)
+        return row
+
+
+def _target_to_dict(link: TrackerLinkRow, credential: CredentialRow) -> dict[str, str]:
+    return {
+        "link_id": link.id,
+        "project_id": link.project_id,
+        "credential_id": link.credential_id,
+        "external_ref": link.external_ref,
+        "provider": credential.provider,
+        "base_url": credential.base_url,
+    }
+
+
+def _summary_to_dict(row: TrackerSummaryRow) -> dict[str, Any]:
+    try:
+        tickets = json.loads(row.tickets_json)
+    except (TypeError, json.JSONDecodeError):
+        tickets = []
+    return {
+        "tracker_link_id": row.tracker_link_id,
+        "tickets": tickets if isinstance(tickets, list) else [],
+        "last_synced_at": row.last_synced_at,
+        "last_error": row.last_error,
+    }

--- a/backend/services/tracker_adapter.py
+++ b/backend/services/tracker_adapter.py
@@ -1,0 +1,267 @@
+"""Provider-isolated, read-only external tracker adapters (Story 3.3, AD-7)."""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+from typing import Any, Protocol
+from urllib.parse import quote
+
+import httpx
+
+
+@dataclass(frozen=True)
+class TrackerTicket:
+    """Provider-neutral ticket state persisted by the tracker sync read model."""
+
+    id: str
+    title: str
+    status: str
+    url: str | None
+
+
+class TrackerAdapterError(RuntimeError):
+    """Raised when provider input, transport, or response data is invalid."""
+
+
+class TrackerAdapterInterface(Protocol):
+    async def fetch_tickets(
+        self,
+        *,
+        base_url: str,
+        external_ref: str,
+        token: str,
+    ) -> list[TrackerTicket]: ...
+
+
+class _HttpTrackerAdapter:
+    def __init__(self, client: httpx.AsyncClient) -> None:
+        self._client = client
+
+    async def _request_json(self, method: str, url: str, **kwargs: Any) -> dict[str, Any]:
+        try:
+            response = await self._client.request(method, url, **kwargs)
+            response.raise_for_status()
+            payload = response.json()
+        except (httpx.HTTPError, ValueError) as exc:
+            raise TrackerAdapterError("Tracker provider request failed") from exc
+        if not isinstance(payload, dict):
+            raise TrackerAdapterError("Tracker provider returned an invalid response")
+        return payload
+
+
+class GitHubProjectsTrackerAdapter(_HttpTrackerAdapter):
+    """Read GitHub Projects v2 items through the GraphQL API."""
+
+    _QUERY = """
+    query TrackerProject($owner: String!, $number: Int!) {
+      organization(login: $owner) {
+        projectV2(number: $number) {
+          items(first: 100) {
+            nodes {
+              id
+              content {
+                ... on Issue { number title url }
+                ... on PullRequest { number title url }
+                ... on DraftIssue { title }
+              }
+              status: fieldValueByName(name: "Status") {
+                ... on ProjectV2ItemFieldSingleSelectValue { name }
+              }
+            }
+          }
+        }
+      }
+      user(login: $owner) {
+        projectV2(number: $number) {
+          items(first: 100) {
+            nodes {
+              id
+              content {
+                ... on Issue { number title url }
+                ... on PullRequest { number title url }
+                ... on DraftIssue { title }
+              }
+              status: fieldValueByName(name: "Status") {
+                ... on ProjectV2ItemFieldSingleSelectValue { name }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+
+    async def fetch_tickets(
+        self,
+        *,
+        base_url: str,
+        external_ref: str,
+        token: str,
+    ) -> list[TrackerTicket]:
+        owner, separator, raw_number = external_ref.partition("/")
+        if not separator or not owner or not raw_number.isdigit():
+            raise TrackerAdapterError("GitHub external ref must use owner/project-number")
+
+        payload = await self._request_json(
+            "POST",
+            f"{base_url.rstrip('/')}/graphql",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "query": self._QUERY,
+                "variables": {"owner": owner, "number": int(raw_number)},
+            },
+        )
+        if payload.get("errors"):
+            raise TrackerAdapterError("GitHub Projects query failed")
+
+        data = payload.get("data")
+        if not isinstance(data, dict):
+            raise TrackerAdapterError("GitHub Projects returned an invalid response")
+        owner_data = data.get("organization") or data.get("user")
+        if not isinstance(owner_data, dict):
+            raise TrackerAdapterError("GitHub Project was not found")
+        try:
+            nodes = owner_data["projectV2"]["items"]["nodes"]
+        except (KeyError, TypeError) as exc:
+            raise TrackerAdapterError("GitHub Project was not found") from exc
+        if not isinstance(nodes, list):
+            raise TrackerAdapterError("GitHub Projects returned invalid items")
+
+        tickets: list[TrackerTicket] = []
+        for node in nodes:
+            if not isinstance(node, dict):
+                continue
+            content = node.get("content")
+            if not isinstance(content, dict):
+                continue
+            status = node.get("status")
+            tickets.append(
+                TrackerTicket(
+                    id=str(content.get("number") or node.get("id") or ""),
+                    title=str(content.get("title") or "Untitled"),
+                    status=str(status.get("name") if isinstance(status, dict) else "No status"),
+                    url=str(content["url"]) if content.get("url") else None,
+                )
+            )
+        return tickets
+
+
+class JiraTrackerAdapter(_HttpTrackerAdapter):
+    """Read Jira project issues through the REST API v3 enhanced search."""
+
+    async def fetch_tickets(
+        self,
+        *,
+        base_url: str,
+        external_ref: str,
+        token: str,
+    ) -> list[TrackerTicket]:
+        escaped_ref = external_ref.replace("\\", "\\\\").replace('"', '\\"')
+        payload = await self._request_json(
+            "GET",
+            f"{base_url.rstrip('/')}/rest/api/3/search/jql",
+            headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+            params={
+                "jql": f'project = "{escaped_ref}" ORDER BY updated DESC',
+                "fields": "summary,status",
+                "maxResults": 100,
+            },
+        )
+        issues = payload.get("issues")
+        if not isinstance(issues, list):
+            raise TrackerAdapterError("Jira returned invalid issues")
+
+        tickets: list[TrackerTicket] = []
+        for issue in issues:
+            if not isinstance(issue, dict):
+                continue
+            fields = issue.get("fields")
+            if not isinstance(fields, dict):
+                continue
+            key = str(issue.get("key") or issue.get("id") or "")
+            status = fields.get("status")
+            tickets.append(
+                TrackerTicket(
+                    id=key,
+                    title=str(fields.get("summary") or "Untitled"),
+                    status=str(status.get("name") if isinstance(status, dict) else "Unknown"),
+                    url=f"{base_url.rstrip('/')}/browse/{quote(key, safe='-')}",
+                )
+            )
+        return tickets
+
+
+class AzureDevOpsTrackerAdapter(_HttpTrackerAdapter):
+    """Read Azure DevOps work items using WIQL 7.1."""
+
+    async def fetch_tickets(
+        self,
+        *,
+        base_url: str,
+        external_ref: str,
+        token: str,
+    ) -> list[TrackerTicket]:
+        auth = base64.b64encode(f":{token}".encode()).decode()
+        headers = {
+            "Authorization": f"Basic {auth}",
+            "Accept": "application/json",
+        }
+        project_url = f"{base_url.rstrip('/')}/{quote(external_ref, safe='')}"
+        query_result = await self._request_json(
+            "POST",
+            f"{project_url}/_apis/wit/wiql",
+            headers=headers,
+            params={"api-version": "7.1", "$top": 100},
+            json={
+                "query": (
+                    "SELECT [System.Id], [System.Title], [System.State] "
+                    "FROM WorkItems ORDER BY [System.ChangedDate] DESC"
+                )
+            },
+        )
+        references = query_result.get("workItems")
+        if not isinstance(references, list):
+            raise TrackerAdapterError("Azure DevOps returned invalid work item references")
+        ids = [str(item["id"]) for item in references if isinstance(item, dict) and item.get("id") is not None]
+        if not ids:
+            return []
+
+        item_result = await self._request_json(
+            "GET",
+            f"{project_url}/_apis/wit/workitems",
+            headers=headers,
+            params={
+                "ids": ",".join(ids),
+                "fields": "System.Id,System.Title,System.State",
+                "api-version": "7.1",
+            },
+        )
+        items = item_result.get("value")
+        if not isinstance(items, list):
+            raise TrackerAdapterError("Azure DevOps returned invalid work items")
+
+        tickets: list[TrackerTicket] = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            fields = item.get("fields")
+            if not isinstance(fields, dict):
+                continue
+            tickets.append(
+                TrackerTicket(
+                    id=str(item.get("id") or ""),
+                    title=str(fields.get("System.Title") or "Untitled"),
+                    status=str(fields.get("System.State") or "Unknown"),
+                    url=str(item["url"]) if item.get("url") else None,
+                )
+            )
+        return tickets
+
+
+def build_tracker_adapters(client: httpx.AsyncClient) -> dict[str, TrackerAdapterInterface]:
+    return {
+        "github": GitHubProjectsTrackerAdapter(client),
+        "jira": JiraTrackerAdapter(client),
+        "azure_devops": AzureDevOpsTrackerAdapter(client),
+    }

--- a/backend/services/tracker_sync_service.py
+++ b/backend/services/tracker_sync_service.py
@@ -19,9 +19,8 @@ from backend.services.tracker_adapter import (
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-    from backend.config import CPLConfig
-
 log = structlog.get_logger()
+TRACKER_POLL_INTERVAL_SECONDS = 60.0
 
 
 class TrackerLinkNotFoundError(Exception):
@@ -37,11 +36,9 @@ class TrackerSyncService:
         self,
         *,
         session_factory: async_sessionmaker[AsyncSession],
-        config: CPLConfig,
         adapters: dict[str, TrackerAdapterInterface] | None = None,
     ) -> None:
         self._session_factory = session_factory
-        self._config = config
         self._client: httpx.AsyncClient | None = None
         if adapters is None:
             self._client = httpx.AsyncClient(
@@ -68,9 +65,6 @@ class TrackerSyncService:
         if self._client is not None:
             await self._client.aclose()
             self._client = None
-
-    def notify_interval_changed(self) -> None:
-        self._wake.set()
 
     async def refresh_all(self) -> None:
         async with self._session_factory() as session:
@@ -153,10 +147,14 @@ class TrackerSyncService:
 
     async def _poll_loop(self) -> None:
         while not self._stopping:
-            interval = max(float(self._config.tracker.poll_interval_seconds), 0.001)
             try:
-                await asyncio.wait_for(self._wake.wait(), timeout=interval)
+                await asyncio.wait_for(
+                    self._wake.wait(),
+                    timeout=TRACKER_POLL_INTERVAL_SECONDS,
+                )
             except TimeoutError:
+                if self._stopping:
+                    break
                 await self.refresh_all()
             else:
                 self._wake.clear()

--- a/backend/services/tracker_sync_service.py
+++ b/backend/services/tracker_sync_service.py
@@ -1,0 +1,162 @@
+"""Scheduled and manual tracker synchronization (Story 3.3, AD-7)."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+import httpx
+import structlog
+
+from backend.persistence.credential_repo import CredentialRepository
+from backend.persistence.tracker_summary_repo import TrackerSummaryRepository
+from backend.services.tracker_adapter import (
+    TrackerAdapterError,
+    TrackerAdapterInterface,
+    build_tracker_adapters,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    from backend.config import CPLConfig
+
+log = structlog.get_logger()
+
+
+class TrackerLinkNotFoundError(Exception):
+    """Raised when a TrackerLink is not part of the requested Project."""
+
+
+class TrackerSyncError(Exception):
+    """Raised when a requested TrackerLink cannot be synchronized."""
+
+
+class TrackerSyncService:
+    def __init__(
+        self,
+        *,
+        session_factory: async_sessionmaker[AsyncSession],
+        config: CPLConfig,
+        adapters: dict[str, TrackerAdapterInterface] | None = None,
+    ) -> None:
+        self._session_factory = session_factory
+        self._config = config
+        self._client: httpx.AsyncClient | None = None
+        if adapters is None:
+            self._client = httpx.AsyncClient(
+                timeout=httpx.Timeout(connect=10.0, read=30.0, write=15.0, pool=5.0)
+            )
+            adapters = build_tracker_adapters(self._client)
+        self._adapters = adapters
+        self._wake = asyncio.Event()
+        self._stopping = False
+        self._task: asyncio.Task[None] | None = None
+        self._link_locks: dict[str, asyncio.Lock] = {}
+
+    def start(self) -> None:
+        if self._task is None or self._task.done():
+            self._stopping = False
+            self._task = asyncio.create_task(self._poll_loop(), name="tracker-sync")
+
+    async def stop(self) -> None:
+        self._stopping = True
+        self._wake.set()
+        if self._task is not None:
+            await self._task
+            self._task = None
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    def notify_interval_changed(self) -> None:
+        self._wake.set()
+
+    async def refresh_all(self) -> None:
+        async with self._session_factory() as session:
+            targets = await TrackerSummaryRepository(session).list_targets()
+        for target in targets:
+            try:
+                await self.refresh_link(
+                    project_id=target["project_id"],
+                    link_id=target["link_id"],
+                )
+            except TrackerSyncError:
+                log.warning(
+                    "tracker_sync.link_failed",
+                    tracker_link_id=target["link_id"],
+                    project_id=target["project_id"],
+                )
+
+    async def refresh_link(self, *, project_id: str, link_id: str) -> dict[str, Any]:
+        lock = self._link_locks.setdefault(link_id, asyncio.Lock())
+        async with lock:
+            async with self._session_factory() as session:
+                target = await TrackerSummaryRepository(session).get_target(
+                    project_id=project_id,
+                    link_id=link_id,
+                )
+                if target is None:
+                    raise TrackerLinkNotFoundError(
+                        f"TrackerLink '{link_id}' does not exist in Project '{project_id}'"
+                    )
+                token = await CredentialRepository(session).resolve_secret(target["credential_id"])
+
+            adapter = self._adapters.get(target["provider"])
+            if token is None:
+                return await self._fail(link_id, "Tracker credential could not be resolved")
+            if adapter is None:
+                return await self._fail(link_id, f"Unsupported tracker provider: {target['provider']}")
+
+            try:
+                tickets = await adapter.fetch_tickets(
+                    base_url=target["base_url"],
+                    external_ref=target["external_ref"],
+                    token=token,
+                )
+            except TrackerAdapterError as exc:
+                return await self._fail(link_id, str(exc))
+            except Exception as exc:
+                log.exception(
+                    "tracker_sync.unexpected_provider_error",
+                    tracker_link_id=link_id,
+                    provider=target["provider"],
+                )
+                return await self._fail(link_id, "Tracker provider request failed", cause=exc)
+
+            async with self._session_factory() as session:
+                summary = await TrackerSummaryRepository(session).record_success(link_id, tickets)
+                await session.commit()
+            log.info(
+                "tracker_sync.completed",
+                tracker_link_id=link_id,
+                project_id=project_id,
+                provider=target["provider"],
+                ticket_count=len(tickets),
+            )
+            return summary
+
+    async def _fail(
+        self,
+        link_id: str,
+        message: str,
+        *,
+        cause: Exception | None = None,
+    ) -> dict[str, Any]:
+        async with self._session_factory() as session:
+            await TrackerSummaryRepository(session).record_error(link_id, message)
+            await session.commit()
+        error = TrackerSyncError(message)
+        if cause is not None:
+            raise error from cause
+        raise error
+
+    async def _poll_loop(self) -> None:
+        while not self._stopping:
+            interval = max(float(self._config.tracker.poll_interval_seconds), 0.001)
+            try:
+                await asyncio.wait_for(self._wake.wait(), timeout=interval)
+            except TimeoutError:
+                await self.refresh_all()
+            else:
+                self._wake.clear()

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -45,6 +45,7 @@ from backend.services.runtime import RuntimeService
 from backend.services.sharing.share_service import ShareService
 from backend.services.sidecar.session import SidecarSessionManager
 from backend.services.terminal.terminal_service import TerminalService
+from backend.services.tracker_sync_service import TrackerSyncService
 
 # ---------------------------------------------------------------------------
 # Database
@@ -162,6 +163,11 @@ def mock_coderecon_service() -> AsyncMock:
 
 
 @pytest.fixture
+def mock_tracker_sync_service() -> AsyncMock:
+    return AsyncMock(spec=TrackerSyncService)
+
+
+@pytest.fixture
 def voice_max_bytes_value() -> int:
     """Default voice max bytes — override in specific test classes for smaller limits."""
     return 10 * 1024 * 1024
@@ -195,6 +201,7 @@ async def app(
     mock_utility_session: AsyncMock,
     mock_terminal_service: Mock,
     mock_coderecon_service: AsyncMock,
+    mock_tracker_sync_service: AsyncMock,
     voice_max_bytes_value: int,
     monkeypatch: pytest.MonkeyPatch,
 ) -> AsyncGenerator[FastAPI, None]:
@@ -261,6 +268,7 @@ async def app(
             TerminalService: mock_terminal_service,
             CodeReconService: mock_coderecon_service,
             IngestService: AsyncMock(spec=IngestService),
+            TrackerSyncService: mock_tracker_sync_service,
         },
     )
     setup_dishka(container, application)

--- a/backend/tests/integration/test_api_settings.py
+++ b/backend/tests/integration/test_api_settings.py
@@ -62,6 +62,7 @@ class TestGetSettings:
             "maxTurns",
             "verifyPrompt",
             "selfReviewPrompt",
+            "trackerPollIntervalSeconds",
         }
         assert expected_keys.issubset(data.keys())
 
@@ -75,6 +76,7 @@ class TestGetSettings:
         assert isinstance(data["cleanupWorktree"], bool)
         assert isinstance(data["artifactRetentionDays"], int)
         assert isinstance(data["verify"], bool)
+        assert data["trackerPollIntervalSeconds"] == 300
 
     @pytest.mark.asyncio
     async def test_returns_effective_default_verification_prompts(self, client: AsyncClient, app: FastAPI) -> None:
@@ -134,6 +136,23 @@ class TestUpdateSettings:
         monkeypatch.setattr("backend.api.settings.save_config", lambda config, path=None: None)
 
         resp = await client.put("/api/settings", json={"maxConcurrentJobs": 0})
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_update_tracker_poll_interval(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("backend.api.settings.save_config", lambda config, path=None: None)
+
+        resp = await client.put("/api/settings", json={"trackerPollIntervalSeconds": 45})
+
+        assert resp.status_code == 200
+        assert resp.json()["trackerPollIntervalSeconds"] == 45
+
+    @pytest.mark.asyncio
+    async def test_tracker_poll_interval_out_of_range_returns_422(self, client: AsyncClient) -> None:
+        resp = await client.put("/api/settings", json={"trackerPollIntervalSeconds": 4})
+
         assert resp.status_code == 422
 
 

--- a/backend/tests/integration/test_api_settings.py
+++ b/backend/tests/integration/test_api_settings.py
@@ -62,9 +62,9 @@ class TestGetSettings:
             "maxTurns",
             "verifyPrompt",
             "selfReviewPrompt",
-            "trackerPollIntervalSeconds",
         }
         assert expected_keys.issubset(data.keys())
+        assert "trackerPollIntervalSeconds" not in data
 
     @pytest.mark.asyncio
     async def test_default_values_have_correct_types(self, client: AsyncClient, app: FastAPI) -> None:
@@ -76,7 +76,6 @@ class TestGetSettings:
         assert isinstance(data["cleanupWorktree"], bool)
         assert isinstance(data["artifactRetentionDays"], int)
         assert isinstance(data["verify"], bool)
-        assert data["trackerPollIntervalSeconds"] == 300
 
     @pytest.mark.asyncio
     async def test_returns_effective_default_verification_prompts(self, client: AsyncClient, app: FastAPI) -> None:
@@ -139,22 +138,9 @@ class TestUpdateSettings:
         assert resp.status_code == 422
 
     @pytest.mark.asyncio
-    async def test_update_tracker_poll_interval(
-        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setattr("backend.api.settings.save_config", lambda config, path=None: None)
-
-        resp = await client.put("/api/settings", json={"trackerPollIntervalSeconds": 45})
-
-        assert resp.status_code == 200
-        assert resp.json()["trackerPollIntervalSeconds"] == 45
-
-    @pytest.mark.asyncio
-    async def test_tracker_poll_interval_out_of_range_returns_422(self, client: AsyncClient) -> None:
-        resp = await client.put("/api/settings", json={"trackerPollIntervalSeconds": 4})
-
+    async def test_retired_tracker_interval_is_rejected(self, client: AsyncClient) -> None:
+        resp = await client.put("/api/settings", json={"trackerPollIntervalSeconds": 5})
         assert resp.status_code == 422
-
 
 # ---------------------------------------------------------------------------
 # Repo Endpoints

--- a/backend/tests/integration/test_api_tracker_links.py
+++ b/backend/tests/integration/test_api_tracker_links.py
@@ -15,6 +15,7 @@ from backend.services.credentials import encryption
 
 if TYPE_CHECKING:
     from pathlib import Path
+    from unittest.mock import AsyncMock
 
     from httpx import AsyncClient
     from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -172,3 +173,64 @@ class TestListTrackerLinks:
 
         resp = await client.get("/api/projects/proj-2/tracker-links")
         assert resp.json() == {"trackerLinks": []}
+
+    @pytest.mark.asyncio
+    async def test_list_includes_persisted_summary_without_secret_material(
+        self,
+        client: AsyncClient,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        from backend.persistence.tracker_summary_repo import TrackerSummaryRepository
+        from backend.services.tracker_adapter import TrackerTicket
+
+        await _seed_project(session_factory)
+        credential_id = await _create_credential(client)
+        created = await client.post(
+            "/api/projects/proj-1/tracker-links",
+            json={"credentialId": credential_id, "externalRef": "acme/7"},
+        )
+        link_id = created.json()["id"]
+        async with session_factory() as session:
+            await TrackerSummaryRepository(session).record_success(
+                link_id,
+                [TrackerTicket(id="42", title="Ship it", status="Ready", url=None)],
+            )
+            await session.commit()
+
+        resp = await client.get("/api/projects/proj-1/tracker-links")
+
+        assert resp.status_code == 200
+        summary = resp.json()["trackerLinks"][0]["summary"]
+        assert summary["tickets"][0]["title"] == "Ship it"
+        assert "secret" not in str(resp.json()).lower()
+        assert "encrypted" not in str(resp.json()).lower()
+
+
+class TestRefreshTrackerLink:
+    @pytest.mark.asyncio
+    async def test_manual_refresh_delegates_to_sync_service(
+        self,
+        client: AsyncClient,
+        mock_tracker_sync_service: AsyncMock,
+    ) -> None:
+        mock_tracker_sync_service.refresh_link.return_value = {
+            "tracker_link_id": "link-1",
+            "tickets": [{"id": "1", "title": "Ticket", "status": "Open", "url": None}],
+            "last_synced_at": "2026-08-10T12:00:00+00:00",
+            "last_error": None,
+        }
+
+        resp = await client.post("/api/projects/proj-1/tracker-links/link-1/refresh")
+
+        assert resp.status_code == 200
+        assert resp.json()["tickets"][0]["status"] == "Open"
+        mock_tracker_sync_service.refresh_link.assert_awaited_once_with(
+            project_id="proj-1",
+            link_id="link-1",
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_inbound_webhook_route_exists(self, client: AsyncClient) -> None:
+        resp = await client.post("/api/tracker-webhooks/github", json={})
+
+        assert resp.status_code == 404

--- a/backend/tests/unit/test_config.py
+++ b/backend/tests/unit/test_config.py
@@ -16,7 +16,6 @@ def test_load_config_returns_defaults_when_missing(tmp_path: Path) -> None:
     assert config.server.host == "127.0.0.1"
     assert config.server.port == 8080
     assert config.runtime.max_concurrent_jobs == 2
-    assert config.tracker.poll_interval_seconds == 300
     assert config.repos == []
 
 
@@ -31,9 +30,6 @@ server:
 runtime:
   max_concurrent_jobs: 4
 
-tracker:
-  poll_interval_seconds: 45
-
 repos:
   - /repos/a
   - /repos/b
@@ -43,7 +39,6 @@ repos:
     assert config.server.host == "0.0.0.0"
     assert config.server.port == 9090
     assert config.runtime.max_concurrent_jobs == 4
-    assert config.tracker.poll_interval_seconds == 45
     assert config.repos == ["/repos/a", "/repos/b"]
 
 
@@ -81,19 +76,17 @@ def test_init_config_roundtrips(tmp_path: Path) -> None:
     assert config.server.port == 8080
     assert config.runtime.worktrees_dirname == ".codeplane-worktrees"
     assert config.retention.artifact_retention_days == 30
-    assert config.tracker.poll_interval_seconds == 300
-
-
-def test_tracker_interval_roundtrip(tmp_path: Path) -> None:
+def test_load_config_removes_retired_tracker_interval(tmp_path: Path) -> None:
     cfg_path = tmp_path / "config.yaml"
-    cfg_path.write_text("tracker:\n  poll_interval_seconds: 90\n")
+    cfg_path.write_text(
+        "telemetry:\n"
+        "  instance_id: existing-instance\n"
+        "tracker:\n"
+        "  poll_interval_seconds: 90\n"
+    )
     config = load_config(cfg_path)
-    assert config.tracker.poll_interval_seconds == 90
-
-    config.tracker.poll_interval_seconds = 120
-    save_config(config, cfg_path)
-
-    assert load_config(cfg_path).tracker.poll_interval_seconds == 120
+    assert not hasattr(config, "tracker")
+    assert "tracker" not in cfg_path.read_text()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_config.py
+++ b/backend/tests/unit/test_config.py
@@ -16,6 +16,7 @@ def test_load_config_returns_defaults_when_missing(tmp_path: Path) -> None:
     assert config.server.host == "127.0.0.1"
     assert config.server.port == 8080
     assert config.runtime.max_concurrent_jobs == 2
+    assert config.tracker.poll_interval_seconds == 300
     assert config.repos == []
 
 
@@ -30,6 +31,9 @@ server:
 runtime:
   max_concurrent_jobs: 4
 
+tracker:
+  poll_interval_seconds: 45
+
 repos:
   - /repos/a
   - /repos/b
@@ -39,6 +43,7 @@ repos:
     assert config.server.host == "0.0.0.0"
     assert config.server.port == 9090
     assert config.runtime.max_concurrent_jobs == 4
+    assert config.tracker.poll_interval_seconds == 45
     assert config.repos == ["/repos/a", "/repos/b"]
 
 
@@ -76,6 +81,19 @@ def test_init_config_roundtrips(tmp_path: Path) -> None:
     assert config.server.port == 8080
     assert config.runtime.worktrees_dirname == ".codeplane-worktrees"
     assert config.retention.artifact_retention_days == 30
+    assert config.tracker.poll_interval_seconds == 300
+
+
+def test_tracker_interval_roundtrip(tmp_path: Path) -> None:
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text("tracker:\n  poll_interval_seconds: 90\n")
+    config = load_config(cfg_path)
+    assert config.tracker.poll_interval_seconds == 90
+
+    config.tracker.poll_interval_seconds = 120
+    save_config(config, cfg_path)
+
+    assert load_config(cfg_path).tracker.poll_interval_seconds == 120
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_tracker_adapter.py
+++ b/backend/tests/unit/test_tracker_adapter.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from backend.services.tracker_adapter import (
+    AzureDevOpsTrackerAdapter,
+    GitHubProjectsTrackerAdapter,
+    JiraTrackerAdapter,
+    TrackerAdapterError,
+    TrackerTicket,
+)
+
+
+@pytest.mark.asyncio
+async def test_github_projects_normalizes_issue_and_draft_items() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/graphql"
+        assert request.headers["authorization"] == "Bearer secret"
+        payload = json.loads(request.content)
+        assert payload["variables"] == {"owner": "acme", "number": 7}
+        return httpx.Response(
+            200,
+            json={
+                "data": {
+                    "organization": {
+                        "projectV2": {
+                            "items": {
+                                "nodes": [
+                                    {
+                                        "id": "item-1",
+                                        "content": {
+                                            "number": 12,
+                                            "title": "Fix checkout",
+                                            "url": "https://github.com/acme/shop/issues/12",
+                                        },
+                                        "status": {"name": "In progress"},
+                                    },
+                                    {
+                                        "id": "item-2",
+                                        "content": {"title": "Draft card"},
+                                        "status": None,
+                                    },
+                                ]
+                            }
+                        }
+                    },
+                    "user": None,
+                }
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler), base_url="https://api.github.com") as client:
+        tickets = await GitHubProjectsTrackerAdapter(client).fetch_tickets(
+            base_url="https://api.github.com",
+            external_ref="acme/7",
+            token="secret",
+        )
+
+    assert tickets == [
+        TrackerTicket(
+            id="12",
+            title="Fix checkout",
+            status="In progress",
+            url="https://github.com/acme/shop/issues/12",
+        ),
+        TrackerTicket(id="item-2", title="Draft card", status="No status", url=None),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_github_projects_rejects_invalid_external_ref() -> None:
+    async with httpx.AsyncClient() as client:
+        with pytest.raises(TrackerAdapterError, match="owner/project-number"):
+            await GitHubProjectsTrackerAdapter(client).fetch_tickets(
+                base_url="https://api.github.com",
+                external_ref="not-a-project",
+                token="secret",
+            )
+
+
+@pytest.mark.asyncio
+async def test_jira_normalizes_issue_search_response() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/rest/api/3/search/jql"
+        assert request.headers["authorization"] == "Bearer secret"
+        assert 'project = "PAY"' in request.url.params["jql"]
+        return httpx.Response(
+            200,
+            json={
+                "issues": [
+                    {
+                        "key": "PAY-42",
+                        "fields": {
+                            "summary": "Retry settlement",
+                            "status": {"name": "To Do"},
+                        },
+                    }
+                ]
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        tickets = await JiraTrackerAdapter(client).fetch_tickets(
+            base_url="https://acme.atlassian.net/",
+            external_ref="PAY",
+            token="secret",
+        )
+
+    assert tickets == [
+        TrackerTicket(
+            id="PAY-42",
+            title="Retry settlement",
+            status="To Do",
+            url="https://acme.atlassian.net/browse/PAY-42",
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_azure_devops_queries_then_fetches_work_items() -> None:
+    calls: list[str] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request.url.path)
+        assert request.headers["authorization"].startswith("Basic ")
+        if request.url.path.endswith("/_apis/wit/wiql"):
+            return httpx.Response(200, json={"workItems": [{"id": 5}, {"id": 9}]})
+        assert request.url.path.endswith("/_apis/wit/workitems")
+        assert request.url.params["ids"] == "5,9"
+        return httpx.Response(
+            200,
+            json={
+                "value": [
+                    {
+                        "id": 5,
+                        "url": "https://dev.azure.com/acme/_apis/wit/workItems/5",
+                        "fields": {"System.Title": "Ship API", "System.State": "Active"},
+                    },
+                    {
+                        "id": 9,
+                        "url": "https://dev.azure.com/acme/_apis/wit/workItems/9",
+                        "fields": {"System.Title": "Write docs", "System.State": "New"},
+                    },
+                ]
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        tickets = await AzureDevOpsTrackerAdapter(client).fetch_tickets(
+            base_url="https://dev.azure.com/acme",
+            external_ref="Payments",
+            token="secret",
+        )
+
+    assert calls == ["/acme/Payments/_apis/wit/wiql", "/acme/Payments/_apis/wit/workitems"]
+    assert [ticket.status for ticket in tickets] == ["Active", "New"]
+
+
+@pytest.mark.asyncio
+async def test_adapter_wraps_http_errors_without_exposing_token() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, text="secret rejected")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(TrackerAdapterError) as exc_info:
+            await JiraTrackerAdapter(client).fetch_tickets(
+                base_url="https://acme.atlassian.net",
+                external_ref="PAY",
+                token="secret",
+            )
+
+    assert "secret" not in str(exc_info.value)

--- a/backend/tests/unit/test_tracker_sync_service.py
+++ b/backend/tests/unit/test_tracker_sync_service.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker, create_async_engine
+
+from backend.config import CPLConfig
+from backend.models.db import Base, CredentialRow, ProjectRow, TrackerLinkRow
+from backend.persistence.credential_repo import CredentialRepository
+from backend.persistence.tracker_summary_repo import TrackerSummaryRepository
+from backend.services.tracker_adapter import TrackerAdapterError, TrackerTicket
+from backend.services.tracker_sync_service import TrackerLinkNotFoundError, TrackerSyncService
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@pytest.fixture
+async def engine() -> AsyncGenerator[AsyncEngine, None]:
+    value = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with value.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    yield value
+    await value.dispose()
+
+
+@pytest.fixture
+async def session_factory(engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:
+    return async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_link(
+    session_factory: async_sessionmaker[AsyncSession],
+    *,
+    project_id: str,
+    link_id: str,
+    external_ref: str,
+) -> None:
+    now = datetime.now(UTC)
+    async with session_factory() as session:
+        if await session.get(ProjectRow, project_id) is None:
+            session.add(
+                ProjectRow(
+                    id=project_id,
+                    name=project_id,
+                    repo_paths="[]",
+                    created_at=now,
+                    updated_at=now,
+                )
+            )
+        credential_id = f"cred-{link_id}"
+        session.add(
+            CredentialRow(
+                id=credential_id,
+                provider="github",
+                label=credential_id,
+                base_url="https://api.github.com",
+                encrypted_secret="encrypted",
+                created_at=now.isoformat(),
+            )
+        )
+        session.add(
+            TrackerLinkRow(
+                id=link_id,
+                project_id=project_id,
+                credential_id=credential_id,
+                external_ref=external_ref,
+                created_at=now.isoformat(),
+            )
+        )
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_summary_repository_upserts_success_and_error(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    await _seed_link(session_factory, project_id="proj-1", link_id="link-1", external_ref="acme/1")
+    async with session_factory() as session:
+        repo = TrackerSummaryRepository(session)
+        saved = await repo.record_success(
+            "link-1",
+            [TrackerTicket(id="1", title="Ticket", status="Open", url=None)],
+        )
+        await session.commit()
+
+    assert saved["tickets"][0]["title"] == "Ticket"
+    assert saved["last_error"] is None
+
+    async with session_factory() as session:
+        repo = TrackerSummaryRepository(session)
+        failed = await repo.record_error("link-1", "provider unavailable")
+        await session.commit()
+
+    assert failed["tickets"][0]["title"] == "Ticket"
+    assert failed["last_error"] == "provider unavailable"
+    assert failed["last_synced_at"] == saved["last_synced_at"]
+
+
+@pytest.mark.asyncio
+async def test_refresh_link_is_project_scoped(
+    session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await _seed_link(session_factory, project_id="proj-1", link_id="link-1", external_ref="acme/1")
+    monkeypatch.setattr(CredentialRepository, "resolve_secret", AsyncMock(return_value="token"))
+    adapter = AsyncMock()
+    service = TrackerSyncService(
+        session_factory=session_factory,
+        config=CPLConfig(),
+        adapters={"github": adapter},
+    )
+
+    with pytest.raises(TrackerLinkNotFoundError):
+        await service.refresh_link(project_id="proj-2", link_id="link-1")
+
+    adapter.fetch_tickets.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_refresh_all_isolates_link_failures(
+    session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await _seed_link(session_factory, project_id="proj-1", link_id="link-1", external_ref="fail")
+    await _seed_link(session_factory, project_id="proj-1", link_id="link-2", external_ref="acme/2")
+    monkeypatch.setattr(CredentialRepository, "resolve_secret", AsyncMock(return_value="token"))
+
+    async def fetch_tickets(*, external_ref: str, **_: str) -> list[TrackerTicket]:
+        if external_ref == "fail":
+            raise TrackerAdapterError("provider unavailable")
+        return [TrackerTicket(id="2", title="Second", status="Open", url=None)]
+
+    adapter = AsyncMock()
+    adapter.fetch_tickets.side_effect = fetch_tickets
+    service = TrackerSyncService(
+        session_factory=session_factory,
+        config=CPLConfig(),
+        adapters={"github": adapter},
+    )
+
+    await service.refresh_all()
+
+    async with session_factory() as session:
+        repo = TrackerSummaryRepository(session)
+        failed = await repo.get("link-1")
+        succeeded = await repo.get("link-2")
+    assert failed is not None and failed["last_error"] == "provider unavailable"
+    assert succeeded is not None and succeeded["tickets"][0]["title"] == "Second"
+
+
+@pytest.mark.asyncio
+async def test_interval_change_wakes_running_poller(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    config = CPLConfig()
+    config.tracker.poll_interval_seconds = 3600
+    service = TrackerSyncService(
+        session_factory=session_factory,
+        config=config,
+        adapters={},
+    )
+    service.refresh_all = AsyncMock()
+    service.start()
+
+    config.tracker.poll_interval_seconds = 0.01
+    service.notify_interval_changed()
+    for _ in range(50):
+        if service.refresh_all.await_count:
+            break
+        await asyncio.sleep(0.01)
+    await service.stop()
+
+    service.refresh_all.assert_awaited()

--- a/backend/tests/unit/test_tracker_sync_service.py
+++ b/backend/tests/unit/test_tracker_sync_service.py
@@ -8,12 +8,15 @@ from unittest.mock import AsyncMock
 import pytest
 from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker, create_async_engine
 
-from backend.config import CPLConfig
 from backend.models.db import Base, CredentialRow, ProjectRow, TrackerLinkRow
 from backend.persistence.credential_repo import CredentialRepository
 from backend.persistence.tracker_summary_repo import TrackerSummaryRepository
 from backend.services.tracker_adapter import TrackerAdapterError, TrackerTicket
-from backend.services.tracker_sync_service import TrackerLinkNotFoundError, TrackerSyncService
+from backend.services.tracker_sync_service import (
+    TRACKER_POLL_INTERVAL_SECONDS,
+    TrackerLinkNotFoundError,
+    TrackerSyncService,
+)
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
@@ -113,7 +116,6 @@ async def test_refresh_link_is_project_scoped(
     adapter = AsyncMock()
     service = TrackerSyncService(
         session_factory=session_factory,
-        config=CPLConfig(),
         adapters={"github": adapter},
     )
 
@@ -141,7 +143,6 @@ async def test_refresh_all_isolates_link_failures(
     adapter.fetch_tickets.side_effect = fetch_tickets
     service = TrackerSyncService(
         session_factory=session_factory,
-        config=CPLConfig(),
         adapters={"github": adapter},
     )
 
@@ -156,25 +157,43 @@ async def test_refresh_all_isolates_link_failures(
 
 
 @pytest.mark.asyncio
-async def test_interval_change_wakes_running_poller(
+async def test_poller_uses_fixed_sixty_second_cadence(
     session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    config = CPLConfig()
-    config.tracker.poll_interval_seconds = 3600
     service = TrackerSyncService(
         session_factory=session_factory,
-        config=config,
+        adapters={},
+    )
+    observed_timeout: float | None = None
+
+    async def capture_timeout(awaitable: object, *, timeout: float) -> None:
+        nonlocal observed_timeout
+        observed_timeout = timeout
+        service._stopping = True
+        service._wake.set()
+        await awaitable  # type: ignore[misc]
+
+    monkeypatch.setattr(asyncio, "wait_for", capture_timeout)
+
+    await service._poll_loop()
+
+    assert TRACKER_POLL_INTERVAL_SECONDS == 60.0
+    assert observed_timeout == 60.0
+
+
+@pytest.mark.asyncio
+async def test_stop_wakes_fixed_cadence_wait_promptly(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    service = TrackerSyncService(
+        session_factory=session_factory,
         adapters={},
     )
     service.refresh_all = AsyncMock()
     service.start()
+    await asyncio.sleep(0)
 
-    config.tracker.poll_interval_seconds = 0.01
-    service.notify_interval_changed()
-    for _ in range(50):
-        if service.refresh_all.await_count:
-            break
-        await asyncio.sleep(0.01)
-    await service.stop()
+    await asyncio.wait_for(service.stop(), timeout=2.0)
 
-    service.refresh_all.assert_awaited()
+    service.refresh_all.assert_not_awaited()

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,9 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest",
     "test:coverage": "vitest run --coverage",
-    "generate:api": "openapi-typescript http://localhost:8080/openapi.json -o src/api/schema.d.ts"
+    "generate:api": "openapi-typescript http://localhost:8080/openapi.json -o src/api/schema.d.ts",
+    "lint:e2e:tracker": "eslint tracker-e2e/tracker-sync.spec.ts playwright.tracker.config.ts",
+    "test:e2e:tracker": "npm run build && playwright test --config=playwright.tracker.config.ts"
   },
   "dependencies": {
     "@monaco-editor/react": "^4.6.0",

--- a/frontend/playwright.tracker.config.ts
+++ b/frontend/playwright.tracker.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from "@playwright/test";
+import process from "node:process";
+
+export default defineConfig({
+  testDir: "./tracker-e2e",
+  testMatch: "tracker-sync.spec.ts",
+  timeout: 150_000,
+  retries: 0,
+  workers: 1,
+  fullyParallel: false,
+  use: {
+    baseURL:
+      process.env.CODEPLANE_TRACKER_E2E_BASE_URL ??
+      "http://127.0.0.1:18765",
+    headless: true,
+  },
+  projects: [
+    {
+      name: "tracker-chromium",
+      use: { browserName: "chromium" },
+    },
+  ],
+});

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -642,6 +642,54 @@ export function deleteCredential(credentialId: string): Promise<void> {
   });
 }
 
+// --- Project tracker state (Story 3.3) ---
+
+export interface Project {
+  id: string;
+  name: string;
+  repoPaths: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface TrackerTicket {
+  id: string;
+  title: string;
+  status: string;
+  url: string | null;
+}
+
+export interface TrackerSummary {
+  trackerLinkId: string;
+  tickets: TrackerTicket[];
+  lastSyncedAt: string | null;
+  lastError: string | null;
+}
+
+export interface TrackerLink {
+  id: string;
+  projectId: string;
+  credentialId: string;
+  externalRef: string;
+  createdAt: string;
+  summary: TrackerSummary | null;
+}
+
+export function fetchProjects(): Promise<{ items: Project[] }> {
+  return request("/settings/projects");
+}
+
+export function fetchTrackerLinks(projectId: string): Promise<{ trackerLinks: TrackerLink[] }> {
+  return request(`/projects/${encodeURIComponent(projectId)}/tracker-links`);
+}
+
+export function refreshTrackerLink(projectId: string, linkId: string): Promise<TrackerSummary> {
+  return request(
+    `/projects/${encodeURIComponent(projectId)}/tracker-links/${encodeURIComponent(linkId)}/refresh`,
+    { method: "POST" },
+  );
+}
+
 // --- Operator Messages ---
 
 export function sendOperatorMessage(

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -21,6 +21,8 @@ import type {
   ProjectListSummaryResponse,
   ProjectListResponse,
   TaskLinkListResponse,
+  TrackerLinkListResponse,
+  TrackerSummaryResponse,
   SDKListResponse,
   Settings,
   SidecarTemplate,
@@ -644,46 +646,11 @@ export function deleteCredential(credentialId: string): Promise<void> {
 
 // --- Project tracker state (Story 3.3) ---
 
-export interface Project {
-  id: string;
-  name: string;
-  repoPaths: string[];
-  createdAt: string;
-  updatedAt: string;
-}
-
-export interface TrackerTicket {
-  id: string;
-  title: string;
-  status: string;
-  url: string | null;
-}
-
-export interface TrackerSummary {
-  trackerLinkId: string;
-  tickets: TrackerTicket[];
-  lastSyncedAt: string | null;
-  lastError: string | null;
-}
-
-export interface TrackerLink {
-  id: string;
-  projectId: string;
-  credentialId: string;
-  externalRef: string;
-  createdAt: string;
-  summary: TrackerSummary | null;
-}
-
-export function fetchProjects(): Promise<{ items: Project[] }> {
-  return request("/settings/projects");
-}
-
-export function fetchTrackerLinks(projectId: string): Promise<{ trackerLinks: TrackerLink[] }> {
+export function fetchTrackerLinks(projectId: string): Promise<TrackerLinkListResponse> {
   return request(`/projects/${encodeURIComponent(projectId)}/tracker-links`);
 }
 
-export function refreshTrackerLink(projectId: string, linkId: string): Promise<TrackerSummary> {
+export function refreshTrackerLink(projectId: string, linkId: string): Promise<TrackerSummaryResponse> {
   return request(
     `/projects/${encodeURIComponent(projectId)}/tracker-links/${encodeURIComponent(linkId)}/refresh`,
     { method: "POST" },

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -969,6 +969,13 @@ export interface paths {
         /**
          * Resolve Approval
          * @description Approve or reject a pending approval request.
+         *
+         *     Story 5.4 (AC #1): when an approval created for a gated chain's dependent
+         *     spawn (``proposed_action`` of the form ``"spawn_task:{task_link_id}"``) is
+         *     approved, the deferred spawn is performed here and the new job is started.
+         *     Rejection (AC #3) needs no extra handling — the TaskLink simply keeps
+         *     ``job_id = None``, and a later dependency-satisfying event creates a fresh,
+         *     independent approval on its own.
          */
         post: operations["resolve_approval_api_approvals__approval_id__resolve_post"];
         delete?: never;
@@ -2165,33 +2172,33 @@ export interface paths {
          * Preview Proxy
          * @description Reverse-proxy a request to a local development server.
          */
-        get: operations["preview_proxy_api_preview__port___path__post"];
+        get: operations["preview_proxy_api_preview__port___path__patch"];
         /**
          * Preview Proxy
          * @description Reverse-proxy a request to a local development server.
          */
-        put: operations["preview_proxy_api_preview__port___path__post"];
+        put: operations["preview_proxy_api_preview__port___path__patch"];
         /**
          * Preview Proxy
          * @description Reverse-proxy a request to a local development server.
          */
-        post: operations["preview_proxy_api_preview__port___path__post"];
+        post: operations["preview_proxy_api_preview__port___path__patch"];
         /**
          * Preview Proxy
          * @description Reverse-proxy a request to a local development server.
          */
-        delete: operations["preview_proxy_api_preview__port___path__post"];
+        delete: operations["preview_proxy_api_preview__port___path__patch"];
         options?: never;
         /**
          * Preview Proxy
          * @description Reverse-proxy a request to a local development server.
          */
-        head: operations["preview_proxy_api_preview__port___path__post"];
+        head: operations["preview_proxy_api_preview__port___path__patch"];
         /**
          * Preview Proxy
          * @description Reverse-proxy a request to a local development server.
          */
-        patch: operations["preview_proxy_api_preview__port___path__post"];
+        patch: operations["preview_proxy_api_preview__port___path__patch"];
         trace?: never;
     };
     "/api/jobs/{job_id}/share": {
@@ -2816,6 +2823,78 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/chats/{chat_id}/attach-chain": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Attach Chat To Chain
+         * @description Attach a Chat to a Task Recipe chain via its entry TaskLink (Story 5.3).
+         *
+         *     Settles ``project_id`` from the TaskLink's Project if it was still
+         *     null. A pure linking operation — never touches ``GitService`` or
+         *     creates a Job. Raises 404 (via ``TaskLinkNotFoundError``'s global
+         *     handler) if the TaskLink does not exist.
+         */
+        post: operations["attach_chat_to_chain_api_chats__chat_id__attach_chain_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/chats/{chat_id}/detach-chain": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Detach Chat From Chain
+         * @description Detach a Chat from its Task Recipe chain (Story 5.3).
+         *
+         *     The chain continues to run exactly as before; only the Chat's link to
+         *     it is cleared, and the Chat remains open.
+         */
+        post: operations["detach_chat_from_chain_api_chats__chat_id__detach_chain_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/chats/{chat_id}/chain-status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Chat Chain Status
+         * @description Read-only narration snapshot of a Chat's attached chain (Story 5.3, AC 2).
+         *
+         *     Purely reflects existing TaskLink/Job state via read-only polling —
+         *     never calls ``GitService`` or any job-creation function. 404s if the
+         *     chat does not exist or has nothing attached.
+         */
+        get: operations["get_chat_chain_status_api_chats__chat_id__chain_status_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/settings/projects": {
         parameters: {
             query?: never;
@@ -2924,7 +3003,11 @@ export interface paths {
          */
         get: operations["list_project_task_links_api_settings_projects__project_id__task_links_get"];
         put?: never;
-        post?: never;
+        /**
+         * Create Manual Task Link
+         * @description Create a fresh TaskLink directly against an existing tracker ticket.
+         */
+        post: operations["create_manual_task_link_api_settings_projects__project_id__task_links_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -2943,6 +3026,23 @@ export interface paths {
         put?: never;
         /** Create Tracker Link */
         post: operations["create_tracker_link_api_projects__project_id__tracker_links_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/tracker-links/{link_id}/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Refresh Tracker Link */
+        post: operations["refresh_tracker_link_api_projects__project_id__tracker_links__link_id__refresh_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -3284,6 +3384,14 @@ export interface components {
          */
         ArtifactType: "diff_snapshot" | "agent_summary" | "session_snapshot" | "session_log" | "agent_plan" | "telemetry_report" | "approval_history" | "agent_log" | "document" | "custom";
         /**
+         * AttachChatToChainRequest
+         * @description Attach a Chat to a Task Recipe chain via its entry TaskLink (Story 5.3).
+         */
+        AttachChatToChainRequest: {
+            /** Tasklinkid */
+            taskLinkId: string;
+        };
+        /**
          * BlastRadiusCandidate
          * @description A test candidate from blast radius analysis.
          */
@@ -3398,6 +3506,22 @@ export interface components {
              */
             jobCount: number;
         };
+        /**
+         * ChatChainStatusResponse
+         * @description Read-only narration snapshot of a Chat's attached chain (Story 5.3).
+         */
+        ChatChainStatusResponse: {
+            /** Tasklinkid */
+            taskLinkId: string;
+            /** Storynodeid */
+            storyNodeId: string | null;
+            /** Repopath */
+            repoPath: string;
+            /** Jobid */
+            jobId: string | null;
+            /** Jobstate */
+            jobState: string | null;
+        };
         /** ChatListResponse */
         ChatListResponse: {
             /** Items */
@@ -3439,6 +3563,8 @@ export interface components {
             lastMessageAt: string;
             /** Status */
             status: string;
+            /** Tasklinkid */
+            taskLinkId?: string | null;
         };
         /** CleanupWorktreesResponse */
         CleanupWorktreesResponse: {
@@ -3741,6 +3867,18 @@ export interface components {
              * Format: date-time
              */
             createdAt: string;
+        };
+        /**
+         * CreateManualTaskLinkRequest
+         * @description Create a TaskLink directly from an existing tracker ticket (Story 4.3).
+         */
+        CreateManualTaskLinkRequest: {
+            /** Repopath */
+            repoPath: string;
+            /** Trackerticketref */
+            trackerTicketRef: string;
+            /** Promptoverride */
+            promptOverride: string;
         };
         /** CreateProjectRequest */
         CreateProjectRequest: {
@@ -6649,6 +6787,8 @@ export interface components {
             codereconSplade: boolean;
             /** Codereconcrossencoder */
             codereconCrossEncoder: boolean;
+            /** Trackerpollintervalseconds */
+            trackerPollIntervalSeconds: number;
         };
         /** ShareTokenResponse */
         ShareTokenResponse: {
@@ -7624,6 +7764,29 @@ export interface components {
             externalRef: string;
             /** Createdat */
             createdAt: string;
+            summary?: components["schemas"]["TrackerSummaryResponse"] | null;
+        };
+        /** TrackerSummaryResponse */
+        TrackerSummaryResponse: {
+            /** Trackerlinkid */
+            trackerLinkId: string;
+            /** Tickets */
+            tickets?: components["schemas"]["TrackerTicketResponse"][];
+            /** Lastsyncedat */
+            lastSyncedAt?: string | null;
+            /** Lasterror */
+            lastError?: string | null;
+        };
+        /** TrackerTicketResponse */
+        TrackerTicketResponse: {
+            /** Id */
+            id: string;
+            /** Title */
+            title: string;
+            /** Status */
+            status: string;
+            /** Url */
+            url?: string | null;
         };
         /**
          * TrailBacktrack
@@ -8066,6 +8229,8 @@ export interface components {
             codereconSplade?: boolean | null;
             /** Codereconcrossencoder */
             codereconCrossEncoder?: boolean | null;
+            /** Trackerpollintervalseconds */
+            trackerPollIntervalSeconds?: number | null;
         };
         /** UpdateSidecarTemplateRequest */
         UpdateSidecarTemplateRequest: {
@@ -11492,7 +11657,7 @@ export interface operations {
             };
         };
     };
-    preview_proxy_api_preview__port___path__post: {
+    preview_proxy_api_preview__port___path__patch: {
         parameters: {
             query?: never;
             header?: never;
@@ -11522,7 +11687,7 @@ export interface operations {
             };
         };
     };
-    preview_proxy_api_preview__port___path__post: {
+    preview_proxy_api_preview__port___path__patch: {
         parameters: {
             query?: never;
             header?: never;
@@ -11552,7 +11717,7 @@ export interface operations {
             };
         };
     };
-    preview_proxy_api_preview__port___path__post: {
+    preview_proxy_api_preview__port___path__patch: {
         parameters: {
             query?: never;
             header?: never;
@@ -11582,7 +11747,7 @@ export interface operations {
             };
         };
     };
-    preview_proxy_api_preview__port___path__post: {
+    preview_proxy_api_preview__port___path__patch: {
         parameters: {
             query?: never;
             header?: never;
@@ -11612,7 +11777,7 @@ export interface operations {
             };
         };
     };
-    preview_proxy_api_preview__port___path__post: {
+    preview_proxy_api_preview__port___path__patch: {
         parameters: {
             query?: never;
             header?: never;
@@ -11642,7 +11807,7 @@ export interface operations {
             };
         };
     };
-    preview_proxy_api_preview__port___path__post: {
+    preview_proxy_api_preview__port___path__patch: {
         parameters: {
             query?: never;
             header?: never;
@@ -12890,6 +13055,103 @@ export interface operations {
             };
         };
     };
+    attach_chat_to_chain_api_chats__chat_id__attach_chain_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                chat_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AttachChatToChainRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChatResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    detach_chat_from_chain_api_chats__chat_id__detach_chain_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                chat_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChatResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_chat_chain_status_api_chats__chat_id__chain_status_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                chat_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChatChainStatusResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     list_projects_api_settings_projects_get: {
         parameters: {
             query?: never;
@@ -13091,6 +13353,41 @@ export interface operations {
             };
         };
     };
+    create_manual_task_link_api_settings_projects__project_id__task_links_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateManualTaskLinkRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TaskLinkResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     list_tracker_links_api_projects__project_id__tracker_links_get: {
         parameters: {
             query?: never;
@@ -13144,6 +13441,38 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["TrackerLinkResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    refresh_tracker_link_api_projects__project_id__tracker_links__link_id__refresh_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                link_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TrackerSummaryResponse"];
                 };
             };
             /** @description Validation Error */

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -6787,8 +6787,6 @@ export interface components {
             codereconSplade: boolean;
             /** Codereconcrossencoder */
             codereconCrossEncoder: boolean;
-            /** Trackerpollintervalseconds */
-            trackerPollIntervalSeconds: number;
         };
         /** ShareTokenResponse */
         ShareTokenResponse: {
@@ -8229,8 +8227,6 @@ export interface components {
             codereconSplade?: boolean | null;
             /** Codereconcrossencoder */
             codereconCrossEncoder?: boolean | null;
-            /** Trackerpollintervalseconds */
-            trackerPollIntervalSeconds?: number | null;
         };
         /** UpdateSidecarTemplateRequest */
         UpdateSidecarTemplateRequest: {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -24,6 +24,10 @@ export type ProjectResponse = components["schemas"]["ProjectResponse"];
 export type ProjectListResponse = components["schemas"]["ProjectListResponse"];
 export type TaskLinkResponse = components["schemas"]["TaskLinkResponse"];
 export type TaskLinkListResponse = components["schemas"]["TaskLinkListResponse"];
+export type TrackerTicketResponse = components["schemas"]["TrackerTicketResponse"];
+export type TrackerSummaryResponse = components["schemas"]["TrackerSummaryResponse"];
+export type TrackerLinkResponse = components["schemas"]["TrackerLinkResponse"];
+export type TrackerLinkListResponse = components["schemas"]["TrackerLinkListResponse"];
 export type CompletionStrategy = "auto_merge" | "pr_only" | "manual";
 
 // Sidecar template types

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -51,7 +51,6 @@ export interface Settings {
   selfReview: boolean;
   verifyPrompt: string;
   selfReviewPrompt: string;
-  trackerPollIntervalSeconds: number;
 }
 
 // SSE payload types — not in the OpenAPI schema since they're sent via SSE,

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -47,6 +47,7 @@ export interface Settings {
   selfReview: boolean;
   verifyPrompt: string;
   selfReviewPrompt: string;
+  trackerPollIntervalSeconds: number;
 }
 
 // SSE payload types — not in the OpenAPI schema since they're sent via SSE,

--- a/frontend/src/components/SettingsScreen.tsx
+++ b/frontend/src/components/SettingsScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useId, useState, useCallback } from "react";
 import { Trash2, Plus, Save, Bell } from "lucide-react";
 import { toast } from "sonner";
 import { Link } from "react-router-dom";
@@ -11,6 +11,7 @@ import type { Settings } from "../api/types";
 import { AddRepoModal } from "./AddRepoModal";
 import { PolicySettingsPanel } from "./PolicySettingsPanel";
 import { IntegrationsSettings } from "./IntegrationsSettings";
+import { TrackerSyncPanel } from "./TrackerSyncPanel";
 import { RepoIndexIndicator } from "./RepoIndexIndicator";
 import { SidecarLibraryPanel } from "./SidecarLibraryPanel";
 import { Button } from "./ui/button";
@@ -29,6 +30,7 @@ function NumberField({ label, value, onChange, min, max, description, placeholde
   description?: string;
   placeholder?: string;
 }) {
+  const inputId = useId();
   const [raw, setRaw] = useState(String(value));
 
   useEffect(() => {
@@ -59,8 +61,9 @@ function NumberField({ label, value, onChange, min, max, description, placeholde
 
   return (
     <div className="flex flex-col gap-1.5">
-      <Label>{label}</Label>
+      <Label htmlFor={inputId}>{label}</Label>
       <Input
+        id={inputId}
         type="text"
         inputMode="numeric"
         pattern="[0-9]*"
@@ -285,6 +288,21 @@ export function SettingsScreen() {
 
       {/* Integrations */}
       <IntegrationsSettings />
+
+      <TrackerSyncPanel />
+
+      <div className="rounded-lg border border-border bg-card p-5">
+        <p className="text-sm font-semibold mb-4">Tracker synchronization</p>
+        <NumberField
+          label="Tracker poll interval (seconds)"
+          value={settings.trackerPollIntervalSeconds}
+          onChange={(value) => patch({ trackerPollIntervalSeconds: value })}
+          min={5}
+          max={86400}
+          placeholder="300"
+          description="How often CodePlane fetches ticket state for attached tracker links."
+        />
+      </div>
 
       {/* Retention */}
       <div className="rounded-lg border border-border bg-card p-5">

--- a/frontend/src/components/SettingsScreen.tsx
+++ b/frontend/src/components/SettingsScreen.tsx
@@ -291,19 +291,6 @@ export function SettingsScreen() {
 
       <TrackerSyncPanel />
 
-      <div className="rounded-lg border border-border bg-card p-5">
-        <p className="text-sm font-semibold mb-4">Tracker synchronization</p>
-        <NumberField
-          label="Tracker poll interval (seconds)"
-          value={settings.trackerPollIntervalSeconds}
-          onChange={(value) => patch({ trackerPollIntervalSeconds: value })}
-          min={5}
-          max={86400}
-          placeholder="300"
-          description="How often CodePlane fetches ticket state for attached tracker links."
-        />
-      </div>
-
       {/* Retention */}
       <div className="rounded-lg border border-border bg-card p-5">
         <p className="text-sm font-semibold mb-4">Retention</p>

--- a/frontend/src/components/TrackerSyncPanel.tsx
+++ b/frontend/src/components/TrackerSyncPanel.tsx
@@ -1,0 +1,189 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { RefreshCw } from "lucide-react";
+import { toast } from "sonner";
+import {
+  fetchCredentials,
+  fetchProjects,
+  fetchTrackerLinks,
+  refreshTrackerLink,
+} from "../api/client";
+import type {
+  Credential,
+  Project,
+  TrackerLink,
+  TrackerSummary,
+} from "../api/client";
+import { Button } from "./ui/button";
+import { Spinner } from "./ui/spinner";
+
+interface ProjectLinks {
+  project: Project;
+  links: TrackerLink[];
+}
+
+export function TrackerSyncPanel() {
+  const [groups, setGroups] = useState<ProjectLinks[]>([]);
+  const [credentials, setCredentials] = useState<Credential[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [projectsResponse, credentialsResponse] = await Promise.all([
+        fetchProjects(),
+        fetchCredentials(),
+      ]);
+      const links = await Promise.all(
+        projectsResponse.items.map(async (project) => ({
+          project,
+          links: (await fetchTrackerLinks(project.id)).trackerLinks,
+        })),
+      );
+      setGroups(links);
+      setCredentials(credentialsResponse.credentials);
+    } catch (error) {
+      toast.error(String(error));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const credentialById = useMemo(
+    () => new Map(credentials.map((credential) => [credential.id, credential])),
+    [credentials],
+  );
+
+  const updateSummary = (
+    projectId: string,
+    linkId: string,
+    summary: TrackerSummary,
+  ) => {
+    setGroups((current) =>
+      current.map((group) =>
+        group.project.id !== projectId
+          ? group
+          : {
+              ...group,
+              links: group.links.map((link) =>
+                link.id === linkId ? { ...link, summary } : link,
+              ),
+            },
+      ),
+    );
+  };
+
+  const handleRefresh = async (projectId: string, link: TrackerLink) => {
+    setRefreshing(link.id);
+    try {
+      const summary = await refreshTrackerLink(projectId, link.id);
+      updateSummary(projectId, link.id, summary);
+      toast.success(`Refreshed ${link.externalRef}.`);
+    } catch (error) {
+      toast.error(String(error));
+      await load();
+    } finally {
+      setRefreshing(null);
+    }
+  };
+
+  const linkedGroups = groups.filter((group) => group.links.length > 0);
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-5 space-y-4">
+      <div>
+        <p className="text-sm font-semibold">Synced tracker state</p>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          Ticket state is fetched by polling or with a manual refresh. CodePlane does not expose tracker webhooks.
+        </p>
+      </div>
+
+      {loading ? (
+        <div className="flex justify-center py-4"><Spinner /></div>
+      ) : linkedGroups.length === 0 ? (
+        <p className="text-xs text-muted-foreground">No tracker links attached yet.</p>
+      ) : (
+        <div className="space-y-4">
+          {linkedGroups.map(({ project, links }) => (
+            <section key={project.id} className="space-y-2">
+              <h4 className="text-sm font-medium">{project.name}</h4>
+              {links.map((link) => {
+                const credential = credentialById.get(link.credentialId);
+                const summary = link.summary;
+                return (
+                  <div key={link.id} className="rounded-md border border-border p-3 space-y-3">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="text-xs font-medium">
+                          {credential?.label ?? "Unknown credential"}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          <span>{credential?.provider.replace("_", " ") ?? "unknown"}</span>
+                          {" · "}
+                          <span>{link.externalRef}</span>
+                        </p>
+                        <p className="text-[11px] text-muted-foreground">
+                          {summary?.lastSyncedAt
+                            ? `Last synced ${new Date(summary.lastSyncedAt).toLocaleString()}`
+                            : "Never synced"}
+                        </p>
+                      </div>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        aria-label={`Refresh ${link.externalRef}`}
+                        disabled={refreshing === link.id}
+                        onClick={() => void handleRefresh(project.id, link)}
+                      >
+                        <RefreshCw className={`h-3.5 w-3.5 ${refreshing === link.id ? "animate-spin" : ""}`} />
+                        Refresh
+                      </Button>
+                    </div>
+
+                    {summary?.lastError && (
+                      <p role="alert" className="text-xs text-red-400">{summary.lastError}</p>
+                    )}
+
+                    {!summary || summary.tickets.length === 0 ? (
+                      <p className="text-xs text-muted-foreground">No tickets fetched.</p>
+                    ) : (
+                      <div className="space-y-1">
+                        {summary.tickets.map((ticket) => {
+                          const content = (
+                            <>
+                              <span className="font-medium">{ticket.title}</span>
+                              <span className="text-muted-foreground">{ticket.status}</span>
+                            </>
+                          );
+                          return ticket.url ? (
+                            <a
+                              key={ticket.id}
+                              href={ticket.url}
+                              target="_blank"
+                              rel="noreferrer"
+                              className="flex justify-between gap-3 rounded px-2 py-1 text-xs hover:bg-accent"
+                            >
+                              {content}
+                            </a>
+                          ) : (
+                            <div key={ticket.id} className="flex justify-between gap-3 rounded px-2 py-1 text-xs">
+                              {content}
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </section>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/TrackerSyncPanel.tsx
+++ b/frontend/src/components/TrackerSyncPanel.tsx
@@ -7,18 +7,18 @@ import {
   fetchTrackerLinks,
   refreshTrackerLink,
 } from "../api/client";
+import type { Credential } from "../api/client";
 import type {
-  Credential,
-  Project,
-  TrackerLink,
-  TrackerSummary,
-} from "../api/client";
+  ProjectResponse,
+  TrackerLinkResponse,
+  TrackerSummaryResponse,
+} from "../api/types";
 import { Button } from "./ui/button";
 import { Spinner } from "./ui/spinner";
 
 interface ProjectLinks {
-  project: Project;
-  links: TrackerLink[];
+  project: ProjectResponse;
+  links: TrackerLinkResponse[];
 }
 
 export function TrackerSyncPanel() {
@@ -37,7 +37,7 @@ export function TrackerSyncPanel() {
       const links = await Promise.all(
         projectsResponse.items.map(async (project) => ({
           project,
-          links: (await fetchTrackerLinks(project.id)).trackerLinks,
+          links: (await fetchTrackerLinks(project.id)).trackerLinks ?? [],
         })),
       );
       setGroups(links);
@@ -61,7 +61,7 @@ export function TrackerSyncPanel() {
   const updateSummary = (
     projectId: string,
     linkId: string,
-    summary: TrackerSummary,
+    summary: TrackerSummaryResponse,
   ) => {
     setGroups((current) =>
       current.map((group) =>
@@ -77,7 +77,7 @@ export function TrackerSyncPanel() {
     );
   };
 
-  const handleRefresh = async (projectId: string, link: TrackerLink) => {
+  const handleRefresh = async (projectId: string, link: TrackerLinkResponse) => {
     setRefreshing(link.id);
     try {
       const summary = await refreshTrackerLink(projectId, link.id);
@@ -148,7 +148,7 @@ export function TrackerSyncPanel() {
                       <p role="alert" className="text-xs text-red-400">{summary.lastError}</p>
                     )}
 
-                    {!summary || summary.tickets.length === 0 ? (
+                    {!summary || !summary.tickets?.length ? (
                       <p className="text-xs text-muted-foreground">No tickets fetched.</p>
                     ) : (
                       <div className="space-y-1">

--- a/frontend/src/components/__tests__/SettingsScreen.test.tsx
+++ b/frontend/src/components/__tests__/SettingsScreen.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 
 // Mock the API client
@@ -39,7 +39,6 @@ const defaultSettings = {
   maxArtifactSizeMb: 100,
   autoArchiveDays: 90,
   maxTurns: 3,
-  trackerPollIntervalSeconds: 300,
 };
 
 beforeEach(() => {
@@ -91,25 +90,9 @@ describe("SettingsScreen", () => {
     await waitFor(() => {
       expect(screen.getByText("Runtime")).toBeInTheDocument();
     });
-  });
-
-  it("edits and saves the tracker polling interval", async () => {
-    vi.mocked(updateSettings).mockImplementation(async (settings) => settings as any);
-    render(
-      <MemoryRouter>
-        <SettingsScreen />
-      </MemoryRouter>,
-    );
-
-    const field = await screen.findByLabelText("Tracker poll interval (seconds)");
-    fireEvent.change(field, { target: { value: "45" } });
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
-
-    await waitFor(() => {
-      expect(updateSettings).toHaveBeenCalledWith(
-        expect.objectContaining({ trackerPollIntervalSeconds: 45 }),
-      );
-    });
+    expect(
+      screen.queryByText("Tracker poll interval (seconds)"),
+    ).not.toBeInTheDocument();
   });
 
   it("shows error toast when settings fail to load", async () => {

--- a/frontend/src/components/__tests__/SettingsScreen.test.tsx
+++ b/frontend/src/components/__tests__/SettingsScreen.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 
 // Mock the API client
@@ -11,6 +11,10 @@ vi.mock("../../api/client", () => ({
   unregisterRepo: vi.fn(),
   fetchSidecarTemplates: vi.fn().mockResolvedValue({ items: [] }),
   request: vi.fn().mockResolvedValue(null),
+  fetchProjects: vi.fn().mockResolvedValue({ items: [] }),
+  fetchCredentials: vi.fn().mockResolvedValue({ credentials: [] }),
+  fetchTrackerLinks: vi.fn().mockResolvedValue({ trackerLinks: [] }),
+  refreshTrackerLink: vi.fn(),
 }));
 
 // Mock sonner toast
@@ -35,6 +39,7 @@ const defaultSettings = {
   maxArtifactSizeMb: 100,
   autoArchiveDays: 90,
   maxTurns: 3,
+  trackerPollIntervalSeconds: 300,
 };
 
 beforeEach(() => {
@@ -85,6 +90,25 @@ describe("SettingsScreen", () => {
     );
     await waitFor(() => {
       expect(screen.getByText("Runtime")).toBeInTheDocument();
+    });
+  });
+
+  it("edits and saves the tracker polling interval", async () => {
+    vi.mocked(updateSettings).mockImplementation(async (settings) => settings as any);
+    render(
+      <MemoryRouter>
+        <SettingsScreen />
+      </MemoryRouter>,
+    );
+
+    const field = await screen.findByLabelText("Tracker poll interval (seconds)");
+    fireEvent.change(field, { target: { value: "45" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(updateSettings).toHaveBeenCalledWith(
+        expect.objectContaining({ trackerPollIntervalSeconds: 45 }),
+      );
     });
   });
 

--- a/frontend/src/components/__tests__/TrackerSyncPanel.test.tsx
+++ b/frontend/src/components/__tests__/TrackerSyncPanel.test.tsx
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("../../api/client", () => ({
+  fetchProjects: vi.fn(),
+  fetchCredentials: vi.fn(),
+  fetchTrackerLinks: vi.fn(),
+  refreshTrackerLink: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import {
+  fetchCredentials,
+  fetchProjects,
+  fetchTrackerLinks,
+  refreshTrackerLink,
+} from "../../api/client";
+import { TrackerSyncPanel } from "../TrackerSyncPanel";
+
+beforeEach(() => {
+  vi.mocked(fetchProjects).mockResolvedValue({
+    items: [
+      {
+        id: "project-1",
+        name: "Payments",
+        repoPaths: ["/repos/payments"],
+        createdAt: "2026-08-10T12:00:00Z",
+        updatedAt: "2026-08-10T12:00:00Z",
+      },
+    ],
+  });
+  vi.mocked(fetchCredentials).mockResolvedValue({
+    credentials: [
+      {
+        id: "credential-1",
+        provider: "jira",
+        label: "Acme Jira",
+        baseUrl: "https://acme.atlassian.net",
+        createdAt: "2026-08-10T12:00:00Z",
+      },
+    ],
+  });
+  vi.mocked(fetchTrackerLinks).mockResolvedValue({
+    trackerLinks: [
+      {
+        id: "link-1",
+        projectId: "project-1",
+        credentialId: "credential-1",
+        externalRef: "PAY",
+        createdAt: "2026-08-10T12:00:00Z",
+        summary: {
+          trackerLinkId: "link-1",
+          tickets: [
+            {
+              id: "PAY-42",
+              title: "Retry settlement",
+              status: "In Progress",
+              url: "https://acme.atlassian.net/browse/PAY-42",
+            },
+          ],
+          lastSyncedAt: "2026-08-10T12:05:00Z",
+          lastError: null,
+        },
+      },
+    ],
+  });
+  vi.mocked(refreshTrackerLink).mockReset();
+});
+
+describe("TrackerSyncPanel", () => {
+  it("renders project, provider, link, and normalized ticket state", async () => {
+    render(<TrackerSyncPanel />);
+
+    expect(await screen.findByText("Payments")).toBeInTheDocument();
+    expect(screen.getByText("Acme Jira")).toBeInTheDocument();
+    expect(screen.getByText("PAY")).toBeInTheDocument();
+    expect(screen.getByText("Retry settlement")).toBeInTheDocument();
+    expect(screen.getByText("In Progress")).toBeInTheDocument();
+  });
+
+  it("renders never-synced and error states", async () => {
+    vi.mocked(fetchTrackerLinks).mockResolvedValue({
+      trackerLinks: [
+        {
+          id: "link-1",
+          projectId: "project-1",
+          credentialId: "credential-1",
+          externalRef: "PAY",
+          createdAt: "2026-08-10T12:00:00Z",
+          summary: {
+            trackerLinkId: "link-1",
+            tickets: [],
+            lastSyncedAt: null,
+            lastError: "Tracker provider request failed",
+          },
+        },
+      ],
+    });
+
+    render(<TrackerSyncPanel />);
+
+    expect(await screen.findByText("Tracker provider request failed")).toBeInTheDocument();
+    expect(screen.getByText("Never synced")).toBeInTheDocument();
+  });
+
+  it("manually refreshes one link and renders the returned state", async () => {
+    vi.mocked(refreshTrackerLink).mockResolvedValue({
+      trackerLinkId: "link-1",
+      tickets: [
+        {
+          id: "PAY-43",
+          title: "New ticket",
+          status: "Ready",
+          url: null,
+        },
+      ],
+      lastSyncedAt: "2026-08-10T12:10:00Z",
+      lastError: null,
+    });
+
+    render(<TrackerSyncPanel />);
+    const refreshButton = await screen.findByRole("button", { name: "Refresh PAY" });
+    fireEvent.click(refreshButton);
+
+    await waitFor(() => {
+      expect(refreshTrackerLink).toHaveBeenCalledWith("project-1", "link-1");
+    });
+    expect(await screen.findByText("New ticket")).toBeInTheDocument();
+    expect(screen.getByText("Ready")).toBeInTheDocument();
+  });
+
+  it("shows an empty state when no Projects have tracker links", async () => {
+    vi.mocked(fetchTrackerLinks).mockResolvedValue({ trackerLinks: [] });
+
+    render(<TrackerSyncPanel />);
+
+    expect(await screen.findByText("No tracker links attached yet.")).toBeInTheDocument();
+  });
+});

--- a/frontend/tracker-e2e/tracker-sync.spec.ts
+++ b/frontend/tracker-e2e/tracker-sync.spec.ts
@@ -1,0 +1,365 @@
+import { expect, test } from "@playwright/test";
+import type { ChildProcess } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { dirname, resolve } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_BASE_URL = "http://127.0.0.1:18765";
+const JIRA_TOKEN = "local-e2e-token";
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+let backend: ChildProcess | undefined;
+let backendOutput = "";
+let codeplaneHome = "";
+let jiraStatus = "To Do";
+let jiraRequestCount = 0;
+let closeJira: (() => Promise<void>) | undefined;
+let backendBaseUrl = "";
+let projectId = "";
+let backendSpawnError: Error | undefined;
+
+interface TrackerLinksResponse {
+  trackerLinks: Array<{
+    id: string;
+    summary: {
+      tickets: Array<{ title: string; status: string }>;
+      lastSyncedAt: string | null;
+      lastError: string | null;
+    } | null;
+  }>;
+}
+
+async function requestJson<T>(
+  url: string,
+  init?: RequestInit,
+): Promise<T> {
+  const response = await fetch(url, {
+    ...init,
+    headers: init?.body
+      ? { "Content-Type": "application/json", ...init.headers }
+      : init?.headers,
+  });
+  if (!response.ok) {
+    throw new Error(
+      `${init?.method ?? "GET"} ${url} failed: ${response.status} ${await response.text()}`,
+    );
+  }
+  return response.json() as Promise<T>;
+}
+
+async function startFakeJira(): Promise<string> {
+  const server = createServer((request, response) => {
+    const url = new URL(request.url ?? "/", "http://127.0.0.1");
+    if (request.method === "GET" && url.pathname === "/rest/api/3/search/jql") {
+      const validRequest =
+        request.headers.authorization === `Bearer ${JIRA_TOKEN}` &&
+        url.searchParams.get("jql")?.includes('project = "TEST"') &&
+        url.searchParams.get("fields") === "summary,status" &&
+        url.searchParams.get("maxResults") === "100";
+      if (!validRequest) {
+        response.writeHead(400, { "Content-Type": "application/json" });
+        response.end(JSON.stringify({ error: "invalid Jira request" }));
+        return;
+      }
+      jiraRequestCount += 1;
+      response.writeHead(200, { "Content-Type": "application/json" });
+      response.end(
+        JSON.stringify({
+          issues: [
+            {
+              id: "10001",
+              key: "TEST-1",
+              fields: {
+                summary: "Deterministic Jira ticket",
+                status: { name: jiraStatus },
+              },
+            },
+          ],
+        }),
+      );
+      return;
+    }
+    response.writeHead(404, { "Content-Type": "application/json" });
+    response.end(JSON.stringify({ error: "not found" }));
+  });
+
+  await new Promise<void>((resolveReady, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolveReady);
+  });
+  const address = server.address() as AddressInfo;
+  closeJira = () =>
+    new Promise<void>((resolveClosed, reject) => {
+      if (!server.listening) {
+        resolveClosed();
+        return;
+      }
+      server.close((error) => (error ? reject(error) : resolveClosed()));
+    });
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function waitForBackend(url: string): Promise<void> {
+  const deadline = Date.now() + 120_000;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    if (backendSpawnError) {
+      throw new Error(`CodePlane failed to start: ${backendSpawnError.message}`);
+    }
+    if (backend && (backend.exitCode !== null || backend.signalCode !== null)) {
+      throw new Error(
+        `CodePlane exited before becoming ready (${backend.exitCode ?? backend.signalCode}).\n${backendOutput}`,
+      );
+    }
+    try {
+      const response = await fetch(`${url}/api/health`);
+      if (response.ok) return;
+      lastError = `${response.status} ${await response.text()}`;
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolveWait) => setTimeout(resolveWait, 500));
+  }
+  throw new Error(
+    `CodePlane did not become ready: ${String(lastError)}\n${backendOutput}`,
+  );
+}
+
+async function assertPortAvailable(port: number): Promise<void> {
+  const probe = createServer();
+  await new Promise<void>((resolveReady, reject) => {
+    probe.once("error", reject);
+    probe.listen(port, "127.0.0.1", resolveReady);
+  });
+  await new Promise<void>((resolveClosed, reject) => {
+    probe.close((error) => (error ? reject(error) : resolveClosed()));
+  });
+}
+
+async function stopProcess(child: ChildProcess): Promise<void> {
+  if (
+    child.exitCode !== null ||
+    child.signalCode !== null ||
+    child.pid === undefined
+  ) {
+    return;
+  }
+  const exited = new Promise<void>((resolveExit) =>
+    child.once("exit", () => resolveExit()),
+  );
+  if (process.platform === "win32") {
+    const result = spawnSync("taskkill", ["/PID", String(child.pid), "/T", "/F"], {
+      windowsHide: true,
+      encoding: "utf8",
+    });
+    if (result.status !== 0) {
+      throw new Error(`taskkill failed: ${result.stderr || result.stdout}`);
+    }
+  } else {
+    process.kill(-child.pid, "SIGTERM");
+  }
+
+  const exitedPromptly = await Promise.race([
+    exited.then(() => true),
+    new Promise<false>((resolveTimeout) =>
+      setTimeout(() => resolveTimeout(false), 5_000),
+    ),
+  ]);
+  if (!exitedPromptly && process.platform !== "win32") {
+    process.kill(-child.pid, "SIGKILL");
+    await exited;
+  } else if (!exitedPromptly) {
+    throw new Error(`CodePlane process ${child.pid} did not exit after taskkill`);
+  }
+}
+
+async function cleanup(): Promise<void> {
+  const results = await Promise.allSettled([
+    backend ? stopProcess(backend) : Promise.resolve(),
+  ]);
+  results.push(
+    ...(await Promise.allSettled([
+      closeJira ? closeJira() : Promise.resolve(),
+      codeplaneHome
+        ? rm(codeplaneHome, { recursive: true, force: true })
+        : Promise.resolve(),
+    ])),
+  );
+  const failures = results.filter(
+    (result): result is PromiseRejectedResult => result.status === "rejected",
+  );
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures.map((failure) => failure.reason),
+      "Tracker E2E cleanup failed",
+    );
+  }
+}
+
+async function waitForScheduledSummary(): Promise<TrackerLinksResponse> {
+  const deadline = Date.now() + 80_000;
+  let lastObserved: TrackerLinksResponse | undefined;
+  while (Date.now() < deadline) {
+    lastObserved = await requestJson<TrackerLinksResponse>(
+      `${backendBaseUrl}/api/projects/${projectId}/tracker-links`,
+    );
+    const ticket = lastObserved.trackerLinks[0]?.summary?.tickets[0];
+    if (
+      ticket?.title === "Deterministic Jira ticket" &&
+      ticket.status === "To Do"
+    ) {
+      return lastObserved;
+    }
+    await new Promise((resolveWait) => setTimeout(resolveWait, 750));
+  }
+  throw new Error(
+    `Scheduled tracker summary was not persisted. Last response: ${JSON.stringify(lastObserved)}`,
+  );
+}
+
+test.beforeAll(async () => {
+  backendBaseUrl =
+    process.env.CODEPLANE_TRACKER_E2E_BASE_URL ?? DEFAULT_BASE_URL;
+  const parsedBaseUrl = new URL(backendBaseUrl);
+  backendBaseUrl = parsedBaseUrl.origin;
+  const backendPort = Number(parsedBaseUrl.port);
+
+  try {
+    if (
+      parsedBaseUrl.protocol !== "http:" ||
+      parsedBaseUrl.hostname !== "127.0.0.1" ||
+      parsedBaseUrl.pathname !== "/" ||
+      parsedBaseUrl.search !== "" ||
+      parsedBaseUrl.hash !== "" ||
+      !Number.isInteger(backendPort) ||
+      backendPort < 1
+    ) {
+      throw new Error(
+        "CODEPLANE_TRACKER_E2E_BASE_URL must be an http://127.0.0.1 URL with an explicit port",
+      );
+    }
+    await assertPortAvailable(backendPort);
+    const jiraBaseUrl = await startFakeJira();
+    codeplaneHome = await mkdtemp(resolve(repoRoot, ".tracker-e2e-"));
+
+    const launchScript = [
+      "from backend.persistence.database import run_migrations",
+      "run_migrations()",
+      "import uvicorn",
+      "from backend.app_factory import create_app",
+      `uvicorn.run(create_app(), host="127.0.0.1", port=${backendPort}, log_level="warning")`,
+    ].join("; ");
+
+    backend = spawn(
+      "uv",
+      ["run", "--no-sync", "python", "-c", launchScript],
+      {
+        cwd: repoRoot,
+        detached: true,
+        env: {
+          ...process.env,
+          CODEPLANE_HOME: codeplaneHome,
+          PYTHONIOENCODING: "utf-8",
+          PYTHONUTF8: "1",
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+      },
+    );
+    backend.once("error", (error) => {
+      backendSpawnError = error;
+    });
+    backend.stdout?.on("data", (chunk) => {
+      backendOutput += chunk.toString();
+    });
+    backend.stderr?.on("data", (chunk) => {
+      backendOutput += chunk.toString();
+    });
+
+    await waitForBackend(backendBaseUrl);
+    const project = await requestJson<{ id: string }>(
+      `${backendBaseUrl}/api/settings/projects`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          name: "Tracker E2E Project",
+          repoPaths: [repoRoot],
+        }),
+      },
+    );
+    projectId = project.id;
+    const credential = await requestJson<{ id: string }>(
+      `${backendBaseUrl}/api/settings/credentials`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          provider: "jira",
+          label: "Local Jira",
+          baseUrl: jiraBaseUrl,
+          pat: JIRA_TOKEN,
+        }),
+      },
+    );
+    await requestJson(
+      `${backendBaseUrl}/api/projects/${projectId}/tracker-links`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          credentialId: credential.id,
+          externalRef: "TEST",
+        }),
+      },
+    );
+  } catch (error) {
+    try {
+      await cleanup();
+    } catch (cleanupError) {
+      throw new AggregateError(
+        [error, cleanupError],
+        "Tracker E2E setup and cleanup failed",
+      );
+    }
+    throw error;
+  }
+});
+
+test.afterAll(async () => {
+  await cleanup();
+});
+
+test("scheduled Jira sync persists and renders before manual refresh", async ({
+  page,
+}) => {
+  const initial = await requestJson<TrackerLinksResponse>(
+    `${backendBaseUrl}/api/projects/${projectId}/tracker-links`,
+  );
+  expect(initial.trackerLinks).toHaveLength(1);
+
+  await waitForScheduledSummary();
+  expect(jiraRequestCount).toBeGreaterThanOrEqual(1);
+
+  const consoleErrors: string[] = [];
+  const pageErrors: string[] = [];
+  page.on("console", (message) => {
+    if (message.type() === "error") consoleErrors.push(message.text());
+  });
+  page.on("pageerror", (error) => pageErrors.push(error.message));
+
+  await page.goto(`${backendBaseUrl}/settings`);
+  await expect(
+    page.getByText("Deterministic Jira ticket", { exact: true }),
+  ).toBeVisible();
+  await expect(page.getByText("To Do", { exact: true })).toBeVisible();
+
+  jiraStatus = "In Progress";
+  const requestsBeforeRefresh = jiraRequestCount;
+  await page.getByRole("button", { name: "Refresh TEST" }).click();
+  await expect(page.getByText("In Progress", { exact: true })).toBeVisible();
+  expect(jiraRequestCount).toBeGreaterThanOrEqual(requestsBeforeRefresh + 1);
+  expect(consoleErrors).toEqual([]);
+  expect(pageErrors).toEqual([]);
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -46,6 +46,6 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: ["./src/setupTests.ts"],
-    exclude: ["e2e/**", "node_modules/**"],
+    exclude: ["e2e/**", "tracker-e2e/**", "node_modules/**"],
   },
 });


### PR DESCRIPTION
## Summary
- persist normalized tracker summaries separately from jobs and poll GitHub Projects, Jira, and Azure DevOps through provider adapters
- support project-scoped manual refresh and a fixed, code-owned 60-second polling cadence without inbound webhooks
- remove the retired polling interval from persisted config, settings API, generated types, and Settings UI
- render synced ticket, timestamp, error, empty, and refresh states in Settings
- add migration `0065 -> 0064` on the current mainline head
- commit an isolated production Playwright scenario at `frontend/tracker-e2e/tracker-sync.spec.ts` and run it explicitly in CI

## Validation
- 40 focused tracker/config/API backend tests passed on the final rebased tree
- Ruff and mypy passed for the changed backend surfaces
- 29 frontend test files passed: 289 passed, 1 skipped (290 total)
- frontend ESLint completed with zero errors; tracker E2E lint and TypeScript typecheck passed
- production build passed
- `uv run --no-sync alembic heads` reports the single `0065` head
- `npm --prefix frontend run test:e2e:tracker` passed against production assets, an isolated migrated `CODEPLANE_HOME`, and a local fake Jira service: the real 60-second scheduled poll persisted and rendered ticket state, manual refresh fetched the changed status, provider request shape was validated, browser console/page errors were zero, and spawned resources were removed

## Full-suite note
A broader backend settings slice produced 58 passes plus four existing Windows path/home failures unrelated to Story 3.3. The focused post-rebase Story 3.3 backend slice passes.