### PR TITLE
chore: unbreak Backend CI on main (ruff format + 2 mypy errors)

### DIFF
--- a/backend/api/tracker_links.py
+++ b/backend/api/tracker_links.py
@@ -83,9 +83,7 @@ async def list_tracker_links(
         repo = TrackerLinkRepository(session)
         rows = await repo.list_for_project(project_id)
         summaries = await TrackerSummaryRepository(session).list_for_project(project_id)
-    return TrackerLinkListResponse(
-        tracker_links=[_to_response(row, summaries.get(row["id"])) for row in rows]
-    )
+    return TrackerLinkListResponse(tracker_links=[_to_response(row, summaries.get(row["id"])) for row in rows])
 
 
 @router.post("", response_model=TrackerLinkResponse, status_code=201)

--- a/backend/services/recipe/recipe_service.py
+++ b/backend/services/recipe/recipe_service.py
@@ -287,9 +287,7 @@ class RecipeService:
         if gated:
             assert self._approval_service is not None  # narrowed by _is_chain_gated
             pending = await self._approval_service.list_pending()
-            pending_spawn_actions = {
-                a.proposed_action for a in pending if a.proposed_action is not None
-            }
+            pending_spawn_actions = {a.proposed_action for a in pending if a.proposed_action is not None}
 
         spawned: list[Job] = []
         for candidate in project_links:

--- a/backend/services/tracker_sync_service.py
+++ b/backend/services/tracker_sync_service.py
@@ -41,9 +41,7 @@ class TrackerSyncService:
         self._session_factory = session_factory
         self._client: httpx.AsyncClient | None = None
         if adapters is None:
-            self._client = httpx.AsyncClient(
-                timeout=httpx.Timeout(connect=10.0, read=30.0, write=15.0, pool=5.0)
-            )
+            self._client = httpx.AsyncClient(timeout=httpx.Timeout(connect=10.0, read=30.0, write=15.0, pool=5.0))
             adapters = build_tracker_adapters(self._client)
         self._adapters = adapters
         self._wake = asyncio.Event()
@@ -91,9 +89,7 @@ class TrackerSyncService:
                     link_id=link_id,
                 )
                 if target is None:
-                    raise TrackerLinkNotFoundError(
-                        f"TrackerLink '{link_id}' does not exist in Project '{project_id}'"
-                    )
+                    raise TrackerLinkNotFoundError(f"TrackerLink '{link_id}' does not exist in Project '{project_id}'")
                 token = await CredentialRepository(session).resolve_secret(target["credential_id"])
 
             adapter = self._adapters.get(target["provider"])

--- a/backend/tests/integration/test_api_settings.py
+++ b/backend/tests/integration/test_api_settings.py
@@ -142,6 +142,7 @@ class TestUpdateSettings:
         resp = await client.put("/api/settings", json={"trackerPollIntervalSeconds": 5})
         assert resp.status_code == 422
 
+
 # ---------------------------------------------------------------------------
 # Repo Endpoints
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_config.py
+++ b/backend/tests/unit/test_config.py
@@ -76,14 +76,11 @@ def test_init_config_roundtrips(tmp_path: Path) -> None:
     assert config.server.port == 8080
     assert config.runtime.worktrees_dirname == ".codeplane-worktrees"
     assert config.retention.artifact_retention_days == 30
+
+
 def test_load_config_removes_retired_tracker_interval(tmp_path: Path) -> None:
     cfg_path = tmp_path / "config.yaml"
-    cfg_path.write_text(
-        "telemetry:\n"
-        "  instance_id: existing-instance\n"
-        "tracker:\n"
-        "  poll_interval_seconds: 90\n"
-    )
+    cfg_path.write_text("telemetry:\n  instance_id: existing-instance\ntracker:\n  poll_interval_seconds: 90\n")
     config = load_config(cfg_path)
     assert not hasattr(config, "tracker")
     assert "tracker" not in cfg_path.read_text()

--- a/backend/tests/unit/test_mcp_server.py
+++ b/backend/tests/unit/test_mcp_server.py
@@ -409,9 +409,7 @@ class TestTrackerTool:
         ):
             mock_cred_cls.return_value.resolve_secret = AsyncMock(return_value="secret-pat")
 
