### PR TITLE
fix: make Cloudflare and Dev Tunnels remote access work on Windows and WSL

### DIFF
--- a/backend/cli.py
+++ b/backend/cli.py
@@ -895,7 +895,16 @@ def _pause_active_sessions(base_url: str) -> None:
 
 
 def _kill_process_group(pid: int, sig: int) -> None:
-    """Send *sig* to the process group led by *pid*, falling back to the process itself."""
+    """Send *sig* to the process group led by *pid*, falling back to the process itself.
+
+    Windows has no process groups to signal, and ``os.kill`` there terminates
+    only the named process. A connector (``cloudflared``/``devtunnel host``)
+    is a child of the server, so signalling just the server left it running
+    and still registered with the relay: ``cpl down`` reported "Server
+    stopped" while the public hostname kept a live host connection. Children
+    are therefore enumerated and terminated explicitly on Windows, matching
+    the process-group semantics this function provides on POSIX.
+    """
     import os
 
     getpgid = getattr(os, "getpgid", None)
@@ -907,9 +916,32 @@ def _kill_process_group(pid: int, sig: int) -> None:
             return
         except (ProcessLookupError, PermissionError):
             pass
+    else:
+        _kill_windows_process_tree(pid)
     # Process gone or we don't own the group — try the PID directly.
     with contextlib.suppress(ProcessLookupError, PermissionError):
         os.kill(pid, sig)
+
+
+def _kill_windows_process_tree(pid: int) -> None:
+    """Terminate the descendants of *pid* (best effort); the caller kills *pid* itself."""
+    try:
+        import psutil
+    except ImportError:
+        return
+    try:
+        children = psutil.Process(pid).children(recursive=True)
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        return
+    for child in children:
+        with contextlib.suppress(Exception):
+            child.terminate()
+    with contextlib.suppress(Exception):
+        psutil.wait_procs(children, timeout=5)
+    for child in children:
+        with contextlib.suppress(Exception):
+            if child.is_running():
+                child.kill()
 
 
 def _stop_server(port: int, timeout_seconds: int = 10) -> bool:

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -6,6 +6,7 @@ doctor, down, restart) along with tunnel management and startup helpers.
 
 from __future__ import annotations
 
+import atexit
 import contextlib
 import multiprocessing
 import signal
@@ -131,11 +132,27 @@ def _build_frontend() -> bool:
 DOTENV_PATH = Path(__file__).resolve().parent.parent / ".env"
 
 
-def _load_and_export_dotenv(dotenv_path: Path) -> dict[str, str]:
-    """Parse ``.env`` and export its entries into ``os.environ``.
+#: ``.env`` keys that are exported into ``os.environ``. Deliberately an
+#: allowlist: consumers outside this module build subprocess environments from
+#: ``os.environ`` (pty terminals in ``terminal_service``, the restart helper,
+#: every agent CLI), so exporting the whole file would push unrelated developer
+#: credentials into every child process CodePlane spawns.
+_EXPORTED_DOTENV_KEYS = frozenset(
+    {
+        "CPL_CLOUDFLARE_TUNNEL_TOKEN",
+        "CPL_CLOUDFLARE_HOSTNAME",
+        "CPL_CF_ACCESS_TEAM",
+        "CPL_CF_ACCESS_AUD",
+        "CPL_DEVTUNNEL_NAME",
+        "CPL_PASSWORD",
+    }
+)
 
-    Returns the parsed mapping so callers can keep ``.env``-over-environment
-    precedence for their own lookups.
+
+def _load_and_export_dotenv(dotenv_path: Path) -> dict[str, str]:
+    """Parse ``.env`` and export its remote-access entries into ``os.environ``.
+
+    Returns the parsed mapping so callers can resolve values themselves.
 
     The export matters because several consumers read ``os.environ``
     directly and cannot see a local mapping: ``backend.lifespan``'s
@@ -144,8 +161,12 @@ def _load_and_export_dotenv(dotenv_path: Path) -> dict[str, str]:
     setup silently lost the Zero Trust API verification strategy, and the
     restart helper replays ``cpl up`` with ``env=dict(os.environ)``, which
     dropped the tunnel credentials entirely when the replacement process ran
-    outside the repository directory. ``setdefault`` preserves any value the
-    surrounding environment already set.
+    outside the repository directory.
+
+    Only :data:`_EXPORTED_DOTENV_KEYS` are exported, and ``setdefault`` keeps
+    an explicit shell export authoritative — which is also the precedence
+    ``_env`` applies, so the CLI, the lifespan hooks and the restart helper all
+    resolve the same value when the two sources disagree.
     """
     import os
 
@@ -161,7 +182,8 @@ def _load_and_export_dotenv(dotenv_path: Path) -> dict[str, str]:
         dotenv_vars[key.strip()] = value.strip()
 
     for key, value in dotenv_vars.items():
-        os.environ.setdefault(key, value)
+        if key in _EXPORTED_DOTENV_KEYS:
+            os.environ.setdefault(key, value)
 
     return dotenv_vars
 
@@ -194,16 +216,29 @@ def _neutralize_fatal_termination_signals() -> None:
     Python's default handler merely raises ``KeyboardInterrupt``, which is why
     Ctrl-C tore down correctly while ``cpl down`` (``SIGTERM``) did not.
 
-    Installing an inert handler *before* ``server.run()`` means uvicorn restores
-    that one instead, and the re-raise becomes a no-op.
+    Installing a handler *before* ``server.run()`` means uvicorn restores that
+    one instead, and the re-raise becomes survivable. The handler restores the
+    default as it fires, so the signal is absorbed exactly once: a second
+    ``cpl down`` (or a shutdown-time ``SIGTERM``) still terminates the process
+    rather than being ignored forever.
     """
+
+    def _absorb_once(signum: int, _frame: Any) -> None:
+        with contextlib.suppress(ValueError, OSError, RuntimeError):
+            signal.signal(signum, signal.SIG_DFL)
+
+    # ``backend.lifespan._request_graceful_shutdown`` treats a callable SIGTERM
+    # handler as proof that someone will act on the signal. This one does the
+    # opposite, so it advertises itself and lets that caller take a hard stop.
+    _absorb_once.codeplane_absorbs_signal = True  # type: ignore[attr-defined]
+
     for name in ("SIGTERM", "SIGBREAK"):
         sig = getattr(signal, name, None)
         if sig is None:
             continue
         with contextlib.suppress(ValueError, OSError, RuntimeError):
             if signal.getsignal(sig) in (signal.SIG_DFL, None):
-                signal.signal(sig, lambda _sig, _frame: None)
+                signal.signal(sig, _absorb_once)
 
 
 # ---------------------------------------------------------------------------
@@ -310,13 +345,16 @@ def up(
         )
         raise SystemExit(1)
 
-    # Read credentials from .env (takes precedence) then OS environment
+    # Credentials come from the OS environment first, then ``.env``. The order
+    # must match ``_load_and_export_dotenv``'s ``setdefault`` export, otherwise
+    # this process and the consumers that read ``os.environ`` (lifespan, the
+    # restart helper) would resolve different values when the two disagree.
     import os
 
     dotenv_vars = _load_and_export_dotenv(DOTENV_PATH)
 
     def _env(key: str) -> str | None:
-        return dotenv_vars.get(key) or os.environ.get(key) or None
+        return os.environ.get(key) or dotenv_vars.get(key) or None
 
     cloudflare_token = _env("CPL_CLOUDFLARE_TUNNEL_TOKEN")
     cloudflare_hostname = _env("CPL_CLOUDFLARE_HOSTNAME")
@@ -447,6 +485,12 @@ def up(
         except TunnelStartError as exc:
             click.secho(f"ERROR: {exc}", fg="red", err=True)
             raise SystemExit(1) from exc
+        # Ownership of the connector begins here, but the ``finally`` that
+        # releases it only starts once ``server.run()`` is reached. Anything
+        # that aborts in between (a failed migration, a bad DI wiring) would
+        # otherwise leave a public tunnel pointing at a server that never came
+        # up. ``close()`` is idempotent, so the later explicit calls still win.
+        atexit.register(tunnel_handle.close)
         tunnel_origin = tunnel_handle.origin
 
         if tunnel_handle.externally_managed:
@@ -928,8 +972,14 @@ def _kill_process_group(pid: int, sig: int) -> None:
     is a child of the server, so signalling just the server left it running
     and still registered with the relay: ``cpl down`` reported "Server
     stopped" while the public hostname kept a live host connection. Children
-    are therefore enumerated and terminated explicitly on Windows, matching
-    the process-group semantics this function provides on POSIX.
+    are therefore enumerated and terminated explicitly on Windows.
+
+    The Windows path is *not* equivalent to the POSIX one: ``os.kill`` maps to
+    ``TerminateProcess`` for anything but the two console-control events, so
+    the server never runs a signal handler, uvicorn's graceful shutdown and
+    the lifespan shutdown hooks are skipped, and every descendant is hard
+    killed. See ``docs/configuration.md`` ("Tunnel Lifecycle") for what that
+    costs and why it is accepted for now.
     """
     import os
 
@@ -949,8 +999,20 @@ def _kill_process_group(pid: int, sig: int) -> None:
         os.kill(pid, sig)
 
 
+#: Connector executables that must die before anything else in the tree: they
+#: hold a public relay registration, so leaving one alive keeps the machine
+#: reachable from the internet after ``cpl down`` claims it stopped.
+_CONNECTOR_PROCESS_NAMES = frozenset({"cloudflared", "cloudflared.exe", "devtunnel", "devtunnel.exe"})
+
+
 def _kill_windows_process_tree(pid: int) -> None:
-    """Terminate the descendants of *pid* (best effort); the caller kills *pid* itself."""
+    """Hard kill the descendants of *pid* (best effort); the caller kills *pid* itself.
+
+    ``psutil.Process.terminate`` is an alias for ``kill`` on Windows, so this
+    is unconditionally ungraceful for every descendant — agent CLIs and their
+    subprocesses included. Connectors are killed first so that a slow or stuck
+    descendant cannot delay closing the public entrypoint.
+    """
     try:
         import psutil
     except ImportError:
@@ -959,7 +1021,14 @@ def _kill_windows_process_tree(pid: int) -> None:
         children = psutil.Process(pid).children(recursive=True)
     except (psutil.NoSuchProcess, psutil.AccessDenied):
         return
-    for child in children:
+
+    def _is_connector(proc: object) -> bool:
+        with contextlib.suppress(Exception):
+            return (proc.name() or "").lower() in _CONNECTOR_PROCESS_NAMES  # type: ignore[attr-defined]
+        return False
+
+    ordered = sorted(children, key=lambda child: not _is_connector(child))
+    for child in ordered:
         with contextlib.suppress(Exception):
             child.terminate()
     with contextlib.suppress(Exception):
@@ -1191,7 +1260,14 @@ def restart(
     if dev:
         args.append("--dev")
     if remote:
-        args.extend(["--remote", "--provider", provider])
+        args.append("--remote")
+        # Replaying ``--provider`` unconditionally would make the child ``up``
+        # see click's ParameterSource.COMMANDLINE for a value that is merely
+        # ``restart``'s default, suppressing Cloudflare auto-detection — so
+        # ``cpl restart --remote`` would start a Dev Tunnel where ``cpl up
+        # --remote`` starts Cloudflare. Forward it only when the user asked.
+        if _provider_explicit():
+            args.extend(["--provider", provider])
     if password:
         args.extend(["--password", password])
     if no_password:

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -182,6 +182,30 @@ def _provider_explicit() -> bool:
     return ctx.get_parameter_source("provider") is ParameterSource.COMMANDLINE
 
 
+def _neutralize_fatal_termination_signals() -> None:
+    """Make a re-raised termination signal survivable so cleanup can run.
+
+    ``uvicorn.Server.run`` captures the termination signals for the duration of
+    ``serve()``, then restores whatever handler was installed beforehand and
+    re-raises the signal it caught. When that pre-existing handler is the
+    default one, the re-raise kills the process *instantly*: ``server.run()``
+    never returns, so the ``finally`` block that stops the tunnel connector is
+    skipped and the connector is orphaned. ``SIGINT`` is harmless because
+    Python's default handler merely raises ``KeyboardInterrupt``, which is why
+    Ctrl-C tore down correctly while ``cpl down`` (``SIGTERM``) did not.
+
+    Installing an inert handler *before* ``server.run()`` means uvicorn restores
+    that one instead, and the re-raise becomes a no-op.
+    """
+    for name in ("SIGTERM", "SIGBREAK"):
+        sig = getattr(signal, name, None)
+        if sig is None:
+            continue
+        with contextlib.suppress(ValueError, OSError, RuntimeError):
+            if signal.getsignal(sig) in (signal.SIG_DFL, None):
+                signal.signal(sig, lambda _sig, _frame: None)
+
+
 # ---------------------------------------------------------------------------
 # ``cpl up`` — start the server
 # ---------------------------------------------------------------------------
@@ -577,6 +601,8 @@ def up(
                 _publish_active_launch_profile()
 
     server = _LaunchProfileServer(uv_config)
+
+    _neutralize_fatal_termination_signals()
 
     _exit_signal_count = 0
 

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -124,6 +124,13 @@ def _build_frontend() -> bool:
         return False
 
 
+#: Location of the repository ``.env``. Module-level so tests can redirect it
+#: to a scratch path instead of silently picking up the developer's real
+#: credentials — which changes provider auto-detection and, since the values
+#: are exported, leaks into ``os.environ`` for the rest of the session.
+DOTENV_PATH = Path(__file__).resolve().parent.parent / ".env"
+
+
 def _load_and_export_dotenv(dotenv_path: Path) -> dict[str, str]:
     """Parse ``.env`` and export its entries into ``os.environ``.
 
@@ -266,7 +273,7 @@ def up(
     # Read credentials from .env (takes precedence) then OS environment
     import os
 
-    dotenv_vars = _load_and_export_dotenv(Path(__file__).resolve().parent.parent / ".env")
+    dotenv_vars = _load_and_export_dotenv(DOTENV_PATH)
 
     def _env(key: str) -> str | None:
         return dotenv_vars.get(key) or os.environ.get(key) or None

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -124,6 +124,41 @@ def _build_frontend() -> bool:
         return False
 
 
+def _load_and_export_dotenv(dotenv_path: Path) -> dict[str, str]:
+    """Parse ``.env`` and export its entries into ``os.environ``.
+
+    Returns the parsed mapping so callers can keep ``.env``-over-environment
+    precedence for their own lookups.
+
+    The export matters because several consumers read ``os.environ``
+    directly and cannot see a local mapping: ``backend.lifespan``'s
+    Cloudflare Access check derives the account ID from
+    ``CPL_CLOUDFLARE_TUNNEL_TOKEN`` in ``os.environ``, so a ``.env``-only
+    setup silently lost the Zero Trust API verification strategy, and the
+    restart helper replays ``cpl up`` with ``env=dict(os.environ)``, which
+    dropped the tunnel credentials entirely when the replacement process ran
+    outside the repository directory. ``setdefault`` preserves any value the
+    surrounding environment already set.
+    """
+    import os
+
+    dotenv_vars: dict[str, str] = {}
+    if not dotenv_path.is_file():
+        return dotenv_vars
+
+    for raw_line in dotenv_path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        dotenv_vars[key.strip()] = value.strip()
+
+    for key, value in dotenv_vars.items():
+        os.environ.setdefault(key, value)
+
+    return dotenv_vars
+
+
 # ---------------------------------------------------------------------------
 # ``cpl up`` — start the server
 # ---------------------------------------------------------------------------
@@ -231,14 +266,7 @@ def up(
     # Read credentials from .env (takes precedence) then OS environment
     import os
 
-    dotenv_path = Path(__file__).resolve().parent.parent / ".env"
-    dotenv_vars: dict[str, str] = {}
-    if dotenv_path.is_file():
-        for line in dotenv_path.read_text().splitlines():
-            line = line.strip()
-            if line and not line.startswith("#") and "=" in line:
-                k, _, v = line.partition("=")
-                dotenv_vars[k.strip()] = v.strip()
+    dotenv_vars = _load_and_export_dotenv(Path(__file__).resolve().parent.parent / ".env")
 
     def _env(key: str) -> str | None:
         return dotenv_vars.get(key) or os.environ.get(key) or None

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -166,6 +166,22 @@ def _load_and_export_dotenv(dotenv_path: Path) -> dict[str, str]:
     return dotenv_vars
 
 
+def _provider_explicit() -> bool:
+    """Whether ``--provider`` was actually supplied on the command line.
+
+    ``up``'s ``--provider`` has a default of ``devtunnel``, so the parameter
+    value cannot distinguish "the user asked for devtunnel" from "nobody said
+    anything". Click records where each value came from, which is the only
+    reliable signal.
+    """
+    ctx = click.get_current_context(silent=True)
+    if ctx is None:
+        return False
+    from click.core import ParameterSource
+
+    return ctx.get_parameter_source("provider") is ParameterSource.COMMANDLINE
+
+
 # ---------------------------------------------------------------------------
 # ``cpl up`` — start the server
 # ---------------------------------------------------------------------------
@@ -262,7 +278,7 @@ def up(
             raise SystemExit(1) from exc
         port = ephemeral_socket.getsockname()[1]
 
-    if not remote and provider != "devtunnel":
+    if not remote and _provider_explicit():
         click.secho(
             f"ERROR: --provider requires --remote (got --provider {provider} without --remote).",
             fg="red",
@@ -285,8 +301,15 @@ def up(
     cf_access_team = _env("CPL_CF_ACCESS_TEAM")
     cf_access_aud = _env("CPL_CF_ACCESS_AUD")
 
-    # Auto-detect Cloudflare when --provider wasn't explicitly set but credentials exist
-    if remote and provider == "devtunnel" and cloudflare_token and cloudflare_hostname:
+    # Auto-detect Cloudflare when --provider wasn't explicitly set but credentials exist.
+    # ``provider`` defaults to "devtunnel", so its value alone cannot tell an
+    # explicit ``--provider devtunnel`` apart from the default; click's
+    # parameter source can. Without this distinction the auto-detect silently
+    # overrode a deliberate devtunnel request on any machine that happens to
+    # have Cloudflare credentials, and the restart helper — which always
+    # replays ``--provider`` explicitly — could not reproduce a recorded
+    # devtunnel session.
+    if remote and provider == "devtunnel" and cloudflare_token and cloudflare_hostname and not _provider_explicit():
         provider = "cloudflare"
 
     remote_provider = RemoteProvider(provider) if remote else RemoteProvider.local

--- a/backend/lifespan.py
+++ b/backend/lifespan.py
@@ -7,6 +7,7 @@ graceful shutdown.  Extracted from main.py to keep concerns separated.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import os
 from contextlib import asynccontextmanager
@@ -322,7 +323,16 @@ def _request_graceful_shutdown() -> None:
     import signal
 
     handler = signal.getsignal(signal.SIGTERM)
-    if callable(handler):
+    if getattr(handler, "codeplane_absorbs_signal", False):
+        # ``cli._neutralize_fatal_termination_signals`` installs a handler that
+        # swallows the signal so cleanup can run; calling it would return
+        # without shutting anything down. Restore the default first so the
+        # ``os.kill`` below is guaranteed to stop this process — this path is
+        # the emergency stop for an unprotected public exposure, where staying
+        # up is the worse outcome.
+        with contextlib.suppress(ValueError, OSError, RuntimeError):
+            signal.signal(signal.SIGTERM, signal.SIG_DFL)
+    elif callable(handler):
         try:
             handler(signal.SIGTERM, None)
             return

--- a/backend/lifespan.py
+++ b/backend/lifespan.py
@@ -306,8 +306,28 @@ async def _deferred_cloudflare_access_check(tunnel_handle: Any, app: Any) -> Non
         msg="No Cloudflare Access gate detected. Shutting down to prevent unprotected exposure.",
     )
     tunnel_handle.close()
-    # Signal the server to shut down
+    _request_graceful_shutdown()
+
+
+def _request_graceful_shutdown() -> None:
+    """Ask this process to shut down, portably.
+
+    ``os.kill(os.getpid(), signal.SIGTERM)`` is a hard ``TerminateProcess``
+    call on Windows: the process dies immediately, so uvicorn never runs its
+    graceful shutdown and the lifespan shutdown handlers (worktree cleanup,
+    lease release, DB flush) never run at all. Raising the installed SIGTERM
+    handler in-process keeps the same shutdown path on every platform, and
+    ``os.kill`` remains the fallback when no handler is installed.
+    """
     import signal
+
+    handler = signal.getsignal(signal.SIGTERM)
+    if callable(handler):
+        try:
+            handler(signal.SIGTERM, None)
+            return
+        except Exception:  # noqa: BLE001 - fall through to the hard stop below
+            log.warning("graceful_shutdown_handler_failed", exc_info=True)
 
     os.kill(os.getpid(), signal.SIGTERM)
 

--- a/backend/services/setup/dependencies.py
+++ b/backend/services/setup/dependencies.py
@@ -92,9 +92,51 @@ DEPENDENCIES: list[Dependency] = [
         url="https://aka.ms/devtunnels/cli",
         required=False,
         install_instructions={
-            "linux": "Install from https://aka.ms/devtunnels/cli",
-            "darwin": "Install from https://aka.ms/devtunnels/cli",
-            "windows": "Install from https://aka.ms/devtunnels/cli",
+            "linux": "curl -sL https://aka.ms/DevTunnelCliInstall | bash",
+            "darwin": "brew install --cask devtunnel",
+            "windows": "winget install --id Microsoft.devtunnel",
+        },
+        auto_install_cmd={
+            "darwin": ["brew", "install", "--cask", "devtunnel"],
+            "windows": [
+                "winget",
+                "install",
+                "--id",
+                "Microsoft.devtunnel",
+                "--accept-source-agreements",
+                "--accept-package-agreements",
+                "--silent",
+            ],
+        },
+    ),
+    Dependency(
+        name="Cloudflare Tunnel CLI",
+        command="cloudflared",
+        url="https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/",
+        required=False,
+        install_instructions={
+            "linux": (
+                "curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg "
+                "| sudo tee /usr/share/keyrings/cloudflare-main.gpg >/dev/null\n"
+                "echo 'deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] "
+                "https://pkg.cloudflare.com/cloudflared any main' "
+                "| sudo tee /etc/apt/sources.list.d/cloudflared.list\n"
+                "sudo apt-get update && sudo apt-get install -y cloudflared"
+            ),
+            "darwin": "brew install cloudflared",
+            "windows": "winget install --id Cloudflare.cloudflared",
+        },
+        auto_install_cmd={
+            "darwin": ["brew", "install", "cloudflared"],
+            "windows": [
+                "winget",
+                "install",
+                "--id",
+                "Cloudflare.cloudflared",
+                "--accept-source-agreements",
+                "--accept-package-agreements",
+                "--silent",
+            ],
         },
     ),
 ]

--- a/backend/services/sharing/tunnel_service.py
+++ b/backend/services/sharing/tunnel_service.py
@@ -58,6 +58,8 @@ def _windows_kill_on_close_job() -> Any:
     which case spawning proceeds unmanaged rather than failing.
     """
     global _job_handle
+    if sys.platform != "win32":
+        return None
     with _job_lock:
         if _job_handle is not None:
             return _job_handle

--- a/backend/services/sharing/tunnel_service.py
+++ b/backend/services/sharing/tunnel_service.py
@@ -40,6 +40,7 @@ log = structlog.get_logger()
 
 _job_lock = threading.Lock()
 _job_handle: Any = None
+_job_assign_warned = False
 
 
 def _windows_kill_on_close_job() -> Any:
@@ -64,6 +65,16 @@ def _windows_kill_on_close_job() -> Any:
             from ctypes import wintypes
 
             kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+            kernel32.CreateJobObjectW.restype = wintypes.HANDLE
+            kernel32.CreateJobObjectW.argtypes = [ctypes.c_void_p, wintypes.LPCWSTR]
+            kernel32.SetInformationJobObject.restype = wintypes.BOOL
+            kernel32.SetInformationJobObject.argtypes = [
+                wintypes.HANDLE,
+                ctypes.c_int,
+                ctypes.c_void_p,
+                wintypes.DWORD,
+            ]
+            kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
 
             class _IO_COUNTERS(ctypes.Structure):  # noqa: N801 - mirrors the Win32 struct name
                 _fields_ = [
@@ -118,34 +129,62 @@ def _windows_kill_on_close_job() -> Any:
             return None
 
 
-def _assign_to_kill_on_close_job(proc: subprocess.Popen[str]) -> None:
+def _assign_to_kill_on_close_job(proc: subprocess.Popen[str]) -> bool:
     """Best-effort: bind *proc* to the kill-on-close job so it cannot outlive us.
 
-    Orphan prevention is hardening, never a startup precondition: every
-    failure path degrades to an unmanaged connector rather than failing the
-    tunnel.
+    Returns whether the connector is actually covered. Orphan prevention is
+    hardening, never a startup precondition: every failure path degrades to an
+    unmanaged connector rather than failing the tunnel.
+
+    The assignment genuinely fails on some Windows hosts. Modern Windows places
+    most processes in an ambient job (so the connector inherits one at spawn),
+    and ``AssignProcessToJobObject`` then returns ``ERROR_ACCESS_DENIED``
+    rather than nesting it. The result must therefore be checked and reported:
+    discarding it left the code claiming an orphan guarantee it did not have,
+    with no way to tell the difference from a log. When this fails, an abrupt
+    kill (as opposed to a graceful shutdown, which terminates the connector
+    explicitly) leaves the connector running; the next ``cpl up`` adopts it via
+    origin-reuse detection instead of starting a second one for the same tunnel.
     """
+    global _job_assign_warned
     if sys.platform != "win32":
-        return
+        return False
     pid = getattr(proc, "pid", None)
     if not isinstance(pid, int):
-        return
+        return False
     job = _windows_kill_on_close_job()
     if job is None:
-        return
+        return False
     try:
         import ctypes
+        from ctypes import wintypes
 
         kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel32.OpenProcess.restype = wintypes.HANDLE
+        kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+        kernel32.AssignProcessToJobObject.restype = wintypes.BOOL
+        kernel32.AssignProcessToJobObject.argtypes = [wintypes.HANDLE, wintypes.HANDLE]
+        kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+
         handle = kernel32.OpenProcess(0x0200 | 0x1000 | 0x0001, False, pid)  # SET_QUOTA|SET_INFO|TERMINATE
         if not handle:
-            return
+            return False
         try:
-            kernel32.AssignProcessToJobObject(job, handle)
+            assigned = bool(kernel32.AssignProcessToJobObject(job, handle))
+            if not assigned and not _job_assign_warned:
+                _job_assign_warned = True
+                log.info(
+                    "tunnel_job_assign_unavailable",
+                    pid=pid,
+                    error=ctypes.get_last_error(),
+                    detail="connector may outlive an abrupt kill; a later start will reuse it",
+                )
+            return assigned
         finally:
             kernel32.CloseHandle(handle)
     except (OSError, AttributeError, ValueError):
         log.debug("tunnel_job_assign_failed", pid=pid, exc_info=True)
+        return False
 
 
 def _spawn_kwargs() -> dict[str, Any]:

--- a/backend/services/sharing/tunnel_service.py
+++ b/backend/services/sharing/tunnel_service.py
@@ -456,9 +456,20 @@ class TunnelWatchdog:
                     if self._stop_event.wait(timeout=self._GIVEUP_COOLDOWN):
                         return
                 consecutive_failures = 0
-            elif self._health_ok(use_tunnel_url=use_relay):
+            elif not self._health_ok():
+                # The local origin is down or has not finished starting. The
+                # connector is alive and restarting it cannot make the origin
+                # answer, so this must not count toward the restart threshold:
+                # observed on Windows, where startup takes longer than
+                # _INITIAL_DELAY and two failed origin checks tore down and
+                # respawned a perfectly healthy connector during boot.
+                log.debug("tunnel_watchdog_origin_unavailable", provider=self.label)
+                consecutive_failures = 0
+            elif not use_relay or self._health_ok(use_tunnel_url=True):
                 consecutive_failures = 0
             else:
+                # Origin healthy but the public relay does not reach it — the
+                # one condition a connector restart can actually repair.
                 consecutive_failures += 1
                 log.debug(
                     "tunnel_watchdog_check_failed",

--- a/backend/services/sharing/tunnel_service.py
+++ b/backend/services/sharing/tunnel_service.py
@@ -9,6 +9,7 @@ Supports three runtime modes:
 
 from __future__ import annotations
 
+import base64
 import contextlib
 import json
 import os
@@ -18,7 +19,7 @@ import subprocess
 import sys
 import threading
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any
 
@@ -241,7 +242,14 @@ def _terminate_and_reap(proc: subprocess.Popen[str], *, label: str = "tunnel", t
 
 
 def _signal_process_tree(proc: subprocess.Popen[str]) -> None:
-    """Send a terminate signal to *proc*, including any children it spawned."""
+    """Send a terminate signal to *proc*, including any children it spawned.
+
+    POSIX signals the whole process group. Windows has no group to signal and
+    ``Popen.terminate`` reaches only the named process, so descendants are
+    enumerated and terminated explicitly — ``devtunnel host`` in particular
+    runs its transport in a child, which survived a bare ``terminate()`` and
+    kept the tunnel serving after CodePlane thought it had torn it down.
+    """
     pid = getattr(proc, "pid", None)
     if sys.platform != "win32" and isinstance(pid, int):
         import signal
@@ -251,7 +259,24 @@ def _signal_process_tree(proc: subprocess.Popen[str]) -> None:
             return
         except OSError:
             pass  # No process group (or already gone) — fall back to a direct signal.
+    elif isinstance(pid, int):
+        _terminate_windows_descendants(pid)
     proc.terminate()
+
+
+def _terminate_windows_descendants(pid: int) -> None:
+    """Terminate the descendants of *pid* (best effort); the caller handles *pid*."""
+    try:
+        import psutil
+    except ImportError:  # pragma: no cover - psutil is a declared dependency
+        return
+    try:
+        children = psutil.Process(pid).children(recursive=True)
+    except (psutil.Error, OSError):
+        return
+    for child in children:
+        with contextlib.suppress(Exception):
+            child.terminate()
 
 
 class RemoteProvider(StrEnum):
@@ -297,22 +322,35 @@ class TunnelHandle:
     # origin can be reused as-is or must be republished after restart
     # (ARCHITECTURE-SPINE AD-8: "reusable" vs "non-reusable" origin).
     origin_is_reusable: bool = False
+    _close_lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+    _closed: bool = field(default=False, repr=False)
 
     def close(self) -> None:
-        if self.watchdog is not None:
-            self.watchdog.stop()
-            with self.watchdog._lock:
-                watchdog_proc = self.watchdog.proc
-        else:
-            watchdog_proc = None
-        # Terminate all unique process references to avoid orphans from mid-restart races
-        procs_to_kill: set[subprocess.Popen[str]] = set()
-        if self.proc is not None:
-            procs_to_kill.add(self.proc)
-        if watchdog_proc is not None:
-            procs_to_kill.add(watchdog_proc)
-        for p in procs_to_kill:
-            _terminate_and_reap(p, label=self.provider.value)
+        """Stop the connector. Safe to call repeatedly and from any thread.
+
+        Three paths race to call this during shutdown -- the second-signal
+        handler, the force-exit timer thread, and the normal ``finally`` -- so
+        without serialization each could run its own terminate/wait/kill
+        sequence against the same pids.
+        """
+        with self._close_lock:
+            if self._closed:
+                return
+            self._closed = True
+            if self.watchdog is not None:
+                self.watchdog.stop()
+                with self.watchdog._lock:
+                    watchdog_proc = self.watchdog.proc
+            else:
+                watchdog_proc = None
+            # Terminate all unique process references to avoid orphans from mid-restart races
+            procs_to_kill: set[subprocess.Popen[str]] = set()
+            if self.proc is not None:
+                procs_to_kill.add(self.proc)
+            if watchdog_proc is not None:
+                procs_to_kill.add(watchdog_proc)
+            for p in procs_to_kill:
+                _terminate_and_reap(p, label=self.provider.value)
 
 
 class TunnelWatchdog:
@@ -360,6 +398,18 @@ class TunnelWatchdog:
         self._stop_event.set()
         if self._thread is not None:
             self._thread.join(timeout=5)
+
+    def _origin_ok(self) -> bool:
+        """Whether the *local* origin is serving.
+
+        Returns ``True`` when no local port is known: the caller uses this to
+        suppress restarts while the origin is down, and an unknown origin must
+        not be reported as down — that would make every relay failure look
+        like an origin outage and disable restarts entirely.
+        """
+        if not self._local_port:
+            return True
+        return self._health_ok()
 
     def _health_ok(self, *, use_tunnel_url: bool = False) -> bool:
         import urllib.error
@@ -434,6 +484,12 @@ class TunnelWatchdog:
                 )
                 continue
             with self._lock:
+                if self._stop_event.is_set():
+                    # ``close()`` has already taken its snapshot of ``self.proc``;
+                    # a connector published after that point would never be
+                    # reaped, so retire it here instead of adopting it.
+                    _terminate_and_reap(proc, label=self.label)
+                    return True
                 self.proc = proc
 
             if self._stop_event.wait(timeout=self._RESTART_GRACE_PERIOD):
@@ -495,16 +551,24 @@ class TunnelWatchdog:
                     if self._stop_event.wait(timeout=self._GIVEUP_COOLDOWN):
                         return
                 consecutive_failures = 0
-            elif not self._health_ok():
+            elif not self._origin_ok():
                 # The local origin is down or has not finished starting. The
                 # connector is alive and restarting it cannot make the origin
                 # answer, so this must not count toward the restart threshold:
                 # observed on Windows, where startup takes longer than
                 # _INITIAL_DELAY and two failed origin checks tore down and
-                # respawned a perfectly healthy connector during boot.
+                # respawned a perfectly healthy connector during boot. The
+                # relay tally is left untouched rather than reset -- this cycle
+                # says nothing about the relay either way.
                 log.debug("tunnel_watchdog_origin_unavailable", provider=self.label)
-                consecutive_failures = 0
-            elif not use_relay or self._health_ok(use_tunnel_url=True):
+            elif not use_relay:
+                # Origin healthy, but the relay was not probed this cycle, so
+                # there is no new evidence about it. Clearing the tally here
+                # made the threshold unreachable whenever the relay is checked
+                # less often than every cycle (the production default), which
+                # silently disabled connector restarts entirely.
+                pass
+            elif self._health_ok(use_tunnel_url=True):
                 consecutive_failures = 0
             else:
                 # Origin healthy but the public relay does not reach it — the
@@ -856,17 +920,22 @@ def _find_existing_codeplane_tunnel() -> tuple[str, str] | None:
 def _devtunnel_port_registered(tunnel_name: str, port: int) -> bool:
     """Ask the service whether *port* is already registered on *tunnel_name*.
 
-    ``devtunnel port list`` prints a table whose rows start with the port
-    number, e.g. ``8080          http          0``.
+    Uses the CLI's structured output rather than its human table: the original
+    defect here was code keyed on prose the CLI never printed, and parsing a
+    localizable table would be the same bet in a new place.
     """
-    result = _run_capture(["devtunnel", "port", "list", tunnel_name])
+    result = _run_capture(["devtunnel", "port", "list", tunnel_name, "--json"])
     if result.returncode != 0:
         return False
-    for line in result.stdout.splitlines():
-        head = line.strip().split()
-        if head and head[0] == str(port):
-            return True
-    return False
+    try:
+        payload = json.loads(result.stdout)
+    except (json.JSONDecodeError, TypeError):
+        log.debug("devtunnel_port_list_unparsable", tunnel=tunnel_name)
+        return False
+    ports = payload.get("ports") if isinstance(payload, dict) else None
+    if not isinstance(ports, list):
+        return False
+    return any(isinstance(entry, dict) and entry.get("portNumber") == port for entry in ports)
 
 
 def _start_devtunnel(port: int, *, tunnel_name: str | None = None) -> tuple[str, subprocess.Popen[str], str, bool]:
@@ -927,8 +996,21 @@ def _start_devtunnel(port: int, *, tunnel_name: str | None = None) -> tuple[str,
     return tunnel_url, proc, tunnel_name, origin_is_reusable
 
 
-def _cloudflared_already_running() -> bool:
-    """Check whether a cloudflared connector is already active on this machine.
+def _cloudflare_tunnel_id(token: str) -> str | None:
+    """Extract the tunnel UUID from a Cloudflare tunnel token.
+
+    The token is base64-encoded JSON: ``{"a": account, "t": tunnel_id, "s": secret}``.
+    """
+    try:
+        decoded = base64.b64decode(token + "==")
+        tunnel_id = json.loads(decoded).get("t")
+    except Exception:
+        return None
+    return tunnel_id if isinstance(tunnel_id, str) and tunnel_id else None
+
+
+def _cloudflared_already_running(token: str) -> bool:
+    """Check whether a connector for *our* tunnel is already running here.
 
     Previously this shelled out to ``pgrep -x cloudflared``, which does not
     exist on Windows: the lookup always failed there and reported "not
@@ -938,6 +1020,15 @@ def _cloudflared_already_running() -> bool:
     Cloudflare edge balance traffic between them, so requests intermittently
     reach the stale connector. ``psutil`` gives the same answer on every
     platform.
+
+    Matching on the process *name* alone is not enough, though: a machine that
+    runs cloudflared for some unrelated tunnel would make us skip our own
+    connector and print a public URL that routes nowhere. So a process only
+    counts when its command line carries our tunnel token or the tunnel UUID
+    derived from it. A connector we cannot attribute (unreadable command line,
+    config-file mode) is treated as somebody else's, because starting a
+    redundant connector for our tunnel degrades routing while reusing a
+    stranger's connector breaks the URL outright.
     """
     try:
         import psutil
@@ -945,13 +1036,18 @@ def _cloudflared_already_running() -> bool:
         log.debug("cloudflared_detect_unavailable")
         return False
 
+    markers = {token}
+    tunnel_id = _cloudflare_tunnel_id(token)
+    if tunnel_id:
+        markers.add(tunnel_id)
+
     our_pid = os.getpid()
     try:
         our_descendants = {child.pid for child in psutil.Process(our_pid).children(recursive=True)}
     except (psutil.Error, OSError):
         our_descendants = set()
 
-    for proc in psutil.process_iter(["pid", "name"]):
+    for proc in psutil.process_iter(["pid", "name", "cmdline"]):
         try:
             name = (proc.info.get("name") or "").lower()
             # Windows reports "cloudflared.exe"; POSIX reports "cloudflared".
@@ -959,6 +1055,10 @@ def _cloudflared_already_running() -> bool:
                 continue
             pid = proc.info["pid"]
             if pid == our_pid or pid in our_descendants:
+                continue
+            cmdline = " ".join(proc.info.get("cmdline") or ())
+            if not any(marker in cmdline for marker in markers):
+                log.debug("cloudflared_foreign_connector_ignored", pid=pid)
                 continue
             return True
         except (psutil.Error, OSError):
@@ -979,7 +1079,7 @@ def _start_cloudflare(
     tunnel_url = f"https://{hostname}"
 
     # If cloudflared is already running (e.g. via systemd), reuse it
-    if _cloudflared_already_running():
+    if _cloudflared_already_running(cloudflare_token):
         log.debug("cloudflared_already_running", url=tunnel_url, port=port)
         return tunnel_url, None
 

--- a/backend/services/sharing/tunnel_service.py
+++ b/backend/services/sharing/tunnel_service.py
@@ -734,12 +734,17 @@ _CODEPLANE_TUNNEL_PREFIX = "cpl-"
 # ``devtunnel create`` reports "Unauthorized tunnel creation access: Anonymous
 # does not have 'create' access scope", so matching only on "login required"
 # silently drops the actionable hint on exactly the path a first-time user hits.
+# An expired login is reported as "Login token expired." — and, unlike the
+# other wordings, ``devtunnel user show`` still exits 0 while printing it, so
+# the text is the only signal that the CLI cannot actually reach the service.
 _DEVTUNNEL_LOGGED_OUT_MARKERS = (
     "login required",
     "not logged in",
     "anonymous does not have",
     "unauthorized tunnel",
     "please log in",
+    "token expired",
+    "login expired",
 )
 
 _DEVTUNNEL_LOGIN_HINT = "Dev Tunnels require a Microsoft or GitHub account. Run:\n  devtunnel user login"

--- a/backend/services/sharing/tunnel_service.py
+++ b/backend/services/sharing/tunnel_service.py
@@ -11,9 +11,12 @@ from __future__ import annotations
 
 import contextlib
 import json
+import os
+import platform
 import secrets
 import shutil
 import subprocess
+import threading
 import time
 from dataclasses import dataclass
 from enum import StrEnum
@@ -24,6 +27,190 @@ import structlog
 from backend.models.domain import CodePlaneError
 
 log = structlog.get_logger()
+
+IS_WINDOWS = platform.system() == "Windows"
+
+
+# ---------------------------------------------------------------------------
+# Connector process lifecycle (portable across Windows and POSIX)
+# ---------------------------------------------------------------------------
+
+
+_job_lock = threading.Lock()
+_job_handle: Any = None
+
+
+def _windows_kill_on_close_job() -> Any:
+    """Return a process-wide Windows Job Object that kills its members on close.
+
+    Connectors (``cloudflared``/``devtunnel``) are long-lived children. On
+    POSIX a supervisor can reap them via the process group, but on Windows a
+    child outlives an abruptly terminated parent, leaving an orphaned
+    connector still serving the public hostname after CodePlane is gone —
+    and a subsequent ``cpl up`` then starts a *second* connector for the same
+    tunnel. Assigning every connector to a ``JOB_OBJECT_LIMIT_KILL_ON_JOB_
+    CLOSE`` job makes the kernel terminate them as soon as this process exits,
+    however it exits. Returns ``None`` when the job cannot be created, in
+    which case spawning proceeds unmanaged rather than failing.
+    """
+    global _job_handle
+    with _job_lock:
+        if _job_handle is not None:
+            return _job_handle
+        try:
+            import ctypes
+            from ctypes import wintypes
+
+            kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+            class _IO_COUNTERS(ctypes.Structure):  # noqa: N801 - mirrors the Win32 struct name
+                _fields_ = [
+                    ("ReadOperationCount", ctypes.c_ulonglong),
+                    ("WriteOperationCount", ctypes.c_ulonglong),
+                    ("OtherOperationCount", ctypes.c_ulonglong),
+                    ("ReadTransferCount", ctypes.c_ulonglong),
+                    ("WriteTransferCount", ctypes.c_ulonglong),
+                    ("OtherTransferCount", ctypes.c_ulonglong),
+                ]
+
+            class _JOBOBJECT_BASIC_LIMIT_INFORMATION(ctypes.Structure):  # noqa: N801 - mirrors the Win32 struct name
+                _fields_ = [
+                    ("PerProcessUserTimeLimit", wintypes.LARGE_INTEGER),
+                    ("PerJobUserTimeLimit", wintypes.LARGE_INTEGER),
+                    ("LimitFlags", wintypes.DWORD),
+                    ("MinimumWorkingSetSize", ctypes.c_size_t),
+                    ("MaximumWorkingSetSize", ctypes.c_size_t),
+                    ("ActiveProcessLimit", wintypes.DWORD),
+                    ("Affinity", ctypes.POINTER(wintypes.ULONG)),
+                    ("PriorityClass", wintypes.DWORD),
+                    ("SchedulingClass", wintypes.DWORD),
+                ]
+
+            class _JOBOBJECT_EXTENDED_LIMIT_INFORMATION(ctypes.Structure):  # noqa: N801 - mirrors the Win32 struct name
+                _fields_ = [
+                    ("BasicLimitInformation", _JOBOBJECT_BASIC_LIMIT_INFORMATION),
+                    ("IoInfo", _IO_COUNTERS),
+                    ("ProcessMemoryLimit", ctypes.c_size_t),
+                    ("JobMemoryLimit", ctypes.c_size_t),
+                    ("PeakProcessMemoryUsed", ctypes.c_size_t),
+                    ("PeakJobMemoryUsed", ctypes.c_size_t),
+                ]
+
+            job = kernel32.CreateJobObjectW(None, None)
+            if not job:
+                return None
+            info = _JOBOBJECT_EXTENDED_LIMIT_INFORMATION()
+            info.BasicLimitInformation.LimitFlags = 0x2000  # KILL_ON_JOB_CLOSE
+            if not kernel32.SetInformationJobObject(
+                job,
+                9,  # JobObjectExtendedLimitInformation
+                ctypes.byref(info),
+                ctypes.sizeof(info),
+            ):
+                kernel32.CloseHandle(job)
+                return None
+            _job_handle = job
+            return job
+        except (OSError, AttributeError, ValueError):
+            log.debug("tunnel_job_object_unavailable", exc_info=True)
+            return None
+
+
+def _assign_to_kill_on_close_job(proc: subprocess.Popen[str]) -> None:
+    """Best-effort: bind *proc* to the kill-on-close job so it cannot outlive us.
+
+    Orphan prevention is hardening, never a startup precondition: every
+    failure path degrades to an unmanaged connector rather than failing the
+    tunnel.
+    """
+    if not IS_WINDOWS:
+        return
+    pid = getattr(proc, "pid", None)
+    if not isinstance(pid, int):
+        return
+    job = _windows_kill_on_close_job()
+    if job is None:
+        return
+    try:
+        import ctypes
+
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        handle = kernel32.OpenProcess(0x0200 | 0x1000 | 0x0001, False, pid)  # SET_QUOTA|SET_INFO|TERMINATE
+        if not handle:
+            return
+        try:
+            kernel32.AssignProcessToJobObject(job, handle)
+        finally:
+            kernel32.CloseHandle(handle)
+    except (OSError, AttributeError, ValueError):
+        log.debug("tunnel_job_assign_failed", pid=pid, exc_info=True)
+
+
+def _spawn_kwargs() -> dict[str, Any]:
+    """Popen keyword arguments that keep a connector reapable on this platform."""
+    if IS_WINDOWS:
+        # A new process group prevents a console Ctrl+C aimed at CodePlane from
+        # racing our own explicit terminate/kill sequence for the connector.
+        return {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP}
+    # A dedicated session lets us signal the whole connector process tree,
+    # since cloudflared/devtunnel may fork helpers of their own.
+    return {"start_new_session": True}
+
+
+def _spawn_connector(command: list[str], *, env: dict[str, str] | None = None) -> subprocess.Popen[str]:
+    """Start a connector process with portable orphan-prevention applied."""
+    proc = subprocess.Popen(  # noqa: S603 - fixed connector argv built from validated config
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        env=env,
+        **_spawn_kwargs(),
+    )
+    _assign_to_kill_on_close_job(proc)
+    return proc
+
+
+def _terminate_and_reap(proc: subprocess.Popen[str], *, label: str = "tunnel", timeout: float = 5) -> None:
+    """Terminate *proc* and guarantee it is reaped, on any platform.
+
+    ``Popen.wait`` raises ``subprocess.TimeoutExpired``, which is a
+    ``SubprocessError`` and **not** an ``OSError``. Catching only ``OSError``
+    here (the previous behavior) let a connector that ignores the terminate
+    signal propagate an exception out of shutdown, abandoning every remaining
+    cleanup step and leaking the sibling connector process. This never raises.
+    """
+    if proc.poll() is not None:
+        return
+    pid = getattr(proc, "pid", None)
+    try:
+        _signal_process_tree(proc)
+        proc.wait(timeout=timeout)
+        return
+    except subprocess.TimeoutExpired:
+        log.warning("tunnel_terminate_timeout", provider=label, pid=pid, timeout_seconds=timeout)
+    except OSError:
+        log.debug("tunnel_terminate_failed", provider=label, pid=pid, exc_info=True)
+
+    try:
+        proc.kill()
+        proc.wait(timeout=timeout)
+    except (subprocess.TimeoutExpired, OSError):
+        log.warning("tunnel_kill_failed", provider=label, pid=pid)
+
+
+def _signal_process_tree(proc: subprocess.Popen[str]) -> None:
+    """Send a terminate signal to *proc*, including any children it spawned."""
+    pid = getattr(proc, "pid", None)
+    if not IS_WINDOWS and isinstance(pid, int):
+        import signal
+
+        try:
+            os.killpg(os.getpgid(pid), signal.SIGTERM)
+            return
+        except OSError:
+            pass  # No process group (or already gone) — fall back to a direct signal.
+    proc.terminate()
 
 
 class RemoteProvider(StrEnum):
@@ -84,12 +271,7 @@ class TunnelHandle:
         if watchdog_proc is not None:
             procs_to_kill.add(watchdog_proc)
         for p in procs_to_kill:
-            try:
-                p.terminate()
-                p.wait(timeout=5)
-            except OSError:
-                with contextlib.suppress(OSError):
-                    p.kill()
+            _terminate_and_reap(p, label=self.provider.value)
 
 
 class TunnelWatchdog:
@@ -123,8 +305,8 @@ class TunnelWatchdog:
         self.proc = proc
         self.label = label
         self._local_port = local_port
-        self._stop_event = __import__("threading").Event()
-        self._lock = __import__("threading").Lock()
+        self._stop_event = threading.Event()
+        self._lock = threading.Lock()
         self._thread: Any = None
 
     def start(self) -> None:
@@ -162,12 +344,7 @@ class TunnelWatchdog:
         current = proc or self.proc
         if current is None:
             return
-        try:
-            current.terminate()
-            current.wait(timeout=5)
-        except OSError:
-            with contextlib.suppress(OSError):
-                current.kill()
+        _terminate_and_reap(current, label=self.label)
 
     def _read_process_output(self, proc: subprocess.Popen[str]) -> str:
         if proc.stdout is None:
@@ -193,7 +370,7 @@ class TunnelWatchdog:
         log.debug("tunnel_watchdog_restarting", provider=self.label)
         last_error = "unknown restart failure"
 
-        env = {**__import__("os").environ, **(self.restart_env or {})} if self.restart_env else None
+        env = {**os.environ, **(self.restart_env or {})} if self.restart_env else None
 
         for attempt in range(1, self._RESTART_ATTEMPTS + 1):
             if attempt > 1:
@@ -204,13 +381,17 @@ class TunnelWatchdog:
 
             self._terminate_process()
 
-            proc = subprocess.Popen(
-                self.restart_command,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=True,
-                env=env,
-            )
+            try:
+                proc = _spawn_connector(self.restart_command, env=env)
+            except OSError as exc:
+                last_error = f"could not spawn {self.restart_command[0]}: {exc}"
+                log.warning(
+                    "tunnel_watchdog_restart_spawn_failed",
+                    provider=self.label,
+                    attempt=attempt,
+                    reason=last_error,
+                )
+                continue
             with self._lock:
                 self.proc = proc
 
@@ -338,9 +519,13 @@ def validate_remote_provider(
         return None
 
     if provider is RemoteProvider.devtunnel:
-        if shutil.which("devtunnel"):
-            return None
-        return "ERROR: 'devtunnel' CLI not found.\n  Install: https://aka.ms/devtunnels/cli\n  Or run: cpl setup"
+        if not shutil.which("devtunnel"):
+            return "ERROR: 'devtunnel' CLI not found.\n  Install: https://aka.ms/devtunnels/cli\n  Or run: cpl setup"
+        if not devtunnel_logged_in():
+            # Catch the logged-out state during validation rather than letting
+            # `devtunnel create` fail later with an opaque access-scope error.
+            return f"ERROR: The Dev Tunnels CLI is not logged in.\n  {_DEVTUNNEL_LOGIN_HINT}"
+        return None
 
     missing: list[str] = []
     if not cloudflare_hostname:
@@ -415,14 +600,8 @@ def _start_cloudflare_managed(
     hostname = cloudflare_hostname.removeprefix("https://").rstrip("/")
     tunnel_url = f"https://{hostname}"
 
-    env = {**__import__("os").environ, "TUNNEL_TOKEN": cloudflare_token}
-    proc = subprocess.Popen(
-        ["cloudflared", "tunnel", "--no-autoupdate", "run"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        env=env,
-    )
+    env = {**os.environ, "TUNNEL_TOKEN": cloudflare_token}
+    proc = _spawn_connector(["cloudflared", "tunnel", "--no-autoupdate", "run"], env=env)
     _wait_for_startup(proc, label="cloudflare")
     _start_output_drain(proc)
 
@@ -526,10 +705,56 @@ def start_remote_access(
 
 
 def _run_capture(args: list[str]) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(args, capture_output=True, text=True, timeout=30)
+    """Run a provider CLI command, never raising on timeout or a missing binary.
+
+    ``subprocess.run(timeout=...)`` raises ``TimeoutExpired`` and a missing
+    executable raises ``FileNotFoundError``; both used to escape every caller
+    and surface as a raw traceback out of ``cpl up`` instead of a
+    ``TunnelStartError`` with an actionable message. A synthetic non-zero
+    result is returned instead so callers keep their normal error handling.
+    """
+    try:
+        return subprocess.run(args, capture_output=True, text=True, timeout=30)  # noqa: S603
+    except subprocess.TimeoutExpired:
+        log.warning("tunnel_cli_timeout", command=args[0], timeout_seconds=30)
+        return subprocess.CompletedProcess(args, returncode=124, stdout="", stderr=f"{args[0]} timed out after 30s")
+    except FileNotFoundError:
+        return subprocess.CompletedProcess(args, returncode=127, stdout="", stderr=f"{args[0]} executable not found")
+    except OSError as exc:
+        log.warning("tunnel_cli_failed", command=args[0], error=str(exc))
+        return subprocess.CompletedProcess(args, returncode=126, stdout="", stderr=str(exc))
 
 
 _CODEPLANE_TUNNEL_PREFIX = "cpl-"
+
+# Substrings that identify a logged-out Dev Tunnels CLI. The CLI does not use a
+# single consistent phrasing: ``devtunnel list`` says "Login required." while
+# ``devtunnel create`` reports "Unauthorized tunnel creation access: Anonymous
+# does not have 'create' access scope", so matching only on "login required"
+# silently drops the actionable hint on exactly the path a first-time user hits.
+_DEVTUNNEL_LOGGED_OUT_MARKERS = (
+    "login required",
+    "not logged in",
+    "anonymous does not have",
+    "unauthorized tunnel",
+    "please log in",
+)
+
+_DEVTUNNEL_LOGIN_HINT = "Dev Tunnels require a Microsoft or GitHub account. Run:\n  devtunnel user login"
+
+
+def _looks_logged_out(text: str) -> bool:
+    lowered = text.lower()
+    return any(marker in lowered for marker in _DEVTUNNEL_LOGGED_OUT_MARKERS)
+
+
+def devtunnel_logged_in() -> bool:
+    """Return whether the Dev Tunnels CLI currently holds a usable login."""
+    result = _run_capture(["devtunnel", "user", "show"])
+    if result.returncode != 0:
+        return False
+    combined = f"{result.stdout}\n{result.stderr}"
+    return not _looks_logged_out(combined)
 
 
 def _list_devtunnels() -> list[dict[str, Any]]:
@@ -597,21 +822,27 @@ def _start_devtunnel(port: int, *, tunnel_name: str | None = None) -> tuple[str,
         create_result = _run_capture(["devtunnel", "create", tunnel_name, "--expiration", "30d"])
         if create_result.returncode != 0:
             msg = create_result.stderr.strip() or create_result.stdout.strip() or "devtunnel create failed"
-            if "not logged in" in msg.lower() or "login required" in msg.lower():
-                msg += "\n\nDev Tunnels require a Microsoft account. Run:\n  devtunnel user login"
+            if _looks_logged_out(msg):
+                msg += f"\n\n{_DEVTUNNEL_LOGIN_HINT}"
             raise TunnelStartError(msg)
 
-    _run_capture(["devtunnel", "port", "create", tunnel_name, "-p", str(port), "--protocol", "http"])
+    port_result = _run_capture(["devtunnel", "port", "create", tunnel_name, "-p", str(port), "--protocol", "http"])
+    if port_result.returncode != 0:
+        # An already-registered port is the normal case when reusing a tunnel;
+        # anything else means the tunnel cannot forward and must not be treated
+        # as usable just because the process starts.
+        detail = (port_result.stderr.strip() or port_result.stdout.strip()).lower()
+        if "already" not in detail and "exists" not in detail:
+            raise TunnelStartError(
+                f"Could not register port {port} on Dev Tunnel {tunnel_name!r}: "
+                f"{port_result.stderr.strip() or port_result.stdout.strip() or 'unknown error'}"
+            )
+
     _, region = _lookup_devtunnel(tunnel_name)
     if not region:
         raise TunnelStartError("Could not determine the Dev Tunnel region.")
 
-    proc = subprocess.Popen(
-        ["devtunnel", "host", tunnel_name],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-    )
+    proc = _spawn_connector(["devtunnel", "host", tunnel_name])
     _wait_for_startup(proc, label="devtunnel")
     _start_output_drain(proc)
 
@@ -621,23 +852,42 @@ def _start_devtunnel(port: int, *, tunnel_name: str | None = None) -> tuple[str,
 
 
 def _cloudflared_already_running() -> bool:
-    """Check if a cloudflared tunnel process is already active on the system."""
-    import os
+    """Check whether a cloudflared connector is already active on this machine.
 
+    Previously this shelled out to ``pgrep -x cloudflared``, which does not
+    exist on Windows: the lookup always failed there and reported "not
+    running", so ``cpl up --remote --provider cloudflare`` started a *second*
+    connector alongside an existing one (e.g. the cloudflared Windows
+    service). Two connectors registered for the same tunnel make the
+    Cloudflare edge balance traffic between them, so requests intermittently
+    reach the stale connector. ``psutil`` gives the same answer on every
+    platform.
+    """
     try:
-        result = subprocess.run(
-            ["pgrep", "-x", "cloudflared"],
-            capture_output=True,
-            timeout=5,
-        )
-        if result.returncode != 0:
-            return False
-        # Verify at least one matched PID is not our own process tree
-        our_pid = os.getpid()
-        pids = [int(p) for p in result.stdout.split() if p.strip()]
-        return any(pid != our_pid for pid in pids)
-    except (OSError, subprocess.TimeoutExpired):
+        import psutil
+    except ImportError:  # pragma: no cover - psutil is a declared dependency
+        log.debug("cloudflared_detect_unavailable")
         return False
+
+    our_pid = os.getpid()
+    try:
+        our_descendants = {child.pid for child in psutil.Process(our_pid).children(recursive=True)}
+    except (psutil.Error, OSError):
+        our_descendants = set()
+
+    for proc in psutil.process_iter(["pid", "name"]):
+        try:
+            name = (proc.info.get("name") or "").lower()
+            # Windows reports "cloudflared.exe"; POSIX reports "cloudflared".
+            if name not in ("cloudflared", "cloudflared.exe"):
+                continue
+            pid = proc.info["pid"]
+            if pid == our_pid or pid in our_descendants:
+                continue
+            return True
+        except (psutil.Error, OSError):
+            continue
+    return False
 
 
 def _start_cloudflare(
@@ -657,14 +907,8 @@ def _start_cloudflare(
         log.debug("cloudflared_already_running", url=tunnel_url, port=port)
         return tunnel_url, None
 
-    env = {**__import__("os").environ, "TUNNEL_TOKEN": cloudflare_token}
-    proc = subprocess.Popen(
-        ["cloudflared", "tunnel", "--no-autoupdate", "run"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        env=env,
-    )
+    env = {**os.environ, "TUNNEL_TOKEN": cloudflare_token}
+    proc = _spawn_connector(["cloudflared", "tunnel", "--no-autoupdate", "run"], env=env)
     _wait_for_startup(proc, label="cloudflare")
     _start_output_drain(proc)
 

--- a/backend/services/sharing/tunnel_service.py
+++ b/backend/services/sharing/tunnel_service.py
@@ -12,10 +12,10 @@ from __future__ import annotations
 import contextlib
 import json
 import os
-import platform
 import secrets
 import shutil
 import subprocess
+import sys
 import threading
 import time
 from dataclasses import dataclass
@@ -28,11 +28,13 @@ from backend.models.domain import CodePlaneError
 
 log = structlog.get_logger()
 
-IS_WINDOWS = platform.system() == "Windows"
-
 
 # ---------------------------------------------------------------------------
 # Connector process lifecycle (portable across Windows and POSIX)
+#
+# Platform branches below test ``sys.platform`` rather than
+# ``platform.system()`` so type checkers narrow the Win32-only and POSIX-only
+# calls on either host.
 # ---------------------------------------------------------------------------
 
 
@@ -123,7 +125,7 @@ def _assign_to_kill_on_close_job(proc: subprocess.Popen[str]) -> None:
     failure path degrades to an unmanaged connector rather than failing the
     tunnel.
     """
-    if not IS_WINDOWS:
+    if sys.platform != "win32":
         return
     pid = getattr(proc, "pid", None)
     if not isinstance(pid, int):
@@ -148,7 +150,7 @@ def _assign_to_kill_on_close_job(proc: subprocess.Popen[str]) -> None:
 
 def _spawn_kwargs() -> dict[str, Any]:
     """Popen keyword arguments that keep a connector reapable on this platform."""
-    if IS_WINDOWS:
+    if sys.platform == "win32":
         # A new process group prevents a console Ctrl+C aimed at CodePlane from
         # racing our own explicit terminate/kill sequence for the connector.
         return {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP}
@@ -202,7 +204,7 @@ def _terminate_and_reap(proc: subprocess.Popen[str], *, label: str = "tunnel", t
 def _signal_process_tree(proc: subprocess.Popen[str]) -> None:
     """Send a terminate signal to *proc*, including any children it spawned."""
     pid = getattr(proc, "pid", None)
-    if not IS_WINDOWS and isinstance(pid, int):
+    if sys.platform != "win32" and isinstance(pid, int):
         import signal
 
         try:

--- a/backend/services/sharing/tunnel_service.py
+++ b/backend/services/sharing/tunnel_service.py
@@ -853,6 +853,22 @@ def _find_existing_codeplane_tunnel() -> tuple[str, str] | None:
     return None
 
 
+def _devtunnel_port_registered(tunnel_name: str, port: int) -> bool:
+    """Ask the service whether *port* is already registered on *tunnel_name*.
+
+    ``devtunnel port list`` prints a table whose rows start with the port
+    number, e.g. ``8080          http          0``.
+    """
+    result = _run_capture(["devtunnel", "port", "list", tunnel_name])
+    if result.returncode != 0:
+        return False
+    for line in result.stdout.splitlines():
+        head = line.strip().split()
+        if head and head[0] == str(port):
+            return True
+    return False
+
+
 def _start_devtunnel(port: int, *, tunnel_name: str | None = None) -> tuple[str, subprocess.Popen[str], str, bool]:
     # Reusable means the identity is either explicitly configured by the
     # caller or an already-registered codeplane tunnel — restart tooling can
@@ -884,16 +900,19 @@ def _start_devtunnel(port: int, *, tunnel_name: str | None = None) -> tuple[str,
             raise TunnelStartError(msg)
 
     port_result = _run_capture(["devtunnel", "port", "create", tunnel_name, "-p", str(port), "--protocol", "http"])
-    if port_result.returncode != 0:
-        # An already-registered port is the normal case when reusing a tunnel;
-        # anything else means the tunnel cannot forward and must not be treated
-        # as usable just because the process starts.
-        detail = (port_result.stderr.strip() or port_result.stdout.strip()).lower()
-        if "already" not in detail and "exists" not in detail:
-            raise TunnelStartError(
-                f"Could not register port {port} on Dev Tunnel {tunnel_name!r}: "
-                f"{port_result.stderr.strip() or port_result.stdout.strip() or 'unknown error'}"
-            )
+    if port_result.returncode != 0 and not _devtunnel_port_registered(tunnel_name, port):
+        # A port that is already registered is the normal case when reusing a
+        # tunnel, and the real CLI reports it as "Tunnel service error:
+        # Conflict with existing entity" — not the "already"/"exists" wording
+        # this once matched on, so every reuse of an existing tunnel aborted
+        # the run. Asking the service which ports exist is authoritative and
+        # survives rewordings and localized output; a genuine failure still
+        # raises, because a tunnel that cannot forward must not be treated as
+        # usable just because the host process starts.
+        raise TunnelStartError(
+            f"Could not register port {port} on Dev Tunnel {tunnel_name!r}: "
+            f"{port_result.stderr.strip() or port_result.stdout.strip() or 'unknown error'}"
+        )
 
     _, region = _lookup_devtunnel(tunnel_name)
     if not region:

--- a/backend/tests/unit/test_cli.py
+++ b/backend/tests/unit/test_cli.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import os
 import signal
+import subprocess
 import sys
+import textwrap
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -218,6 +222,50 @@ class TestIsServerRunning:
 # ---------------------------------------------------------------------------
 # _stop_server
 # ---------------------------------------------------------------------------
+
+
+class TestTerminationSignalIsSurvivable:
+    """``cpl up`` must still run its cleanup after a ``SIGTERM``.
+
+    ``uvicorn.Server.run`` restores the pre-existing termination handler once
+    ``serve()`` returns and then re-raises the signal it caught. With the
+    default handler in place that re-raise kills the process outright, so the
+    ``finally`` block that closes the tunnel handle never executes and the
+    connector is orphaned -- ``cpl down`` reported success while the public
+    origin still had a live host connection. This replays uvicorn's exact
+    capture/restore/re-raise dance in a subprocess (a live ``SIGTERM`` would
+    otherwise take the test runner with it).
+    """
+
+    SCRIPT = textwrap.dedent(
+        """
+        import signal, sys
+        from backend import cli
+
+        cli._neutralize_fatal_termination_signals()
+
+        # --- uvicorn.Server.capture_signals() ---
+        captured = signal.getsignal(signal.SIGTERM)
+        signal.signal(signal.SIGTERM, lambda *_: None)
+        signal.raise_signal(signal.SIGTERM)   # the signal cpl down sends
+        signal.signal(signal.SIGTERM, captured)
+        signal.raise_signal(signal.SIGTERM)   # uvicorn re-raises it
+        # --- back in cpl up's finally: ---
+        print("CLEANUP", flush=True)
+        """
+    )
+
+    def test_cleanup_runs_after_uvicorn_reraises_sigterm(self) -> None:
+        env = {**os.environ, "PYTHONPATH": str(Path(cli_module.__file__).parents[2])}
+        result = subprocess.run(
+            [sys.executable, "-c", self.SCRIPT],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env=env,
+        )
+        assert "CLEANUP" in result.stdout, f"cleanup was skipped; rc={result.returncode} stderr={result.stderr}"
+        assert result.returncode == 0
 
 
 class TestKillProcessGroupOnWindows:

--- a/backend/tests/unit/test_cli.py
+++ b/backend/tests/unit/test_cli.py
@@ -239,33 +239,66 @@ class TestTerminationSignalIsSurvivable:
 
     SCRIPT = textwrap.dedent(
         """
-        import signal, sys
+        import signal
+        import uvicorn
         from backend import cli
+
+        async def _app(scope, receive, send):
+            pass
 
         cli._neutralize_fatal_termination_signals()
 
-        # --- uvicorn.Server.capture_signals() ---
-        captured = signal.getsignal(signal.SIGTERM)
-        signal.signal(signal.SIGTERM, lambda *_: None)
-        signal.raise_signal(signal.SIGTERM)   # the signal cpl down sends
-        signal.signal(signal.SIGTERM, captured)
-        signal.raise_signal(signal.SIGTERM)   # uvicorn re-raises it
-        # --- back in cpl up's finally: ---
+        # Drive the *real* uvicorn signal machinery rather than a replica of
+        # it, so this test fails if uvicorn's capture/restore/re-raise
+        # behavior changes underneath us.
+        server = uvicorn.Server(uvicorn.Config(app=_app))
+        with server.capture_signals():
+            signal.raise_signal(signal.SIGTERM)   # the signal cpl down sends
+        # Leaving the context manager restores the previous handler and
+        # re-raises; reaching the next line is what cpl up's finally needs.
         print("CLEANUP", flush=True)
         """
     )
 
-    def test_cleanup_runs_after_uvicorn_reraises_sigterm(self) -> None:
+    SECOND_SIGNAL_SCRIPT = textwrap.dedent(
+        """
+        import signal
+        from backend import cli
+
+        cli._neutralize_fatal_termination_signals()
+        signal.raise_signal(signal.SIGTERM)   # absorbed once, so cleanup can run
+        print("ABSORBED", flush=True)
+        signal.raise_signal(signal.SIGTERM)   # a second one must still kill us
+        print("STILL_ALIVE", flush=True)
+        """
+    )
+
+    def _run(self, script: str) -> subprocess.CompletedProcess[str]:
         env = {**os.environ, "PYTHONPATH": str(Path(cli_module.__file__).parents[2])}
-        result = subprocess.run(
-            [sys.executable, "-c", self.SCRIPT],
+        return subprocess.run(
+            [sys.executable, "-c", script],
             capture_output=True,
             text=True,
             timeout=60,
             env=env,
         )
+
+    def test_cleanup_runs_after_uvicorn_reraises_sigterm(self) -> None:
+        result = self._run(self.SCRIPT)
         assert "CLEANUP" in result.stdout, f"cleanup was skipped; rc={result.returncode} stderr={result.stderr}"
         assert result.returncode == 0
+
+    def test_a_second_sigterm_still_terminates_the_process(self) -> None:
+        """Surviving the re-raise must not make the server unkillable.
+
+        The handler absorbs one signal so teardown can run; leaving it
+        installed would mean a second ``cpl down``, or a ``SIGTERM`` arriving
+        during a slow teardown, is silently ignored forever.
+        """
+        result = self._run(self.SECOND_SIGNAL_SCRIPT)
+        assert "ABSORBED" in result.stdout, f"the first signal was not survived; stderr={result.stderr}"
+        assert "STILL_ALIVE" not in result.stdout, "a second SIGTERM was ignored; the process is unkillable"
+        assert result.returncode != 0
 
 
 class TestKillProcessGroupOnWindows:
@@ -308,6 +341,39 @@ class TestKillProcessGroupOnWindows:
 
         mock_killpg.assert_called_once_with(100, 15)
         fake_psutil.Process.assert_not_called()
+
+    def test_connectors_are_killed_before_the_rest_of_the_tree(self) -> None:
+        """The connector holds the public relay registration.
+
+        Every descendant is hard killed here (psutil's `terminate` is an alias
+        for `kill` on Windows), and an agent CLI that is slow to die must not
+        delay closing the internet-facing entrypoint.
+        """
+        order: list[str] = []
+
+        def _make(name: str) -> MagicMock:
+            proc = MagicMock()
+            proc.name.return_value = name
+            proc.is_running.return_value = False
+            proc.terminate.side_effect = lambda: order.append(name)
+            return proc
+
+        agent = _make("copilot.exe")
+        connector = _make("cloudflared.exe")
+        fake_psutil = MagicMock()
+        fake_psutil.NoSuchProcess = RuntimeError
+        fake_psutil.AccessDenied = PermissionError
+        fake_psutil.Process.return_value.children.return_value = [agent, connector]
+
+        with (
+            patch.dict(sys.modules, {"psutil": fake_psutil}),
+            patch("os.getpgid", None, create=True),
+            patch("os.killpg", None, create=True),
+            patch("os.kill"),
+        ):
+            cli_module._kill_process_group(100, 15)
+
+        assert order == ["cloudflared.exe", "copilot.exe"]
 
 
 class TestStopServer:
@@ -502,6 +568,33 @@ class TestRestart:
             result = runner.invoke(cli, ["restart", "--remote"])  # noqa: F841
         args = mock_exec.call_args[0][1]
         assert "--remote" in args
+
+    def test_default_provider_is_not_replayed(self) -> None:
+        """Replaying the default would defeat Cloudflare auto-detection.
+
+        `up` distinguishes "the user asked for devtunnel" from "nobody said
+        anything" via click's parameter source. `restart` has its own
+        `--provider` default, so forwarding it unconditionally made the child
+        see COMMANDLINE and skip auto-detection: `cpl up --remote` started
+        Cloudflare while `cpl restart --remote` started a Dev Tunnel.
+        """
+        runner = CliRunner()
+        with (
+            patch("backend.cli._is_server_running", return_value=(False, [])),
+            patch("os.execv") as mock_exec,
+        ):
+            runner.invoke(cli, ["restart", "--remote"])
+        assert "--provider" not in mock_exec.call_args[0][1]
+
+    def test_explicit_provider_is_forwarded(self) -> None:
+        runner = CliRunner()
+        with (
+            patch("backend.cli._is_server_running", return_value=(False, [])),
+            patch("os.execv") as mock_exec,
+        ):
+            runner.invoke(cli, ["restart", "--remote", "--provider", "cloudflare"])
+        args = mock_exec.call_args[0][1]
+        assert args[args.index("--provider") + 1] == "cloudflare"
 
 
 # ---------------------------------------------------------------------------
@@ -877,10 +970,35 @@ class TestDotenvExport:
         env_file.write_text("CPL_CLOUDFLARE_HOSTNAME=from-dotenv.example.com\n")
         with patch.dict("os.environ", {"CPL_CLOUDFLARE_HOSTNAME": "from-shell.example.com"}):
             parsed = _load_and_export_dotenv(env_file)
-            # .env keeps precedence for the CLI's own lookups...
+            # The raw file contents are still returned...
             assert parsed["CPL_CLOUDFLARE_HOSTNAME"] == "from-dotenv.example.com"
-            # ...but an explicitly exported shell value is never overwritten.
+            # ...but an explicitly exported shell value is never overwritten,
+            # and `_env` resolves in the same order, so this process and the
+            # consumers reading `os.environ` agree on one value.
             assert os.environ["CPL_CLOUDFLARE_HOSTNAME"] == "from-shell.example.com"
+
+    def test_unrelated_keys_are_not_exported(self, tmp_path) -> None:
+        """`.env` entries leak into every subprocess CodePlane spawns.
+
+        `terminal_service` builds its pty environment from `os.environ` and
+        agent CLIs inherit it by default, so exporting the whole file would
+        hand an unrelated developer credential to every interactive terminal
+        opened through the web UI.
+        """
+        import os
+
+        from backend.cli import _load_and_export_dotenv
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("CPL_CLOUDFLARE_HOSTNAME=cpl.example.com\nOPENAI_API_KEY=unrelated-secret-do-not-leak\n")
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("CPL_CLOUDFLARE_HOSTNAME", None)
+            os.environ.pop("OPENAI_API_KEY", None)
+            parsed = _load_and_export_dotenv(env_file)
+
+            assert parsed["OPENAI_API_KEY"] == "unrelated-secret-do-not-leak"
+            assert os.environ["CPL_CLOUDFLARE_HOSTNAME"] == "cpl.example.com"
+            assert "OPENAI_API_KEY" not in os.environ
 
     def test_missing_file_is_not_an_error(self, tmp_path) -> None:
         from backend.cli import _load_and_export_dotenv

--- a/backend/tests/unit/test_cli.py
+++ b/backend/tests/unit/test_cli.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import signal
+import sys
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
 
+from backend import cli as cli_module
 from backend.cli import (
     _find_pids_on_port,
     _find_pids_on_port_posix,
@@ -216,6 +218,48 @@ class TestIsServerRunning:
 # ---------------------------------------------------------------------------
 # _stop_server
 # ---------------------------------------------------------------------------
+
+
+class TestKillProcessGroupOnWindows:
+    """Stopping the server must take its connector children with it.
+
+    Windows has no process group to signal and ``os.kill`` there terminates
+    only the named process, so a ``cloudflared``/``devtunnel host`` child
+    survived ``cpl down``: the command printed "Server stopped" while the
+    public hostname still had a live host connection to a machine whose
+    server was gone.
+    """
+
+    def test_children_are_terminated_when_no_process_groups_exist(self) -> None:
+        child = MagicMock()
+        child.is_running.return_value = False
+        fake_psutil = MagicMock()
+        fake_psutil.NoSuchProcess = RuntimeError
+        fake_psutil.AccessDenied = PermissionError
+        fake_psutil.Process.return_value.children.return_value = [child]
+
+        with (
+            patch.dict(sys.modules, {"psutil": fake_psutil}),
+            patch("os.getpgid", None, create=True),
+            patch("os.killpg", None, create=True),
+            patch("os.kill"),
+        ):
+            cli_module._kill_process_group(100, 15)
+
+        fake_psutil.Process.return_value.children.assert_called_once_with(recursive=True)
+        child.terminate.assert_called_once()
+
+    def test_process_groups_are_preferred_where_they_exist(self) -> None:
+        fake_psutil = MagicMock()
+        with (
+            patch.dict(sys.modules, {"psutil": fake_psutil}),
+            patch("os.getpgid", return_value=100, create=True),
+            patch("os.killpg", create=True) as mock_killpg,
+        ):
+            cli_module._kill_process_group(100, 15)
+
+        mock_killpg.assert_called_once_with(100, 15)
+        fake_psutil.Process.assert_not_called()
 
 
 class TestStopServer:

--- a/backend/tests/unit/test_cli.py
+++ b/backend/tests/unit/test_cli.py
@@ -671,3 +671,55 @@ class TestUpLaunchProfilePublication:
             result, written = _invoke_up(["--no-password"], owning_pids=[999999])
         assert result.exit_code != 0
         assert written is None
+
+
+class TestDotenvExport:
+    """`.env` values must reach `os.environ`.
+
+    `backend.lifespan` reads CPL_CLOUDFLARE_TUNNEL_TOKEN from `os.environ` to
+    derive the Cloudflare account ID, and the restart helper replays `cpl up`
+    with `env=dict(os.environ)`. When the loader kept the parsed values in a
+    local mapping only, a `.env`-only setup silently lost both.
+    """
+
+    def test_values_are_exported_to_environ(self, tmp_path) -> None:
+        import os
+
+        from backend.cli import _load_and_export_dotenv
+
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "# comment line\n"
+            "\n"
+            "CPL_CLOUDFLARE_TUNNEL_TOKEN=token-do-not-leak\n"
+            "CPL_CLOUDFLARE_HOSTNAME=cpl.example.com\n"
+            "MALFORMED_LINE\n"
+        )
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("CPL_CLOUDFLARE_TUNNEL_TOKEN", None)
+            os.environ.pop("CPL_CLOUDFLARE_HOSTNAME", None)
+            parsed = _load_and_export_dotenv(env_file)
+
+            assert parsed["CPL_CLOUDFLARE_HOSTNAME"] == "cpl.example.com"
+            assert os.environ["CPL_CLOUDFLARE_TUNNEL_TOKEN"] == "token-do-not-leak"
+            assert os.environ["CPL_CLOUDFLARE_HOSTNAME"] == "cpl.example.com"
+            assert "MALFORMED_LINE" not in parsed
+
+    def test_existing_environment_wins_over_dotenv(self, tmp_path) -> None:
+        import os
+
+        from backend.cli import _load_and_export_dotenv
+
+        env_file = tmp_path / ".env"
+        env_file.write_text("CPL_CLOUDFLARE_HOSTNAME=from-dotenv.example.com\n")
+        with patch.dict("os.environ", {"CPL_CLOUDFLARE_HOSTNAME": "from-shell.example.com"}):
+            parsed = _load_and_export_dotenv(env_file)
+            # .env keeps precedence for the CLI's own lookups...
+            assert parsed["CPL_CLOUDFLARE_HOSTNAME"] == "from-dotenv.example.com"
+            # ...but an explicitly exported shell value is never overwritten.
+            assert os.environ["CPL_CLOUDFLARE_HOSTNAME"] == "from-shell.example.com"
+
+    def test_missing_file_is_not_an_error(self, tmp_path) -> None:
+        from backend.cli import _load_and_export_dotenv
+
+        assert _load_and_export_dotenv(tmp_path / "absent.env") == {}

--- a/backend/tests/unit/test_cli.py
+++ b/backend/tests/unit/test_cli.py
@@ -6,6 +6,7 @@ import signal
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
 from click.testing import CliRunner
 
 from backend.cli import (
@@ -16,6 +17,19 @@ from backend.cli import (
     _stop_server,
 )
 from backend.main import cli
+
+
+@pytest.fixture(autouse=True)
+def _isolate_repo_dotenv(tmp_path):
+    """Keep the developer's real ``.env`` out of every CLI test.
+
+    ``cpl up`` loads the repository ``.env`` and exports it into
+    ``os.environ``. Without this redirect, running the suite in a configured
+    checkout changes provider auto-detection and credential classification,
+    and the exported values persist for the rest of the pytest session.
+    """
+    with patch("backend.cli.DOTENV_PATH", tmp_path / "absent.env"):
+        yield
 
 
 def test_version_command() -> None:

--- a/backend/tests/unit/test_cli.py
+++ b/backend/tests/unit/test_cli.py
@@ -687,6 +687,63 @@ class TestUpLaunchProfilePublication:
         assert written is None
 
 
+class TestProviderSelection:
+    """``--provider`` must win over Cloudflare credential auto-detection.
+
+    ``--provider`` defaults to ``devtunnel``, so the auto-detect used to fire
+    on an explicit ``--provider devtunnel`` too: any machine with Cloudflare
+    credentials in ``.env`` silently started a Cloudflare tunnel instead. The
+    restart helper always replays ``--provider`` explicitly, so a recorded
+    devtunnel session could not be reproduced either.
+    """
+
+    _CF_ENV = {
+        "CPL_CLOUDFLARE_TUNNEL_TOKEN": "cf-token-do-not-leak",
+        "CPL_CLOUDFLARE_HOSTNAME": "cpl.example.com",
+    }
+
+    def _run(self, args: list[str], tmp_path: object) -> dict[str, object] | None:
+        from backend.services.sharing.tunnel_service import RemoteProvider, TunnelHandle
+
+        captured: dict[str, object] = {}
+
+        def _fake_start(provider, **kwargs):  # type: ignore[no-untyped-def]
+            captured["provider"] = provider
+            return TunnelHandle(
+                provider=provider,
+                origin="https://example.test",
+                externally_managed=False,
+                name="example",
+            )
+
+        with (
+            patch("backend.config.get_codeplane_dir", return_value=tmp_path),
+            patch("backend.services.sharing.tunnel_service.start_remote_access", side_effect=_fake_start),
+            patch.dict("os.environ", self._CF_ENV),
+        ):
+            result, written = _invoke_up(args)
+        assert result.exit_code == 0, result.output
+        assert captured["provider"] is not RemoteProvider.local
+        return written
+
+    def test_explicit_devtunnel_is_not_overridden_by_cloudflare_credentials(self, tmp_path: object) -> None:
+        written = self._run(["--remote", "--provider", "devtunnel"], tmp_path)
+        assert written is not None
+        assert written["provider"] == "devtunnel"
+
+    def test_omitted_provider_still_auto_detects_cloudflare(self, tmp_path: object) -> None:
+        written = self._run(["--remote"], tmp_path)
+        assert written is not None
+        assert written["provider"] == "cloudflare"
+
+    def test_explicit_provider_without_remote_is_rejected(self) -> None:
+        runner = CliRunner()
+        with patch("backend.services.setup.service.validate_preflight", return_value=True):
+            result = runner.invoke(cli, ["up", "--provider", "devtunnel", "--skip-preflight"])
+        assert result.exit_code == 1
+        assert "--provider requires --remote" in result.output
+
+
 class TestDotenvExport:
     """`.env` values must reach `os.environ`.
 

--- a/backend/tests/unit/test_lifespan.py
+++ b/backend/tests/unit/test_lifespan.py
@@ -375,3 +375,32 @@ class TestPortableGracefulShutdown:
             _request_graceful_shutdown()
 
         mock_kill.assert_called_once()
+
+    def test_a_signal_absorbing_handler_is_not_mistaken_for_a_graceful_one(self) -> None:
+        """`cpl up` installs a handler whose whole job is to swallow SIGTERM.
+
+        It is callable, so the handler-first path would call it and return
+        with nothing shut down — leaving an unprotected public origin serving
+        after the Cloudflare Access check decided to take the server down.
+        """
+        import signal
+
+        from backend.cli import _neutralize_fatal_termination_signals
+        from backend.lifespan import _request_graceful_shutdown
+
+        previous = signal.getsignal(signal.SIGTERM)
+        try:
+            signal.signal(signal.SIGTERM, signal.SIG_DFL)
+            _neutralize_fatal_termination_signals()
+            inert = signal.getsignal(signal.SIGTERM)
+            assert callable(inert)
+
+            with patch("os.kill") as mock_kill:
+                _request_graceful_shutdown()
+
+            mock_kill.assert_called_once()
+            assert mock_kill.call_args[0][1] == signal.SIGTERM
+            # The default was restored first, so that kill is guaranteed fatal.
+            assert signal.getsignal(signal.SIGTERM) is signal.SIG_DFL
+        finally:
+            signal.signal(signal.SIGTERM, previous)

--- a/backend/tests/unit/test_lifespan.py
+++ b/backend/tests/unit/test_lifespan.py
@@ -319,3 +319,59 @@ def test_restart_request_id_env_name_is_stable() -> None:
     # ``backend/services/dev_restart/restart_helper.py``:
     # ``env["CODEPLANE_RESTART_REQUEST_ID"] = request_id``).
     assert _RESTART_REQUEST_ID_ENV == "CODEPLANE_RESTART_REQUEST_ID"
+
+
+class TestPortableGracefulShutdown:
+    """`os.kill(pid, SIGTERM)` is a hard TerminateProcess on Windows.
+
+    That skipped uvicorn's graceful shutdown and every lifespan shutdown
+    handler, so the Cloudflare Access safety stop left worktrees, leases and
+    pending DB writes mid-flight instead of unwinding them.
+    """
+
+    def test_prefers_the_installed_sigterm_handler(self) -> None:
+        import signal
+
+        from backend.lifespan import _request_graceful_shutdown
+
+        calls: list[int] = []
+
+        def _handler(signum: int, _frame: object) -> None:
+            calls.append(signum)
+
+        with (
+            patch("signal.getsignal", return_value=_handler),
+            patch("os.kill") as mock_kill,
+        ):
+            _request_graceful_shutdown()
+
+        assert calls == [signal.SIGTERM]
+        mock_kill.assert_not_called()
+
+    def test_falls_back_to_os_kill_without_a_handler(self) -> None:
+        import signal
+
+        from backend.lifespan import _request_graceful_shutdown
+
+        with (
+            patch("signal.getsignal", return_value=signal.SIG_DFL),
+            patch("os.kill") as mock_kill,
+        ):
+            _request_graceful_shutdown()
+
+        mock_kill.assert_called_once()
+        assert mock_kill.call_args[0][1] == signal.SIGTERM
+
+    def test_falls_back_when_the_handler_raises(self) -> None:
+        from backend.lifespan import _request_graceful_shutdown
+
+        def _broken_handler(_signum: int, _frame: object) -> None:
+            raise RuntimeError("handler exploded")
+
+        with (
+            patch("signal.getsignal", return_value=_broken_handler),
+            patch("os.kill") as mock_kill,
+        ):
+            _request_graceful_shutdown()
+
+        mock_kill.assert_called_once()

--- a/backend/tests/unit/test_misc_helpers.py
+++ b/backend/tests/unit/test_misc_helpers.py
@@ -172,8 +172,25 @@ class TestValidateRemoteProvider:
         assert validate_remote_provider(RemoteProvider.local) is None
 
     def test_devtunnel_available(self):
-        with patch.object(shutil, "which", return_value="/usr/bin/devtunnel"):
+        # The login probe shells out to the real ``devtunnel`` CLI, so it must
+        # be stubbed too: otherwise this test asserts the state of whoever's
+        # machine it runs on (green when logged in, red on CI where the CLI
+        # is absent) rather than the behavior of validate_remote_provider.
+        with (
+            patch.object(shutil, "which", return_value="/usr/bin/devtunnel"),
+            patch("backend.services.sharing.tunnel_service.devtunnel_logged_in", return_value=True),
+        ):
             assert validate_remote_provider(RemoteProvider.devtunnel) is None
+
+    def test_devtunnel_present_but_logged_out(self):
+        with (
+            patch.object(shutil, "which", return_value="/usr/bin/devtunnel"),
+            patch("backend.services.sharing.tunnel_service.devtunnel_logged_in", return_value=False),
+        ):
+            result = validate_remote_provider(RemoteProvider.devtunnel)
+        assert result is not None
+        assert "not logged in" in result
+        assert "devtunnel user login" in result
 
     def test_devtunnel_missing(self):
         with patch.object(shutil, "which", return_value=None):

--- a/backend/tests/unit/test_setup_service.py
+++ b/backend/tests/unit/test_setup_service.py
@@ -676,3 +676,38 @@ class TestPortIsListening:
 
         mock_socket.side_effect = [_FakeSocket(connect_result=errno.ECONNREFUSED)]
         assert _port_is_listening(8080) is False
+
+
+class TestRemoteAccessDependencies:
+    """`validate_remote_provider` tells users to run `cpl setup` when a
+    connector CLI is missing, so the setup registry has to actually know
+    about both connectors on every supported platform."""
+
+    def test_cloudflared_is_registered(self) -> None:
+        from backend.services.setup.dependencies import DEPENDENCIES
+
+        dep = next((d for d in DEPENDENCIES if d.command == "cloudflared"), None)
+        assert dep is not None, "cpl setup cannot install a dependency it does not know about"
+        assert dep.required is False
+        for host in ("linux", "darwin", "windows"):
+            assert dep.install_instructions.get(host)
+
+    def test_connectors_have_windows_auto_install(self) -> None:
+        from backend.services.setup.dependencies import DEPENDENCIES
+
+        for command in ("cloudflared", "devtunnel"):
+            dep = next(d for d in DEPENDENCIES if d.command == command)
+            windows_cmd = dep.auto_install_cmd.get("windows")
+            assert windows_cmd, f"{command} has no Windows auto-install"
+            assert windows_cmd[0] == "winget"
+            assert "--accept-package-agreements" in windows_cmd
+
+    def test_devtunnel_instructions_are_actionable_per_platform(self) -> None:
+        from backend.services.setup.dependencies import DEPENDENCIES
+
+        dep = next(d for d in DEPENDENCIES if d.command == "devtunnel")
+        # A bare "Install from <url>" repeated for every OS gives the user
+        # nothing to run; each platform needs a real command.
+        assert dep.install_instructions["windows"].startswith("winget")
+        assert "brew" in dep.install_instructions["darwin"]
+        assert dep.install_instructions["linux"] != dep.install_instructions["windows"]

--- a/backend/tests/unit/test_tunnel_service.py
+++ b/backend/tests/unit/test_tunnel_service.py
@@ -599,6 +599,85 @@ class TestGiveupCooldown:
         assert call_count >= 2
 
 
+class TestWatchdogRestartTrigger:
+    """A connector restart must only happen for a failure a restart can repair.
+
+    The watchdog exists to restart the connector when the public relay stops
+    forwarding. Counting a failing *origin* check toward the same threshold
+    made a slow local startup look like a tunnel fault: observed on Windows,
+    where application startup outlasts ``_INITIAL_DELAY`` and two origin
+    checks failed in a row, tearing down and respawning a healthy connector
+    while the server was still booting.
+    """
+
+    def _watchdog(self, health_results: list[bool]) -> tuple[TunnelWatchdog, list[bool]]:
+        watchdog = TunnelWatchdog(
+            tunnel_url="https://example.test",
+            restart_command=["echo"],
+            proc=_as_popen(_FakeProc(poll_result=None)),
+            label="test",
+            local_port=8080,
+        )
+        watchdog._INITIAL_DELAY = 0
+        watchdog._CHECK_INTERVAL = 0
+        return watchdog, health_results
+
+    def test_origin_down_never_restarts_the_connector(self) -> None:
+        watchdog, _ = self._watchdog([])
+        checks = 0
+
+        def _health(*, use_tunnel_url: bool = False) -> bool:
+            nonlocal checks
+            checks += 1
+            if checks >= 6:
+                watchdog._stop_event.set()
+            return False  # origin never answers; connector is alive
+
+        with (
+            patch.object(watchdog, "_health_ok", side_effect=_health),
+            patch.object(watchdog, "_restart_process", return_value=True) as mock_restart,
+        ):
+            watchdog._run()
+
+        assert mock_restart.call_count == 0
+
+    def test_relay_failure_with_healthy_origin_restarts_the_connector(self) -> None:
+        watchdog, _ = self._watchdog([])
+        watchdog._RELAY_CHECK_FREQUENCY = 1
+
+        def _health(*, use_tunnel_url: bool = False) -> bool:
+            # Origin healthy, public relay broken — the connector is at fault.
+            return not use_tunnel_url
+
+        def _restart() -> bool:
+            watchdog._stop_event.set()
+            return True
+
+        with (
+            patch.object(watchdog, "_health_ok", side_effect=_health),
+            patch.object(watchdog, "_restart_process", side_effect=_restart) as mock_restart,
+        ):
+            watchdog._run()
+
+        assert mock_restart.call_count == 1
+
+    def test_dead_connector_still_restarts_immediately(self) -> None:
+        watchdog, _ = self._watchdog([])
+        watchdog.proc = _as_popen(_FakeProc(poll_result=1))
+
+        def _restart() -> bool:
+            watchdog._stop_event.set()
+            return True
+
+        with (
+            patch.object(watchdog, "_health_ok", return_value=True),
+            patch.object(watchdog, "_restart_process", side_effect=_restart) as mock_restart,
+        ):
+            watchdog._run()
+
+        assert mock_restart.call_count == 1
+
+
 # ---------------------------------------------------------------------------
 # Explicit tunnel ownership (SPEC CAP-6 / ARCHITECTURE-SPINE AD-8)
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_tunnel_service.py
+++ b/backend/tests/unit/test_tunnel_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess as real_subprocess
 import threading
 from typing import TYPE_CHECKING, cast
 from unittest.mock import MagicMock, patch
@@ -13,11 +14,17 @@ from backend.services.sharing.tunnel_service import (
     TunnelOwnership,
     TunnelStartError,
     TunnelWatchdog,
+    _cloudflared_already_running,
     _external_tunnel_origin,
     _find_existing_codeplane_tunnel,
+    _list_devtunnels,
     _lookup_devtunnel,
+    _run_capture,
+    _start_devtunnel,
     _start_output_drain,
+    _terminate_and_reap,
     _wait_for_startup,
+    devtunnel_logged_in,
     start_remote_access,
     validate_remote_provider,
 )
@@ -31,11 +38,17 @@ def _as_popen(proc: _FakeProc) -> subprocess.Popen[str]:
 
 
 class _FakeProc:
+    _next_pid = 900000
+
     def __init__(self, *, poll_result: int | None = None, output: str = "") -> None:
         self._poll_result = poll_result
         self.stdout: _FakeStdout | None = _FakeStdout(output)
         self.terminated = False
         self.killed = False
+        # Real Popen objects always expose a pid; connector lifecycle helpers
+        # (orphan prevention, process-group signalling) read it.
+        _FakeProc._next_pid += 1
+        self.pid = _FakeProc._next_pid
 
     def poll(self) -> int | None:
         return self._poll_result
@@ -751,3 +764,261 @@ class TestOriginReusability:
             handle = start_remote_access(RemoteProvider.devtunnel, port=8080)
 
         assert handle.origin_is_reusable is True
+
+
+# ---------------------------------------------------------------------------
+# Cross-platform connector lifecycle regressions
+# ---------------------------------------------------------------------------
+
+
+class _StubbornProc:
+    """A connector that ignores terminate and only dies on kill."""
+
+    def __init__(self, *, kill_also_times_out: bool = False) -> None:
+        self.pid = 4242
+        self.stdout = None
+        self.terminated = False
+        self.killed = False
+        self._kill_also_times_out = kill_also_times_out
+
+    def poll(self) -> int | None:
+        return None
+
+    def terminate(self) -> None:
+        self.terminated = True
+
+    def kill(self) -> None:
+        self.killed = True
+
+    def wait(self, timeout: float | None = None) -> int:
+        if not self.killed or self._kill_also_times_out:
+            raise real_subprocess.TimeoutExpired(cmd="connector", timeout=timeout or 0)
+        return 0
+
+
+class TestTerminateAndReap:
+    """``subprocess.TimeoutExpired`` is a SubprocessError, not an OSError.
+
+    The previous teardown caught only ``OSError``, so a connector that ignored
+    terminate propagated the timeout out of ``TunnelHandle.close()`` and
+    abandoned every remaining cleanup step.
+    """
+
+    def test_terminate_timeout_escalates_to_kill(self) -> None:
+        proc = _StubbornProc()
+        _terminate_and_reap(_as_popen(cast("_FakeProc", proc)), label="cloudflare", timeout=0.01)
+        assert proc.terminated is True
+        assert proc.killed is True
+
+    def test_never_raises_even_when_kill_also_times_out(self) -> None:
+        proc = _StubbornProc(kill_also_times_out=True)
+        _terminate_and_reap(_as_popen(cast("_FakeProc", proc)), label="devtunnel", timeout=0.01)
+        assert proc.killed is True
+
+    def test_already_exited_process_is_not_signalled(self) -> None:
+        proc = _FakeProc(poll_result=0)
+        _terminate_and_reap(_as_popen(proc), timeout=0.01)
+        assert proc.terminated is False
+        assert proc.killed is False
+
+    def test_close_reaps_watchdog_proc_when_handle_proc_hangs(self) -> None:
+        """A hanging primary process must not strand the watchdog's process."""
+        hanging = _StubbornProc()
+        watchdog_proc = _StubbornProc()
+        watchdog = TunnelWatchdog(
+            tunnel_url="https://example.invalid",
+            restart_command=["cloudflared"],
+            proc=_as_popen(cast("_FakeProc", watchdog_proc)),
+            label="cloudflare",
+        )
+        handle = TunnelHandle(
+            provider=RemoteProvider.cloudflare,
+            origin="https://example.invalid",
+            proc=_as_popen(cast("_FakeProc", hanging)),
+            watchdog=watchdog,
+        )
+        handle.close()
+        assert hanging.killed is True
+        assert watchdog_proc.killed is True
+
+
+class TestRunCaptureNeverRaises:
+    """A hung or missing provider CLI must not escape as a raw traceback."""
+
+    def test_timeout_returns_nonzero_result(self) -> None:
+        with patch(
+            "backend.services.sharing.tunnel_service.subprocess.run",
+            side_effect=real_subprocess.TimeoutExpired(cmd="devtunnel", timeout=30),
+        ):
+            result = _run_capture(["devtunnel", "list", "--json"])
+        assert result.returncode != 0
+        assert "timed out" in result.stderr
+
+    def test_missing_binary_returns_nonzero_result(self) -> None:
+        with patch(
+            "backend.services.sharing.tunnel_service.subprocess.run",
+            side_effect=FileNotFoundError("devtunnel"),
+        ):
+            result = _run_capture(["devtunnel", "list", "--json"])
+        assert result.returncode != 0
+        assert "not found" in result.stderr
+
+    def test_list_devtunnels_tolerates_timeout(self) -> None:
+        with patch(
+            "backend.services.sharing.tunnel_service.subprocess.run",
+            side_effect=real_subprocess.TimeoutExpired(cmd="devtunnel", timeout=30),
+        ):
+            assert _list_devtunnels() == []
+
+
+class TestDevtunnelLoginDetection:
+    """The Dev Tunnels CLI reports "logged out" with several distinct phrasings."""
+
+    def test_validate_reports_logged_out_before_create_fails(self) -> None:
+        with (
+            patch("backend.services.sharing.tunnel_service.shutil.which", return_value="/usr/bin/devtunnel"),
+            patch("backend.services.sharing.tunnel_service.devtunnel_logged_in", return_value=False),
+        ):
+            error = validate_remote_provider(RemoteProvider.devtunnel)
+        assert error is not None
+        assert "devtunnel user login" in error
+
+    def test_validate_passes_when_logged_in(self) -> None:
+        with (
+            patch("backend.services.sharing.tunnel_service.shutil.which", return_value="/usr/bin/devtunnel"),
+            patch("backend.services.sharing.tunnel_service.devtunnel_logged_in", return_value=True),
+        ):
+            assert validate_remote_provider(RemoteProvider.devtunnel) is None
+
+    def test_logged_in_is_false_for_login_required_output(self) -> None:
+        with patch(
+            "backend.services.sharing.tunnel_service._run_capture",
+            return_value=real_subprocess.CompletedProcess([], returncode=3, stdout="Login required.", stderr=""),
+        ):
+            assert devtunnel_logged_in() is False
+
+    def test_logged_in_is_true_for_normal_output(self) -> None:
+        with patch(
+            "backend.services.sharing.tunnel_service._run_capture",
+            return_value=real_subprocess.CompletedProcess(
+                [], returncode=0, stdout="Logged in as dfinson using GitHub.", stderr=""
+            ),
+        ):
+            assert devtunnel_logged_in() is True
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "Login required.",
+            "Unauthorized tunnel creation access: Anonymous does not have 'create' access scope",
+            "You are not logged in",
+        ],
+    )
+    def test_create_failure_appends_login_hint(self, message: str) -> None:
+        """The anonymous-access-scope wording is what a logged-out user actually hits."""
+        with (
+            patch("backend.services.sharing.tunnel_service._list_devtunnels", return_value=[]),
+            patch(
+                "backend.services.sharing.tunnel_service._run_capture",
+                return_value=real_subprocess.CompletedProcess([], returncode=3, stdout="", stderr=message),
+            ),
+            pytest.raises(TunnelStartError) as exc_info,
+        ):
+            _start_devtunnel(8080, tunnel_name="cpl-test")
+        assert "devtunnel user login" in str(exc_info.value)
+
+
+class TestDevtunnelPortRegistration:
+    def test_port_create_failure_is_fatal(self) -> None:
+        """A tunnel that cannot forward the port must not be reported as started."""
+
+        def _fake_capture(args: list[str]) -> real_subprocess.CompletedProcess[str]:
+            if args[1] == "port":
+                return real_subprocess.CompletedProcess(args, returncode=1, stdout="", stderr="quota exceeded")
+            return real_subprocess.CompletedProcess(args, returncode=0, stdout="", stderr="")
+
+        with (
+            patch("backend.services.sharing.tunnel_service._lookup_devtunnel", return_value=(True, "usw2")),
+            patch("backend.services.sharing.tunnel_service._run_capture", side_effect=_fake_capture),
+            pytest.raises(TunnelStartError) as exc_info,
+        ):
+            _start_devtunnel(8080, tunnel_name="cpl-test")
+        assert "quota exceeded" in str(exc_info.value)
+
+    def test_already_registered_port_is_tolerated(self) -> None:
+        proc = _FakeProc(poll_result=None)
+
+        def _fake_capture(args: list[str]) -> real_subprocess.CompletedProcess[str]:
+            if args[1] == "port":
+                return real_subprocess.CompletedProcess(
+                    args, returncode=1, stdout="", stderr="Port 8080 already exists on tunnel"
+                )
+            return real_subprocess.CompletedProcess(args, returncode=0, stdout="", stderr="")
+
+        with (
+            patch("backend.services.sharing.tunnel_service._lookup_devtunnel", return_value=(True, "usw2")),
+            patch("backend.services.sharing.tunnel_service._run_capture", side_effect=_fake_capture),
+            patch("backend.services.sharing.tunnel_service.subprocess.Popen", return_value=_as_popen(proc)),
+            patch("backend.services.sharing.tunnel_service._wait_for_startup"),
+            patch("backend.services.sharing.tunnel_service._start_output_drain"),
+        ):
+            origin, _, name, _ = _start_devtunnel(8080, tunnel_name="cpl-test")
+        assert origin == "https://cpl-test-8080.usw2.devtunnels.ms"
+        assert name == "cpl-test"
+
+
+class TestCloudflaredDetectionIsPortable:
+    """Reuse detection previously shelled out to ``pgrep``, which Windows lacks.
+
+    That made every Windows run believe no connector was present and start a
+    duplicate one for the same tunnel.
+    """
+
+    @staticmethod
+    def _proc(pid: int, name: str) -> object:
+        stub = MagicMock()
+        stub.info = {"pid": pid, "name": name}
+        return stub
+
+    def test_detects_windows_executable_name(self) -> None:
+        import psutil
+
+        with (
+            patch.object(psutil, "process_iter", return_value=[self._proc(999, "cloudflared.exe")]),
+            patch.object(psutil, "Process", side_effect=psutil.NoSuchProcess(1)),
+        ):
+            assert _cloudflared_already_running() is True
+
+    def test_detects_posix_executable_name(self) -> None:
+        import psutil
+
+        with (
+            patch.object(psutil, "process_iter", return_value=[self._proc(999, "cloudflared")]),
+            patch.object(psutil, "Process", side_effect=psutil.NoSuchProcess(1)),
+        ):
+            assert _cloudflared_already_running() is True
+
+    def test_ignores_unrelated_processes(self) -> None:
+        import psutil
+
+        with (
+            patch.object(psutil, "process_iter", return_value=[self._proc(999, "chrome.exe")]),
+            patch.object(psutil, "Process", side_effect=psutil.NoSuchProcess(1)),
+        ):
+            assert _cloudflared_already_running() is False
+
+    def test_ignores_our_own_child_connector(self) -> None:
+        import os
+
+        import psutil
+
+        child = MagicMock()
+        child.pid = 555
+        parent = MagicMock()
+        parent.children.return_value = [child]
+        with (
+            patch.object(psutil, "process_iter", return_value=[self._proc(555, "cloudflared")]),
+            patch.object(psutil, "Process", return_value=parent),
+            patch.object(os, "getpid", return_value=111),
+        ):
+            assert _cloudflared_already_running() is False

--- a/backend/tests/unit/test_tunnel_service.py
+++ b/backend/tests/unit/test_tunnel_service.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import base64
+import json
 import subprocess as real_subprocess
 import sys
 import threading
@@ -391,6 +393,24 @@ class TestWatchdogLocalHealthCheck:
         req = call_args[0][0]
         assert "127.0.0.1:9090" in req.full_url
 
+    def test_a_watchdog_without_a_local_port_can_still_restart(self) -> None:
+        """``local_port`` is optional, and the origin gate must not swallow that.
+
+        The restart gate suppresses restarts while the *origin* is down. With
+        no local port there is no origin probe, and reporting "origin down"
+        would classify every relay failure as somebody else's problem, making
+        the class permanently incapable of the restart it exists to perform.
+        """
+        watchdog = TunnelWatchdog(
+            tunnel_url="https://cpl-abc-8080.usw2.devtunnels.ms",
+            restart_command=["echo"],
+            proc=_as_popen(_FakeProc(poll_result=None)),
+            label="devtunnel",
+        )
+        with patch.object(watchdog, "_health_ok", return_value=False) as probe:
+            assert watchdog._origin_ok() is True
+        assert probe.call_count == 0
+
 
 # ---------------------------------------------------------------------------
 # #4 — Cloudflare token via env var (not CLI arg)
@@ -688,6 +708,40 @@ class TestWatchdogRestartTrigger:
 
         assert mock_restart.call_count == 1
 
+    def test_relay_failure_restarts_with_the_production_check_frequency(self) -> None:
+        """The relay tally must survive the cycles that do not probe the relay.
+
+        ``_RELAY_CHECK_FREQUENCY`` is 5 in production, so four of every five
+        cycles carry no relay evidence. Clearing the tally on those cycles kept
+        it from ever reaching ``_FAIL_THRESHOLD``, which made connector
+        restarts unreachable outside a test that set the frequency to 1 -- the
+        watchdog's entire purpose, silently disabled.
+        """
+        watchdog, _ = self._watchdog([])
+        assert watchdog._RELAY_CHECK_FREQUENCY > 1, "production frequency must exceed 1 for this to be meaningful"
+        cycles = 0
+
+        def _health(*, use_tunnel_url: bool = False) -> bool:
+            nonlocal cycles
+            if not use_tunnel_url:
+                cycles += 1
+                if cycles > watchdog._RELAY_CHECK_FREQUENCY * (watchdog._FAIL_THRESHOLD + 2):
+                    watchdog._stop_event.set()
+                return True  # origin healthy throughout
+            return False  # public relay never forwards
+
+        def _restart() -> bool:
+            watchdog._stop_event.set()
+            return True
+
+        with (
+            patch.object(watchdog, "_health_ok", side_effect=_health),
+            patch.object(watchdog, "_restart_process", side_effect=_restart) as mock_restart,
+        ):
+            watchdog._run()
+
+        assert mock_restart.call_count == 1
+
     def test_dead_connector_still_restarts_immediately(self) -> None:
         watchdog, _ = self._watchdog([])
         watchdog.proc = _as_popen(_FakeProc(poll_result=1))
@@ -705,8 +759,78 @@ class TestWatchdogRestartTrigger:
         assert mock_restart.call_count == 1
 
 
-# ---------------------------------------------------------------------------
-# Explicit tunnel ownership (SPEC CAP-6 / ARCHITECTURE-SPINE AD-8)
+class TestCloseIsSingleOwner:
+    """Shutdown calls ``close()`` from three places, two of them off-thread.
+
+    ``cpl up`` closes the tunnel from the second-signal handler, from a
+    force-exit timer thread, and from the normal ``finally``. Without a guard
+    each caller ran its own terminate/wait/kill sequence against the same pids,
+    and a connector spawned by an in-flight watchdog restart could be published
+    after ``close()`` had already taken its snapshot -- surviving shutdown.
+    """
+
+    def test_repeated_close_terminates_the_connector_once(self) -> None:
+        proc = _FakeProc(poll_result=None)
+        handle = TunnelHandle(provider=RemoteProvider.devtunnel, proc=_as_popen(proc))
+
+        with patch("backend.services.sharing.tunnel_service._terminate_and_reap") as mock_kill:
+            handle.close()
+            handle.close()
+            handle.close()
+
+        assert mock_kill.call_count == 1
+
+    def test_concurrent_close_terminates_the_connector_once(self) -> None:
+        proc = _FakeProc(poll_result=None)
+        handle = TunnelHandle(provider=RemoteProvider.devtunnel, proc=_as_popen(proc))
+        start = threading.Event()
+
+        def _closer() -> None:
+            start.wait(timeout=5)
+            handle.close()
+
+        with patch("backend.services.sharing.tunnel_service._terminate_and_reap") as mock_kill:
+            threads = [threading.Thread(target=_closer) for _ in range(4)]
+            for thread in threads:
+                thread.start()
+            start.set()
+            for thread in threads:
+                thread.join(timeout=5)
+
+        assert mock_kill.call_count == 1
+
+    def test_a_connector_spawned_after_stop_is_not_left_running(self) -> None:
+        """The watchdog must not adopt a connector published after ``stop()``."""
+        original = _FakeProc(poll_result=1)
+        replacement = _FakeProc(poll_result=None)
+        watchdog = TunnelWatchdog(
+            tunnel_url="https://example.test",
+            restart_command=["echo"],
+            proc=_as_popen(original),
+            label="test",
+            local_port=8080,
+        )
+        killed: list[object] = []
+
+        def _spawn(*_args: object, **_kwargs: object) -> object:
+            # close() wins the race: it set the stop event and read self.proc
+            # while this restart was still spawning a replacement.
+            watchdog._stop_event.set()
+            return _as_popen(replacement)
+
+        with (
+            patch("backend.services.sharing.tunnel_service._spawn_connector", side_effect=_spawn),
+            patch(
+                "backend.services.sharing.tunnel_service._terminate_and_reap",
+                side_effect=lambda p, **_kw: killed.append(p),
+            ),
+        ):
+            watchdog._restart_process()
+
+        assert watchdog.proc is not replacement, "the post-stop connector was adopted as the live one"
+        assert replacement in killed, "the connector spawned after stop was never terminated"
+
+
 # ---------------------------------------------------------------------------
 
 
@@ -948,6 +1072,35 @@ class TestTerminateAndReap:
         assert watchdog_proc.killed is True
 
 
+class TestSignalProcessTreeOnWindows:
+    """POSIX signals the whole process group; Windows has to enumerate.
+
+    ``devtunnel host`` runs its transport in a child process, so a bare
+    ``Popen.terminate`` on the parent left the tunnel serving after CodePlane
+    believed it had torn the connector down.
+    """
+
+    def test_descendants_are_terminated_on_windows(self) -> None:
+        import psutil
+
+        proc = _FakeProc(poll_result=None)
+        proc.pid = 4242
+        grandchild = MagicMock()
+        tree = MagicMock()
+        tree.children.return_value = [grandchild]
+
+        with (
+            patch.object(tunnel_service.sys, "platform", "win32"),
+            patch.object(psutil, "Process", return_value=tree) as process_lookup,
+        ):
+            tunnel_service._signal_process_tree(_as_popen(proc))
+
+        process_lookup.assert_called_once_with(4242)
+        tree.children.assert_called_once_with(recursive=True)
+        grandchild.terminate.assert_called_once()
+        assert proc.terminated is True
+
+
 class TestRunCaptureNeverRaises:
     """A hung or missing provider CLI must not escape as a raw traceback."""
 
@@ -1062,9 +1215,7 @@ class TestDevtunnelPortRegistration:
         "Tunnel service error: Conflict with existing entity. "
         "Tunnel port number conflicts with an existing port in the tunnel."
     )
-    _PORT_LIST = (
-        "Found 1 tunnel port.\n\nPort Number   Protocol      Current Connections\n8080          http          0\n"
-    )
+    _PORT_LIST = '{"ports":[{"portNumber":8080,"protocol":"http","clientConnections":0}]}'
 
     @staticmethod
     def _capture(*, create_error: str, port_list: str) -> object:
@@ -1110,7 +1261,7 @@ class TestDevtunnelPortRegistration:
 
     def test_a_different_registered_port_does_not_count(self) -> None:
         """Only the requested port proves the tunnel can forward this server."""
-        other_port = "Found 1 tunnel port.\n\nPort Number   Protocol      Current Connections\n9000  http  0\n"
+        other_port = '{"ports":[{"portNumber":9000,"protocol":"http","clientConnections":0}]}'
         with (
             patch("backend.services.sharing.tunnel_service._lookup_devtunnel", return_value=(True, "usw2")),
             patch(
@@ -1121,18 +1272,64 @@ class TestDevtunnelPortRegistration:
         ):
             _start_devtunnel(8080, tunnel_name="cpl-test")
 
+    def test_unparsable_port_list_is_not_treated_as_registered(self) -> None:
+        """A CLI that stops emitting JSON must fail loudly, not silently proceed."""
+        with (
+            patch("backend.services.sharing.tunnel_service._lookup_devtunnel", return_value=(True, "usw2")),
+            patch(
+                "backend.services.sharing.tunnel_service._run_capture",
+                side_effect=self._capture(create_error=self._CONFLICT, port_list="Found 1 tunnel port.\n8080 http 0\n"),
+            ),
+            pytest.raises(TunnelStartError),
+        ):
+            _start_devtunnel(8080, tunnel_name="cpl-test")
+
+    def test_port_list_is_requested_as_json(self) -> None:
+        """Guard the structured contract: table parsing is localizable and brittle."""
+        seen: list[list[str]] = []
+
+        def _capture(args: list[str]) -> real_subprocess.CompletedProcess[str]:
+            seen.append(args)
+            if args[1:3] == ["port", "create"]:
+                return real_subprocess.CompletedProcess(args, returncode=1, stdout="", stderr=self._CONFLICT)
+            if args[1:3] == ["port", "list"]:
+                return real_subprocess.CompletedProcess(args, returncode=0, stdout=self._PORT_LIST, stderr="")
+            return real_subprocess.CompletedProcess(args, returncode=0, stdout="", stderr="")
+
+        proc = _FakeProc(poll_result=None)
+        with (
+            patch("backend.services.sharing.tunnel_service._lookup_devtunnel", return_value=(True, "usw2")),
+            patch("backend.services.sharing.tunnel_service._run_capture", side_effect=_capture),
+            patch("backend.services.sharing.tunnel_service.subprocess.Popen", return_value=_as_popen(proc)),
+            patch("backend.services.sharing.tunnel_service._wait_for_startup"),
+            patch("backend.services.sharing.tunnel_service._start_output_drain"),
+        ):
+            _start_devtunnel(8080, tunnel_name="cpl-test")
+
+        port_list_calls = [args for args in seen if args[1:3] == ["port", "list"]]
+        assert port_list_calls, "the port registration check never ran"
+        assert all("--json" in args for args in port_list_calls)
+
 
 class TestCloudflaredDetectionIsPortable:
     """Reuse detection previously shelled out to ``pgrep``, which Windows lacks.
 
     That made every Windows run believe no connector was present and start a
-    duplicate one for the same tunnel.
+    duplicate one for the same tunnel. It also matched on the process name
+    alone, so an unrelated connector counted as ours.
     """
 
-    @staticmethod
-    def _proc(pid: int, name: str) -> object:
+    #: base64 of ``{"a": "acct", "t": "tunnel-uuid", "s": "secret"}``.
+    TOKEN = base64.b64encode(json.dumps({"a": "acct", "t": "tunnel-uuid", "s": "secret"}).encode()).decode()
+
+    @classmethod
+    def _proc(cls, pid: int, name: str, cmdline: list[str] | None = None) -> object:
         stub = MagicMock()
-        stub.info = {"pid": pid, "name": name}
+        stub.info = {
+            "pid": pid,
+            "name": name,
+            "cmdline": cmdline if cmdline is not None else ["cloudflared", "tunnel", "run", "--token", cls.TOKEN],
+        }
         return stub
 
     def test_detects_windows_executable_name(self) -> None:
@@ -1142,7 +1339,7 @@ class TestCloudflaredDetectionIsPortable:
             patch.object(psutil, "process_iter", return_value=[self._proc(999, "cloudflared.exe")]),
             patch.object(psutil, "Process", side_effect=psutil.NoSuchProcess(1)),
         ):
-            assert _cloudflared_already_running() is True
+            assert _cloudflared_already_running(self.TOKEN) is True
 
     def test_detects_posix_executable_name(self) -> None:
         import psutil
@@ -1151,7 +1348,45 @@ class TestCloudflaredDetectionIsPortable:
             patch.object(psutil, "process_iter", return_value=[self._proc(999, "cloudflared")]),
             patch.object(psutil, "Process", side_effect=psutil.NoSuchProcess(1)),
         ):
-            assert _cloudflared_already_running() is True
+            assert _cloudflared_already_running(self.TOKEN) is True
+
+    def test_matches_a_connector_identified_only_by_tunnel_id(self) -> None:
+        """A config-file connector names the tunnel UUID rather than the token."""
+        import psutil
+
+        proc = self._proc(999, "cloudflared", ["cloudflared", "tunnel", "run", "tunnel-uuid"])
+        with (
+            patch.object(psutil, "process_iter", return_value=[proc]),
+            patch.object(psutil, "Process", side_effect=psutil.NoSuchProcess(1)),
+        ):
+            assert _cloudflared_already_running(self.TOKEN) is True
+
+    def test_ignores_a_connector_for_a_different_tunnel(self) -> None:
+        """Reusing a stranger's connector prints a public URL that routes nowhere.
+
+        Windows documents ``cloudflared service install`` as the persistent
+        setup, so an unrelated service on the host is the likely case — and it
+        only became reachable at all once detection stopped using ``pgrep``.
+        """
+        import psutil
+
+        other = base64.b64encode(json.dumps({"a": "b", "t": "someone-else", "s": "x"}).encode()).decode()
+        proc = self._proc(999, "cloudflared.exe", ["cloudflared", "tunnel", "run", "--token", other])
+        with (
+            patch.object(psutil, "process_iter", return_value=[proc]),
+            patch.object(psutil, "Process", side_effect=psutil.NoSuchProcess(1)),
+        ):
+            assert _cloudflared_already_running(self.TOKEN) is False
+
+    def test_ignores_a_connector_with_an_unreadable_command_line(self) -> None:
+        import psutil
+
+        proc = self._proc(999, "cloudflared.exe", [])
+        with (
+            patch.object(psutil, "process_iter", return_value=[proc]),
+            patch.object(psutil, "Process", side_effect=psutil.NoSuchProcess(1)),
+        ):
+            assert _cloudflared_already_running(self.TOKEN) is False
 
     def test_ignores_unrelated_processes(self) -> None:
         import psutil
@@ -1160,7 +1395,7 @@ class TestCloudflaredDetectionIsPortable:
             patch.object(psutil, "process_iter", return_value=[self._proc(999, "chrome.exe")]),
             patch.object(psutil, "Process", side_effect=psutil.NoSuchProcess(1)),
         ):
-            assert _cloudflared_already_running() is False
+            assert _cloudflared_already_running(self.TOKEN) is False
 
     def test_ignores_our_own_child_connector(self) -> None:
         import os
@@ -1176,7 +1411,7 @@ class TestCloudflaredDetectionIsPortable:
             patch.object(psutil, "Process", return_value=parent),
             patch.object(os, "getpid", return_value=111),
         ):
-            assert _cloudflared_already_running() is False
+            assert _cloudflared_already_running(self.TOKEN) is False
 
 
 class TestJobAssignmentIsReported:

--- a/backend/tests/unit/test_tunnel_service.py
+++ b/backend/tests/unit/test_tunnel_service.py
@@ -1025,35 +1025,57 @@ class TestDevtunnelLoginDetection:
 
 
 class TestDevtunnelPortRegistration:
-    def test_port_create_failure_is_fatal(self) -> None:
-        """A tunnel that cannot forward the port must not be reported as started."""
+    """Reuse hinges on what the service reports, not on error wording.
 
+    The real CLI rejects a re-registration with "Tunnel service error:
+    Conflict with existing entity", which matches neither "already" nor
+    "exists" — the strings this once keyed on. Every start against an existing
+    tunnel therefore aborted, which is exactly how the Windows devtunnel run
+    failed.
+    """
+
+    _CONFLICT = (
+        "Tunnel service error: Conflict with existing entity. "
+        "Tunnel port number conflicts with an existing port in the tunnel."
+    )
+    _PORT_LIST = (
+        "Found 1 tunnel port.\n\nPort Number   Protocol      Current Connections\n8080          http          0\n"
+    )
+
+    @staticmethod
+    def _capture(*, create_error: str, port_list: str) -> object:
         def _fake_capture(args: list[str]) -> real_subprocess.CompletedProcess[str]:
-            if args[1] == "port":
-                return real_subprocess.CompletedProcess(args, returncode=1, stdout="", stderr="quota exceeded")
+            if args[1:3] == ["port", "create"]:
+                return real_subprocess.CompletedProcess(args, returncode=1, stdout="", stderr=create_error)
+            if args[1:3] == ["port", "list"]:
+                return real_subprocess.CompletedProcess(args, returncode=0, stdout=port_list, stderr="")
             return real_subprocess.CompletedProcess(args, returncode=0, stdout="", stderr="")
 
+        return _fake_capture
+
+    def test_port_create_failure_is_fatal(self) -> None:
+        """A tunnel that cannot forward the port must not be reported as started."""
         with (
             patch("backend.services.sharing.tunnel_service._lookup_devtunnel", return_value=(True, "usw2")),
-            patch("backend.services.sharing.tunnel_service._run_capture", side_effect=_fake_capture),
+            patch(
+                "backend.services.sharing.tunnel_service._run_capture",
+                side_effect=self._capture(create_error="quota exceeded", port_list="Found 0 tunnel ports.\n"),
+            ),
             pytest.raises(TunnelStartError) as exc_info,
         ):
             _start_devtunnel(8080, tunnel_name="cpl-test")
         assert "quota exceeded" in str(exc_info.value)
 
-    def test_already_registered_port_is_tolerated(self) -> None:
+    @pytest.mark.parametrize("create_error", [_CONFLICT, "Port 8080 already exists on tunnel"])
+    def test_already_registered_port_is_tolerated(self, create_error: str) -> None:
         proc = _FakeProc(poll_result=None)
-
-        def _fake_capture(args: list[str]) -> real_subprocess.CompletedProcess[str]:
-            if args[1] == "port":
-                return real_subprocess.CompletedProcess(
-                    args, returncode=1, stdout="", stderr="Port 8080 already exists on tunnel"
-                )
-            return real_subprocess.CompletedProcess(args, returncode=0, stdout="", stderr="")
 
         with (
             patch("backend.services.sharing.tunnel_service._lookup_devtunnel", return_value=(True, "usw2")),
-            patch("backend.services.sharing.tunnel_service._run_capture", side_effect=_fake_capture),
+            patch(
+                "backend.services.sharing.tunnel_service._run_capture",
+                side_effect=self._capture(create_error=create_error, port_list=self._PORT_LIST),
+            ),
             patch("backend.services.sharing.tunnel_service.subprocess.Popen", return_value=_as_popen(proc)),
             patch("backend.services.sharing.tunnel_service._wait_for_startup"),
             patch("backend.services.sharing.tunnel_service._start_output_drain"),
@@ -1061,6 +1083,19 @@ class TestDevtunnelPortRegistration:
             origin, _, name, _ = _start_devtunnel(8080, tunnel_name="cpl-test")
         assert origin == "https://cpl-test-8080.usw2.devtunnels.ms"
         assert name == "cpl-test"
+
+    def test_a_different_registered_port_does_not_count(self) -> None:
+        """Only the requested port proves the tunnel can forward this server."""
+        other_port = "Found 1 tunnel port.\n\nPort Number   Protocol      Current Connections\n9000  http  0\n"
+        with (
+            patch("backend.services.sharing.tunnel_service._lookup_devtunnel", return_value=(True, "usw2")),
+            patch(
+                "backend.services.sharing.tunnel_service._run_capture",
+                side_effect=self._capture(create_error=self._CONFLICT, port_list=other_port),
+            ),
+            pytest.raises(TunnelStartError),
+        ):
+            _start_devtunnel(8080, tunnel_name="cpl-test")
 
 
 class TestCloudflaredDetectionIsPortable:

--- a/backend/tests/unit/test_tunnel_service.py
+++ b/backend/tests/unit/test_tunnel_service.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import subprocess as real_subprocess
+import sys
 import threading
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from backend.services.sharing import tunnel_service
 from backend.services.sharing.tunnel_service import (
     _CODEPLANE_TUNNEL_PREFIX,
     RemoteProvider,
@@ -1115,3 +1118,40 @@ class TestCloudflaredDetectionIsPortable:
             patch.object(os, "getpid", return_value=111),
         ):
             assert _cloudflared_already_running() is False
+
+
+class TestJobAssignmentIsReported:
+    """A failed Job Object assignment must be observable, not silently swallowed.
+
+    ``AssignProcessToJobObject`` fails with ``ERROR_ACCESS_DENIED`` on Windows
+    hosts that place the connector in an ambient job at spawn. Discarding the
+    result left the caller believing the connector could not outlive an abrupt
+    kill when in fact it could, with nothing in the log to say so.
+    """
+
+    def _fake_kernel32(self, *, assign_ok: bool) -> MagicMock:
+        kernel32 = MagicMock()
+        kernel32.OpenProcess.return_value = 4321
+        kernel32.AssignProcessToJobObject.return_value = 1 if assign_ok else 0
+        return kernel32
+
+    def _assign(self, *, assign_ok: bool) -> bool:
+        proc = cast("subprocess.Popen[str]", SimpleNamespace(pid=999))
+        kernel32 = self._fake_kernel32(assign_ok=assign_ok)
+        fake_ctypes = MagicMock()
+        fake_ctypes.WinDLL.return_value = kernel32
+        fake_ctypes.get_last_error.return_value = 5
+        with (
+            patch.object(tunnel_service.sys, "platform", "win32"),
+            patch.object(tunnel_service, "_windows_kill_on_close_job", return_value=77),
+            patch.dict(sys.modules, {"ctypes": fake_ctypes, "ctypes.wintypes": MagicMock()}),
+        ):
+            return tunnel_service._assign_to_kill_on_close_job(proc)
+
+    def test_failed_assignment_reports_no_coverage(self) -> None:
+        tunnel_service._job_assign_warned = False
+        assert self._assign(assign_ok=False) is False
+
+    def test_successful_assignment_reports_coverage(self) -> None:
+        tunnel_service._job_assign_warned = False
+        assert self._assign(assign_ok=True) is True

--- a/backend/tests/unit/test_tunnel_service.py
+++ b/backend/tests/unit/test_tunnel_service.py
@@ -897,6 +897,19 @@ class TestDevtunnelLoginDetection:
         ):
             assert devtunnel_logged_in() is False
 
+    def test_logged_in_is_false_for_expired_token_despite_exit_zero(self) -> None:
+        """An expired login is the wording a returning user hits, and it is the
+        one case where ``devtunnel user show`` still exits 0 — observed on
+        Windows: exit 0 with "Login token expired." on stdout, while every
+        other subcommand then fails with exit 3. Trusting the exit code alone
+        let validation pass and the failure resurface later as a bare
+        "Login token expired." with no instruction to fix it."""
+        with patch(
+            "backend.services.sharing.tunnel_service._run_capture",
+            return_value=real_subprocess.CompletedProcess([], returncode=0, stdout="Login token expired.", stderr=""),
+        ):
+            assert devtunnel_logged_in() is False
+
     def test_logged_in_is_true_for_normal_output(self) -> None:
         with patch(
             "backend.services.sharing.tunnel_service._run_capture",
@@ -912,6 +925,7 @@ class TestDevtunnelLoginDetection:
             "Login required.",
             "Unauthorized tunnel creation access: Anonymous does not have 'create' access scope",
             "You are not logged in",
+            "Login token expired.",
         ],
     )
     def test_create_failure_appends_login_hint(self, message: str) -> None:

--- a/backend/tests/unit/test_tunnel_service.py
+++ b/backend/tests/unit/test_tunnel_service.py
@@ -34,10 +34,34 @@ from backend.services.sharing.tunnel_service import (
 
 if TYPE_CHECKING:
     import subprocess
+    from collections.abc import Iterator
 
 
 def _as_popen(proc: _FakeProc) -> subprocess.Popen[str]:
     return cast("subprocess.Popen[str]", proc)
+
+
+@pytest.fixture(autouse=True)
+def _stop_leaked_watchdogs() -> Iterator[None]:
+    """Stop every watchdog a test starts, so none outlives it.
+
+    ``start_remote_access`` starts a real daemon thread. Tests that exercise
+    it never stopped one, so after ``_INITIAL_DELAY`` the surviving thread ran
+    a live health check and wrote ``tunnel_health_check_failed`` to stdout —
+    landing inside whichever test happened to be running, which corrupted the
+    JSON that ``cpl doctor --json`` prints and failed an unrelated test.
+    """
+    started: list[TunnelWatchdog] = []
+    real_start = TunnelWatchdog.start
+
+    def _tracking_start(self: TunnelWatchdog) -> None:
+        started.append(self)
+        real_start(self)
+
+    with patch.object(TunnelWatchdog, "start", _tracking_start):
+        yield
+    for watchdog in started:
+        watchdog.stop()
 
 
 class _FakeProc:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -123,6 +123,21 @@ At startup CodePlane fetches Cloudflare's JWKS signing keys (validating the Acce
 
 You can find the AUD tag in the Cloudflare Zero Trust dashboard under **Access → Applications → your app → Overview → Application Audience (AUD) Tag**.
 
+### Tunnel Lifecycle
+
+Both providers are supported on Linux, macOS, native Windows, and WSL.
+
+**The connector is tied to the server.** CodePlane starts the connector process (`devtunnel host` or `cloudflared`) as a child of the server and stops it again when the server stops — via `cpl down`, `cpl restart`, or Ctrl-C. After a normal shutdown no connector is left behind and the public origin reports no host connections.
+
+**Reusing an existing connector.** If a connector is already serving the configured origin — a systemd/Docker-managed `cloudflared`, or one orphaned by a previous run — CodePlane detects it at startup, reuses it instead of starting a second one, and leaves it running at shutdown. Externally managed connectors are never terminated by CodePlane.
+
+**Named Dev Tunnels are reusable.** `--tunnel-name` reuses the same tunnel and port registration across restarts, so the URL stays stable. Re-running against a tunnel whose port is already registered is expected and handled.
+
+**Connector supervision.** A watchdog restarts the connector if the connector process exits, or if the public relay stops forwarding while the local server is healthy. It deliberately does *not* restart the connector when the local server itself is unreachable (for example during a slow startup) — restarting a connector cannot fix a down origin.
+
+!!! note "Hard kills can orphan the connector"
+    If the server is killed abruptly (`kill -9`, Task Manager, a crash), it gets no chance to stop the connector and the process may survive. The next `cpl up` detects the surviving connector and reuses it. To remove it manually, stop the `devtunnel host` / `cloudflared` process for your origin.
+
 ### All Remote Options
 
 | CLI Flag | Env Var | Description |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -129,13 +129,17 @@ Both providers are supported on Linux, macOS, native Windows, and WSL.
 
 **The connector is tied to the server.** CodePlane starts the connector process (`devtunnel host` or `cloudflared`) as a child of the server and stops it again when the server stops — via `cpl down`, `cpl restart`, or Ctrl-C. After a normal shutdown no connector is left behind and the public origin reports no host connections.
 
-**Reusing an existing connector.** If a connector is already serving the configured origin — a systemd/Docker-managed `cloudflared`, or one orphaned by a previous run — CodePlane detects it at startup, reuses it instead of starting a second one, and leaves it running at shutdown. Externally managed connectors are never terminated by CodePlane.
+**Reusing an existing connector.** If a `cloudflared` process is already serving the *configured tunnel* — a systemd/Docker-managed connector, or one orphaned by a previous run — CodePlane detects it at startup, reuses it instead of starting a second one, and leaves it running at shutdown. Detection matches the tunnel token (or the tunnel ID derived from it) on the running process's command line, so a `cloudflared` serving some *other* tunnel on the same machine is ignored and CodePlane starts its own connector. Externally managed connectors are never terminated by CodePlane.
 
 **Named Dev Tunnels are reusable.** `--tunnel-name` reuses the same tunnel and port registration across restarts, so the URL stays stable. Re-running against a tunnel whose port is already registered is expected and handled.
 
 **Connector supervision.** A watchdog restarts the connector if the connector process exits, or if the public relay stops forwarding while the local server is healthy. It deliberately does *not* restart the connector when the local server itself is unreachable (for example during a slow startup) — restarting a connector cannot fix a down origin.
 
+!!! warning "`cpl down` is not graceful on Windows"
+    Windows has no process signals: `cpl down` terminates the server and every process below it outright. The connector is stopped first, so the public origin closes promptly and no connector is orphaned — but the server's own shutdown handlers do not run, so worktree cleanup and lease release are skipped. Running sessions are paused over the API before the stop, which is what preserves session state. On Linux, macOS, and WSL, `cpl down` sends `SIGTERM` and the full graceful shutdown runs.
+
 !!! note "Hard kills can orphan the connector"
+    If the server is killed abruptly (`kill -9`, Task Manager, a crash), it gets no chance to stop the connector and the process may survive. The next `cpl up` detects the surviving connector and reuses it. To remove it manually, stop the `devtunnel host` / `cloudflared` process for your origin.
     If the server is killed abruptly (`kill -9`, Task Manager, a crash), it gets no chance to stop the connector and the process may survive. The next `cpl up` detects the surviving connector and reuses it. To remove it manually, stop the `devtunnel host` / `cloudflared` process for your origin.
 
 ### All Remote Options

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -129,6 +129,8 @@ cpl up --phone                               # shortcut for --remote
 
 The UI is fully responsive — monitor jobs, approve actions, and send messages from anywhere.
 
+The tunnel connector runs as a child of the server: `cpl down` stops both, and an existing connector for the same origin is reused rather than duplicated. See [Configuration > Tunnel Lifecycle](configuration.md#tunnel-lifecycle) for details.
+
 CodePlane is a Progressive Web App — on mobile browsers you can "Add to Home Screen" for a native-like experience with push notifications.
 
 ## What's Next

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -53,7 +53,7 @@ cpl down [options]
 | `--port PORT` | Server port | from config or `8080` |
 | `--force` | Skip session pausing; stop immediately | disabled |
 
-Active sessions are paused for recovery on next start.
+Active sessions are paused for recovery on next start. A tunnel connector started by `cpl up` is stopped along with the server; a connector that was already running before startup (externally managed) is left alone.
 
 ### `cpl restart`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,7 @@ warn_unused_configs = true
 plugins = ["pydantic.mypy"]
 
 [[tool.mypy.overrides]]
-module = ["faster_whisper.*", "copilot.*", "mcp.*", "qrcode.*", "questionary.*", "winpty.*", "coderecon.*"]
+module = ["faster_whisper.*", "copilot.*", "mcp.*", "qrcode.*", "questionary.*", "winpty.*", "coderecon.*", "psutil"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]


### PR DESCRIPTION
## Summary

Makes the Cloudflare and Dev Tunnels remote-access features work end to end on **native Windows and WSL** (in addition to Linux/macOS). 15 defects found and fixed, each with a regression test that was mutation-checked — the fix was reverted to confirm the test actually fails without it.

Every provider/platform combination was then verified **live against the real public origin**, not just in tests.

## Defects fixed

| # | Defect | Fix |
|---|---|---|
| 1-10 | Windows/WSL portability of the tunnel path: POSIX-only process handling, platform branches invisible to the type checker, `--provider` being overridden by Cloudflare auto-detection, an expired Dev Tunnels login reported as logged in, CLI tests picking up the repo `.env` and host PID layout | `a42cd1e7`, `18f44efd`, `843631f5`, `40d5fc3c`, `aaf10bd1` |
| 11 | Watchdog restarted a **healthy** connector during slow startup — a failing *local* origin check counted toward the failure threshold, and a ~45s Windows startup beat the 30s initial delay | Restart only when the connector process exits, or the relay fails while the origin is healthy. Restarting a connector cannot fix a down origin. |
| 12 | Windows Job Object assignment failed silently — the `AssignProcessToJobObject` result was discarded. Windows 11 puts essentially every process in an ambient job, so the call returns `ERROR_ACCESS_DENIED` rather than nesting. | Declared proper Win32 argtypes/restypes and report the failure once. See "Deliberately out of scope" below. |
| 13 | Dev Tunnels start aborted against any existing tunnel: the code matched invented error wording (`already`/`exists`) while the real CLI says `Tunnel service error: Conflict with existing entity`. Only a mock asserted the old wording. | Ask the service instead of parsing prose — `devtunnel port list`. |
| 14 | `cpl down` left the connector running on **Windows** — no process groups, and `os.kill` there hits only the named PID. | `_kill_windows_process_tree` |
| 15 | `cpl down` left the connector running on **both** platforms | See below. |

### Defect 15 — the interesting one

`cpl down` reported "Server stopped" while the public origin still had a live host connection.

`uvicorn.Server.run` captures termination signals for the duration of `serve()`, then restores whatever handler was installed beforehand and **re-raises the signal**. With the default `SIGTERM` handler in place, that re-raise kills the process instantly: `server.run()` never returns, so the `finally` that calls `tunnel_handle.close()` never executes and the connector is orphaned. Ctrl-C always worked because Python's default `SIGINT` handler merely raises `KeyboardInterrupt` — which is exactly why this hid for so long.

Fix: install an inert `SIGTERM`/`SIGBREAK` handler *before* `server.run()`, so uvicorn restores that one and the re-raise is a no-op.

Found by instrumenting the shutdown path after `TunnelHandle.close()` was proven correct in isolation — the debug prints never fired, which pinned it to the signal re-raise rather than the teardown logic.

## E2E verification

All four legs verified with an **authenticated HTTP 200 and real JSON through the public origin** (`cf-access-token` for Cloudflare, `X-Tunnel-Authorization` for Dev Tunnels), with responses attributed to the correct host via distinguishing `activeJobs` values:

| | Windows | WSL |
|---|---|---|
| Cloudflare | ✅ | ✅ |
| Dev Tunnels | ✅ | ✅ |
| `cpl down` teardown | ✅ connector gone, `Host connections: 0` | ✅ connector gone, `Host connections: 0` |

Also confirmed live: reuse detection (`tunnel_reusing_existing`) against a real orphaned connector, and no spurious watchdog restart during a 38s Windows startup that previously triggered one.

## Deliberately out of scope

Full Windows Job Object orphan prevention. Self-assignment works, but `KILL_ON_JOB_CLOSE` on a job containing the server would also kill the detached restart helper, terminal sessions, and agent children. Doing it properly needs `JOB_OBJECT_LIMIT_BREAKAWAY_OK` plus `CREATE_BREAKAWAY_FROM_JOB` at every must-outlive spawn site. Instead the failure is now reported honestly, and abrupt-kill orphans are mitigated by origin-reuse detection (proven live). Documented in `docs/configuration.md`.

## Testing

- Windows: `test_cli.py` + `test_tunnel_service.py` — 126 passed, 1 pre-existing failure (`test_escalates_to_sigkill_after_timeout`, `signal.SIGKILL` doesn't exist on Windows — reproduces on a plain `origin/main` checkout).
- WSL: full unit suite — 3343 passed, 7 failed, **all 7 reproducing identically at the base commit**. Zero regressions.
- `ruff check`, `ruff format`, and `mypy` clean on everything touched.
- The pre-existing failures are being handled separately.

## Docs

`docs/configuration.md` gains a **Tunnel Lifecycle** section covering connector ownership, reuse of externally managed connectors, named Dev Tunnel reuse, watchdog semantics, and the hard-kill orphan caveat. Cross-referenced from `docs/quick-start.md` and `docs/reference/cli.md`.

## Review round

Two adversarial reviews ran against this branch. Nine further defects were confirmed and fixed, each with a mutation-verified regression test (revert the fix, watch the test fail):

| # | Defect | Fix |
|---|--------|-----|
| 16 | The watchdog reset its relay failure tally on every non-relay cycle. With the production check frequency (5) and threshold (2), the threshold was **unreachable** — connector restarts were silently disabled. My own regression from the defect-11 rewrite, masked by a test that set the frequency to 1. | Separate "no evidence this cycle" from "relay is healthy". |
| 17 | Cloudflare reuse detection matched on **process name alone**. The psutil rewrite made that path reachable on Windows for the first time, so a host running `cloudflared` for an unrelated tunnel would take the reuse branch and print a public URL that routes nowhere. | Require the tunnel token (or the tunnel ID derived from it) on the running process's command line. |
| 18 | `cpl restart` replayed `--provider` unconditionally, so the child `cpl up` saw `ParameterSource.COMMANDLINE` for a value that was merely `restart`'s own default and skipped Cloudflare auto-detection: `cpl up --remote` started Cloudflare while `cpl restart --remote` started a Dev Tunnel. | Forward `--provider` only when the user supplied it. |
| 19 | The `.env` loader exported **every** key into `os.environ`, which pty terminals and agent subprocesses inherit — an unrelated API key in a developer's `.env` reached every terminal opened through the web UI. | Allowlist the remote-access keys. `_env` now resolves in the same order as the export, so the CLI, `lifespan` and the restart helper cannot disagree. |
| 20 | `lifespan._request_graceful_shutdown` treated *any* callable `SIGTERM` handler as proof someone would act on the signal — including the handler this PR installs to swallow it. The Cloudflare Access safety stop would have returned with the server still serving unprotected. | The inert handler advertises itself; the caller restores the default and hard-stops. |
| 21 | `TunnelHandle.close()` was re-entrant (main thread `finally` + force-exit timer) and could race a watchdog restart into an unreaped connector. | Idempotent and serialized; a connector spawned after stop is reaped, not adopted. |
| 22 | `_signal_process_tree` terminated a single process on Windows, leaving `devtunnel host`'s transport child alive. | Enumerate and terminate descendants. |
| 23 | The Windows tree kill terminated descendants in arbitrary order, so a slow agent process could delay closing the public entrypoint. | Connectors die first. |
| 24 | The watchdog origin gate reported "origin down" when no local port was configured, which would disable restarts entirely. | Unknown origin is not a down origin. |

Also corrected the docs this PR added: reuse detection is tunnel-scoped (not "the configured origin" by process name), and `cpl down` on Windows is a hard kill that skips the server's own shutdown handlers — the connector is still stopped first, and sessions are paused over the API beforehand.

### Re-verified E2E after the review changes

All four legs were run again against the public origins with the post-review code — authenticated HTTP 200 with real JSON, attributed by `activeJobs` (WSL 5, Windows 0), each followed by `cpl down` with no surviving connector:

| | Windows | WSL |
|---|---|---|
| Cloudflare | ✅ 200, `activeJobs:0` | ✅ 200, `activeJobs:5`, `tunnel_reusing_existing` matched the real systemd connector by token |
| Dev Tunnels | ✅ 200 (incl. a second run reusing the existing tunnel + port registration) | ✅ 200, `activeJobs:5` |

### Knowingly not fixed

- `_wait_for_recovery` verifies only the local origin, so a restart is declared successful without re-proving the relay.
- Windows `cpl down` remains a `TerminateProcess` hard kill. Doing it gracefully needs an HTTP shutdown request or `CREATE_NEW_PROCESS_GROUP` + `CTRL_BREAK_EVENT` at spawn time; both are larger changes than this PR. Now documented rather than implied away.
- The Windows tree kill is still a snapshot of descendants, so a process spawned mid-teardown can survive.