-            result = await _tool(mcp_server, "codeplane_tracker")(
-                action="transition", job_id="job-123", value="Done"
-            )
+            result = await _tool(mcp_server, "codeplane_tracker")(action="transition", job_id="job-123", value="Done")
 
         assert result["dispatched"] is False
         mock_cred_cls.return_value.resolve_secret.assert_not_called()

--- a/backend/tests/unit/test_mcp_server.py
+++ b/backend/tests/unit/test_mcp_server.py
@@ -330,7 +330,7 @@ class TestPrTool:
 def _make_task_link(**overrides: object):
     from backend.models.domain import TaskLink
 
-    defaults = dict(
+    defaults: dict[str, object] = dict(
         id="tl-1",
         project_id="proj-1",
         repo_path="/repo",

--- a/backend/tests/unit/test_recipe_service.py
+++ b/backend/tests/unit/test_recipe_service.py
@@ -609,9 +609,7 @@ class TestHandleJobCompletedTrackerWrite:
         # No story_node_id (manually-assigned, Story 4.3) — must not be skipped
         # by the dependency-graph early return, since a manually-assigned
         # TaskLink is exactly the kind most likely paired with a ticket.
-        completed_link = _make_task_link(
-            id="link-a", story_node_id=None, job_id="job-1", tracker_ticket_ref="JIRA-7"
-        )
+        completed_link = _make_task_link(id="link-a", story_node_id=None, job_id="job-1", tracker_ticket_ref="JIRA-7")
         mock_task_link_repo.get_by_job_id.return_value = completed_link
         mock_tracker_link_repo.list_for_project.return_value = [
             {"id": "trk-1", "project_id": "proj-1", "credential_id": "cred-1", "external_ref": "PROJ"}
@@ -821,9 +819,7 @@ class TestHandleJobCompletedGating:
         mock_task_link_repo.list_by_project.return_value = [completed_link, dependent]
         mock_job_repo.get.return_value = _make_job(id="job-1", state=JobState.completed, resolution="merged")
         mock_chat_repo.get_attached_open_chat_for_project.return_value = object()
-        mock_approval_service.list_pending.return_value = [
-            _make_approval(proposed_action="spawn_task:link-b")
-        ]
+        mock_approval_service.list_pending.return_value = [_make_approval(proposed_action="spawn_task:link-b")]
 
         service = RecipeService(
             mock_task_link_repo,

--- a/backend/tests/unit/test_tracker_resolution.py
+++ b/backend/tests/unit/test_tracker_resolution.py
@@ -44,7 +44,7 @@ async def _make_credential(session: AsyncSession, credential_id: str = "cred-1")
         credential_id=credential_id, provider="github", label="GH", base_url="https://api.github.com", pat="secret"
     )
     await session.commit()
-    return row["id"]
+    return str(row["id"])
 
 
 async def _make_job(session: AsyncSession, job_id: str = "job-1") -> None:


### PR DESCRIPTION
## Why

The **Backend** CI job is failing on `main`, so every open PR is blocked on a red check that has nothing to do with its contents. PRs #75 and #76 both hit this; #76 needed an admin override to merge.

There were **two** independent pre-existing breakages, stacked. The second was invisible until the first was fixed, because ruff runs before mypy and the job stops at the first failure.

## What

**1. `ruff format` on 7 files** (commit 1)

Mechanical: line joins and blank-line placement. The only string touched is in `test_config.py`, where an implicit concatenation collapses into a single literal with a **byte-identical value**.

**2. Two mypy errors** (commit 2)

- `test_tracker_resolution.py:47` - the repository returns an untyped mapping, so `row["id"]` is `Any` while the function declares `-> str`. Wrapped in `str()`.
- `test_mcp_server.py:333` - mypy cannot infer an element type from a heterogeneous `dict()` call. Annotated `dict[str, object]`.

## Pre-existing, verified not caused by this PR

I checked out the `origin/main` versions of both files and ran mypy against them: both errors reproduce. So this PR does not introduce them and is not papering over anything it caused.

## Verification

- `ruff check backend/` -> All checks passed
- `ruff format --check backend/` -> 385 files already formatted
- `mypy` on both touched files -> clean
- `pytest` on the affected modules -> 143 passed

## Worth a separate decision

A formatting/type gate that is already failing on the default branch has stopped being a gate - it trains everyone to reach for `--admin`. Consider a branch-protection rule requiring Backend green before merge to `main`, so this cannot silently re-accumulate.
