### PR TITLE
fix: persist push subscriptions across server restarts

### DIFF
--- a/alembic/versions/0066_add_push_subscriptions.py
+++ b/alembic/versions/0066_add_push_subscriptions.py
@@ -1,0 +1,29 @@
+"""Add push_subscriptions table for persistent Web Push endpoints.
+
+Revision ID: 0066
+Revises: 0065
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0066"
+down_revision = "0065"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "push_subscriptions",
+        sa.Column("endpoint", sa.String(), primary_key=True),
+        sa.Column("p256dh", sa.String(), nullable=False),
+        sa.Column("auth_key", sa.String(), nullable=False),
+        sa.Column("created_at", sa.String(), nullable=False),
+        sa.Column("updated_at", sa.String(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("push_subscriptions")

--- a/alembic/versions/0066_add_push_subscriptions.py
+++ b/alembic/versions/0066_add_push_subscriptions.py
@@ -20,8 +20,8 @@ def upgrade() -> None:
         sa.Column("endpoint", sa.String(), primary_key=True),
         sa.Column("p256dh", sa.String(), nullable=False),
         sa.Column("auth_key", sa.String(), nullable=False),
-        sa.Column("created_at", sa.String(), nullable=False),
-        sa.Column("updated_at", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
     )
 
 

--- a/backend/api/notifications.py
+++ b/backend/api/notifications.py
@@ -22,12 +22,12 @@ def get_vapid_key(push_service: FromDishka[PushService]) -> VapidKeyResponse:
 
 
 @router.post("/notifications/subscribe", status_code=204)
-def subscribe(body: SubscriptionRequest, push_service: FromDishka[PushService]) -> None:
+async def subscribe(body: SubscriptionRequest, push_service: FromDishka[PushService]) -> None:
     """Register a Web Push subscription."""
-    push_service.subscribe({"endpoint": body.endpoint, "keys": body.keys})
+    await push_service.subscribe_async({"endpoint": body.endpoint, "keys": body.keys})
 
 
 @router.post("/notifications/unsubscribe", status_code=204)
-def unsubscribe(body: UnsubscribeRequest, push_service: FromDishka[PushService]) -> None:
+async def unsubscribe(body: UnsubscribeRequest, push_service: FromDishka[PushService]) -> None:
     """Remove a Web Push subscription."""
-    push_service.unsubscribe(body.endpoint)
+    await push_service.unsubscribe_async(body.endpoint)

--- a/backend/lifespan.py
+++ b/backend/lifespan.py
@@ -861,7 +861,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     push_service = PushService(
         vapid_private_key=vapid_keys["private_key"],
         vapid_public_key=vapid_keys["public_key"],
+        session_factory=session_factory,
     )
+    await push_service.load_from_db()
 
     async def _push_subscriber(event: SessionEvent) -> None:
         """Send push notifications for approval requests and terminal job states."""
@@ -871,6 +873,39 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
                 title="Approval needed",
                 body=str(desc),
                 tag=f"approval-{event.payload.get('approval_id', event.session_id)}",
+                url=f"/jobs/{event.session_id}",
+            )
+        elif event.kind == EventKind.batch_approval_requested:
+            desc = event.payload.get("description", "Batch action requires your approval")
+            await push_service.notify(
+                title="Batch approval needed",
+                body=str(desc),
+                tag=f"batch-approval-{event.session_id}",
+                url=f"/jobs/{event.session_id}",
+            )
+        elif event.kind == EventKind.merge_conflict:
+            files = event.payload.get("conflict_files", [])
+            body = f"{len(files)} conflicting file(s)" if files else "Merge conflict detected"
+            await push_service.notify(
+                title="Merge conflict",
+                body=body,
+                tag=f"conflict-{event.session_id}",
+                url=f"/jobs/{event.session_id}",
+            )
+        elif event.kind == EventKind.job_review:
+            pr_url = event.payload.get("pr_url", "")
+            body = f"PR ready: {pr_url}" if pr_url else "Job ready for review"
+            await push_service.notify(
+                title="Job ready for review",
+                body=body,
+                tag=f"review-{event.session_id}",
+                url=f"/jobs/{event.session_id}",
+            )
+        elif event.kind == EventKind.stall_detected:
+            await push_service.notify(
+                title="Job stalled",
+                body="Agent may be stuck",
+                tag=f"stall-{event.session_id}",
                 url=f"/jobs/{event.session_id}",
             )
         elif event.kind == EventKind.job_completed:

--- a/backend/lifespan.py
+++ b/backend/lifespan.py
@@ -866,7 +866,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     await push_service.load_from_db()
 
     async def _push_subscriber(event: SessionEvent) -> None:
-        """Send push notifications for approval requests and terminal job states."""
+        """Send push notifications for actionable and terminal job events."""
         if event.kind == EventKind.approval_requested:
             desc = event.payload.get("description", "Action requires your approval")
             await push_service.notify(

--- a/backend/models/db.py
+++ b/backend/models/db.py
@@ -713,3 +713,15 @@ class SecondarySessionEntryRow(Base):
     tool_visibility: Mapped[str | None] = mapped_column(String, nullable=True)
 
     __table_args__ = (Index("ix_ss_entries_session", "session_id"),)
+
+
+class PushSubscriptionRow(Base):
+    """Persisted Web Push subscription endpoint."""
+
+    __tablename__ = "push_subscriptions"
+
+    endpoint: Mapped[str] = mapped_column(String, primary_key=True)
+    p256dh: Mapped[str] = mapped_column(String, nullable=False)
+    auth_key: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[str] = mapped_column(String, nullable=False)
+    updated_at: Mapped[str] = mapped_column(String, nullable=False)

--- a/backend/models/db.py
+++ b/backend/models/db.py
@@ -723,5 +723,5 @@ class PushSubscriptionRow(Base):
     endpoint: Mapped[str] = mapped_column(String, primary_key=True)
     p256dh: Mapped[str] = mapped_column(String, nullable=False)
     auth_key: Mapped[str] = mapped_column(String, nullable=False)
-    created_at: Mapped[str] = mapped_column(String, nullable=False)
-    updated_at: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(TZDateTime, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(TZDateTime, nullable=False)

--- a/backend/persistence/push_subscription_repo.py
+++ b/backend/persistence/push_subscription_repo.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 from sqlalchemy import delete, select
 
 from backend.models.db import PushSubscriptionRow
 from backend.persistence.repository import BaseRepository
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine import CursorResult
 
 
 class PushSubscriptionRepository(BaseRepository):
@@ -45,7 +48,7 @@ class PushSubscriptionRepository(BaseRepository):
         result = await self._session.execute(
             delete(PushSubscriptionRow).where(PushSubscriptionRow.endpoint == endpoint)
         )
-        return result.rowcount > 0  # type: ignore[union-attr]
+        return cast("CursorResult[Any]", result).rowcount > 0
 
     async def delete_many(self, endpoints: list[str]) -> int:
         if not endpoints:
@@ -53,4 +56,4 @@ class PushSubscriptionRepository(BaseRepository):
         result = await self._session.execute(
             delete(PushSubscriptionRow).where(PushSubscriptionRow.endpoint.in_(endpoints))
         )
-        return result.rowcount  # type: ignore[union-attr]
+        return int(cast("CursorResult[Any]", result).rowcount)

--- a/backend/persistence/push_subscription_repo.py
+++ b/backend/persistence/push_subscription_repo.py
@@ -16,10 +16,7 @@ class PushSubscriptionRepository(BaseRepository):
 
     async def list_all(self) -> list[dict[str, Any]]:
         result = await self._session.execute(select(PushSubscriptionRow))
-        return [
-            {"endpoint": r.endpoint, "keys": {"p256dh": r.p256dh, "auth": r.auth_key}}
-            for r in result.scalars()
-        ]
+        return [{"endpoint": r.endpoint, "keys": {"p256dh": r.p256dh, "auth": r.auth_key}} for r in result.scalars()]
 
     async def upsert(self, endpoint: str, p256dh: str, auth_key: str) -> None:
         """Insert or update a subscription (endpoint is the natural idempotency key)."""

--- a/backend/persistence/push_subscription_repo.py
+++ b/backend/persistence/push_subscription_repo.py
@@ -1,0 +1,59 @@
+"""Persistence for Web Push subscription endpoints."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import delete, select
+
+from backend.models.db import PushSubscriptionRow
+from backend.persistence.repository import BaseRepository
+
+
+class PushSubscriptionRepository(BaseRepository):
+    """Database access for push subscription endpoints."""
+
+    async def list_all(self) -> list[dict[str, Any]]:
+        result = await self._session.execute(select(PushSubscriptionRow))
+        return [
+            {"endpoint": r.endpoint, "keys": {"p256dh": r.p256dh, "auth": r.auth_key}}
+            for r in result.scalars()
+        ]
+
+    async def upsert(self, endpoint: str, p256dh: str, auth_key: str) -> None:
+        """Insert or update a subscription (endpoint is the natural idempotency key)."""
+        now = datetime.now(UTC).isoformat()
+        existing = await self._session.execute(
+            select(PushSubscriptionRow).where(PushSubscriptionRow.endpoint == endpoint)
+        )
+        row = existing.scalar_one_or_none()
+        if row is None:
+            self._session.add(
+                PushSubscriptionRow(
+                    endpoint=endpoint,
+                    p256dh=p256dh,
+                    auth_key=auth_key,
+                    created_at=now,
+                    updated_at=now,
+                )
+            )
+        else:
+            row.p256dh = p256dh
+            row.auth_key = auth_key
+            row.updated_at = now
+        await self._session.flush()
+
+    async def delete(self, endpoint: str) -> bool:
+        result = await self._session.execute(
+            delete(PushSubscriptionRow).where(PushSubscriptionRow.endpoint == endpoint)
+        )
+        return result.rowcount > 0  # type: ignore[union-attr]
+
+    async def delete_many(self, endpoints: list[str]) -> int:
+        if not endpoints:
+            return 0
+        result = await self._session.execute(
+            delete(PushSubscriptionRow).where(PushSubscriptionRow.endpoint.in_(endpoints))
+        )
+        return result.rowcount  # type: ignore[union-attr]

--- a/backend/persistence/push_subscription_repo.py
+++ b/backend/persistence/push_subscription_repo.py
@@ -23,7 +23,7 @@ class PushSubscriptionRepository(BaseRepository):
 
     async def upsert(self, endpoint: str, p256dh: str, auth_key: str) -> None:
         """Insert or update a subscription (endpoint is the natural idempotency key)."""
-        now = datetime.now(UTC).isoformat()
+        now = datetime.now(UTC)
         existing = await self._session.execute(
             select(PushSubscriptionRow).where(PushSubscriptionRow.endpoint == endpoint)
         )

--- a/backend/services/sharing/push_service.py
+++ b/backend/services/sharing/push_service.py
@@ -19,6 +19,19 @@ if TYPE_CHECKING:
 log = structlog.get_logger()
 
 
+def _is_gone_status(exc: Exception) -> bool:
+    """Return True if the push endpoint is permanently gone (404/410).
+
+    Uses the structured ``response.status_code`` from ``WebPushException``.
+    Exceptions without a response object are never treated as gone.
+    """
+    response = getattr(exc, "response", None)
+    if response is None:
+        return False
+    status = getattr(response, "status_code", None)
+    return status in (404, 410)
+
+
 @dataclass
 class PushSubscription:
     """A single Web Push subscription from a client."""
@@ -31,7 +44,8 @@ class PushService:
     """Manages Web Push subscriptions and notification delivery.
 
     Subscriptions are persisted via PushSubscriptionRepository and cached
-    in-memory for fast notification fanout.
+    in-memory for fast notification fanout. All DB writes go through
+    ``serialized_write`` to respect the global SQLite write lock.
     """
 
     def __init__(
@@ -75,20 +89,24 @@ class PushService:
         log.info("push_subscribed", endpoint=endpoint, total=len(self._subscriptions))
 
     async def subscribe_async(self, subscription_info: dict[str, Any]) -> None:
-        """Register a push subscription with DB persistence."""
+        """Register a push subscription with DB persistence.
+
+        Persists to the database first via ``serialized_write``, then
+        updates the in-memory cache only on commit success.
+        """
         endpoint = subscription_info.get("endpoint", "")
         keys = subscription_info.get("keys", {})
         if not endpoint or not keys.get("p256dh") or not keys.get("auth"):
             log.warning("push_subscribe_invalid", endpoint=endpoint if endpoint else "empty")
             return
-        self._subscriptions[endpoint] = PushSubscription(endpoint=endpoint, keys=keys)
         if self._session_factory is not None:
+            from backend.persistence.database import serialized_write
             from backend.persistence.push_subscription_repo import PushSubscriptionRepository
 
-            async with self._session_factory() as session:
+            async with serialized_write(self._session_factory) as session:
                 repo = PushSubscriptionRepository(session)
                 await repo.upsert(endpoint, keys["p256dh"], keys["auth"])
-                await session.commit()
+        self._subscriptions[endpoint] = PushSubscription(endpoint=endpoint, keys=keys)
         log.info("push_subscribed", endpoint=endpoint, total=len(self._subscriptions))
 
     def unsubscribe(self, endpoint: str) -> None:
@@ -98,16 +116,20 @@ class PushService:
             log.info("push_unsubscribed", endpoint=endpoint, total=len(self._subscriptions))
 
     async def unsubscribe_async(self, endpoint: str) -> None:
-        """Remove a push subscription with DB persistence."""
-        removed = self._subscriptions.pop(endpoint, None)
-        if removed and self._session_factory is not None:
+        """Remove a push subscription with DB persistence.
+
+        Deletes from the database first regardless of cache state (the row
+        may exist from a prior server lifetime), then removes from cache.
+        """
+        if self._session_factory is not None:
+            from backend.persistence.database import serialized_write
             from backend.persistence.push_subscription_repo import PushSubscriptionRepository
 
-            async with self._session_factory() as session:
+            async with serialized_write(self._session_factory) as session:
                 repo = PushSubscriptionRepository(session)
                 await repo.delete(endpoint)
-                await session.commit()
-            log.info("push_unsubscribed", endpoint=endpoint, total=len(self._subscriptions))
+        self._subscriptions.pop(endpoint, None)
+        log.info("push_unsubscribed", endpoint=endpoint, total=len(self._subscriptions))
 
     async def notify(self, *, title: str, body: str, tag: str = "cpl", url: str = "/") -> None:
         """Send a push notification to all subscribers (fire-and-forget)."""
@@ -121,31 +143,33 @@ class PushService:
 
         for endpoint, sub in list(self._subscriptions.items()):
             try:
-                await asyncio.get_event_loop().run_in_executor(
+                await asyncio.get_running_loop().run_in_executor(
                     None,
                     self._send_one,
                     sub,
                     payload,
                 )
             except Exception as exc:  # noqa: BLE001
-                error_msg = str(exc)
-                if "410" in error_msg or "404" in error_msg:
+                if _is_gone_status(exc):
                     stale.append(endpoint)
                     log.debug("push_subscription_expired", endpoint=endpoint)
                 else:
-                    log.warning("push_send_failed", endpoint=endpoint, error=error_msg)
+                    log.warning("push_send_failed", endpoint=endpoint, error=str(exc))
 
         for ep in stale:
             self._subscriptions.pop(ep, None)
 
-        # Prune stale endpoints from the database
+        # Prune stale endpoints from the database (best-effort)
         if stale and self._session_factory is not None:
-            from backend.persistence.push_subscription_repo import PushSubscriptionRepository
+            try:
+                from backend.persistence.database import serialized_write
+                from backend.persistence.push_subscription_repo import PushSubscriptionRepository
 
-            async with self._session_factory() as session:
-                repo = PushSubscriptionRepository(session)
-                await repo.delete_many(stale)
-                await session.commit()
+                async with serialized_write(self._session_factory) as session:
+                    repo = PushSubscriptionRepository(session)
+                    await repo.delete_many(stale)
+            except Exception:  # noqa: BLE001
+                log.warning("push_prune_db_failed", stale_count=len(stale))
 
     def _send_one(self, sub: PushSubscription, payload: str) -> None:
         """Synchronous push to a single subscription (runs in executor)."""

--- a/backend/services/sharing/push_service.py
+++ b/backend/services/sharing/push_service.py
@@ -61,9 +61,7 @@ class PushService:
             repo = PushSubscriptionRepository(session)
             rows = await repo.list_all()
         for row in rows:
-            self._subscriptions[row["endpoint"]] = PushSubscription(
-                endpoint=row["endpoint"], keys=row["keys"]
-            )
+            self._subscriptions[row["endpoint"]] = PushSubscription(endpoint=row["endpoint"], keys=row["keys"])
         log.info("push_subscriptions_loaded", count=len(rows))
 
     def subscribe(self, subscription_info: dict[str, Any]) -> None:

--- a/backend/services/sharing/push_service.py
+++ b/backend/services/sharing/push_service.py
@@ -1,17 +1,20 @@
 """Web Push notification service.
 
-Manages push subscriptions (in-memory) and sends notifications via the
-Web Push protocol. Subscriptions are ephemeral — if the server restarts,
-clients re-subscribe automatically via the service worker.
+Manages push subscriptions (persisted in the database) and sends notifications
+via the Web Push protocol. On startup the service loads existing subscriptions
+from the DB so they survive server restarts.
 """
 
 from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import structlog
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import async_sessionmaker
 
 log = structlog.get_logger()
 
@@ -25,25 +28,46 @@ class PushSubscription:
 
 
 class PushService:
-    """Manages Web Push subscriptions and notification delivery."""
+    """Manages Web Push subscriptions and notification delivery.
+
+    Subscriptions are persisted via PushSubscriptionRepository and cached
+    in-memory for fast notification fanout.
+    """
 
     def __init__(
         self,
         vapid_private_key: str,
         vapid_public_key: str,
+        session_factory: async_sessionmaker | None = None,
         vapid_mailto: str = "mailto:noreply@codeplane.dev",
     ) -> None:
         self._vapid_private_key = vapid_private_key
         self._vapid_public_key = vapid_public_key
         self._vapid_mailto = vapid_mailto
+        self._session_factory = session_factory
         self._subscriptions: dict[str, PushSubscription] = {}  # keyed by endpoint
 
     @property
     def public_key(self) -> str:
         return self._vapid_public_key
 
+    async def load_from_db(self) -> None:
+        """Load persisted subscriptions into memory. Call once at startup."""
+        if self._session_factory is None:
+            return
+        from backend.persistence.push_subscription_repo import PushSubscriptionRepository
+
+        async with self._session_factory() as session:
+            repo = PushSubscriptionRepository(session)
+            rows = await repo.list_all()
+        for row in rows:
+            self._subscriptions[row["endpoint"]] = PushSubscription(
+                endpoint=row["endpoint"], keys=row["keys"]
+            )
+        log.info("push_subscriptions_loaded", count=len(rows))
+
     def subscribe(self, subscription_info: dict[str, Any]) -> None:
-        """Register a push subscription."""
+        """Register a push subscription (cache only; use subscribe_async for persistence)."""
         endpoint = subscription_info.get("endpoint", "")
         keys = subscription_info.get("keys", {})
         if not endpoint or not keys.get("p256dh") or not keys.get("auth"):
@@ -52,10 +76,39 @@ class PushService:
         self._subscriptions[endpoint] = PushSubscription(endpoint=endpoint, keys=keys)
         log.info("push_subscribed", endpoint=endpoint, total=len(self._subscriptions))
 
+    async def subscribe_async(self, subscription_info: dict[str, Any]) -> None:
+        """Register a push subscription with DB persistence."""
+        endpoint = subscription_info.get("endpoint", "")
+        keys = subscription_info.get("keys", {})
+        if not endpoint or not keys.get("p256dh") or not keys.get("auth"):
+            log.warning("push_subscribe_invalid", endpoint=endpoint if endpoint else "empty")
+            return
+        self._subscriptions[endpoint] = PushSubscription(endpoint=endpoint, keys=keys)
+        if self._session_factory is not None:
+            from backend.persistence.push_subscription_repo import PushSubscriptionRepository
+
+            async with self._session_factory() as session:
+                repo = PushSubscriptionRepository(session)
+                await repo.upsert(endpoint, keys["p256dh"], keys["auth"])
+                await session.commit()
+        log.info("push_subscribed", endpoint=endpoint, total=len(self._subscriptions))
+
     def unsubscribe(self, endpoint: str) -> None:
-        """Remove a push subscription."""
+        """Remove a push subscription (cache only; use unsubscribe_async for persistence)."""
         removed = self._subscriptions.pop(endpoint, None)
         if removed:
+            log.info("push_unsubscribed", endpoint=endpoint, total=len(self._subscriptions))
+
+    async def unsubscribe_async(self, endpoint: str) -> None:
+        """Remove a push subscription with DB persistence."""
+        removed = self._subscriptions.pop(endpoint, None)
+        if removed and self._session_factory is not None:
+            from backend.persistence.push_subscription_repo import PushSubscriptionRepository
+
+            async with self._session_factory() as session:
+                repo = PushSubscriptionRepository(session)
+                await repo.delete(endpoint)
+                await session.commit()
             log.info("push_unsubscribed", endpoint=endpoint, total=len(self._subscriptions))
 
     async def notify(self, *, title: str, body: str, tag: str = "cpl", url: str = "/") -> None:
@@ -86,6 +139,15 @@ class PushService:
 
         for ep in stale:
             self._subscriptions.pop(ep, None)
+
+        # Prune stale endpoints from the database
+        if stale and self._session_factory is not None:
+            from backend.persistence.push_subscription_repo import PushSubscriptionRepository
+
+            async with self._session_factory() as session:
+                repo = PushSubscriptionRepository(session)
+                await repo.delete_many(stale)
+                await session.commit()
 
     def _send_one(self, sub: PushSubscription, payload: str) -> None:
         """Synchronous push to a single subscription (runs in executor)."""

--- a/backend/services/sharing/push_service.py
+++ b/backend/services/sharing/push_service.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 import structlog
 
 if TYPE_CHECKING:
-    from sqlalchemy.ext.asyncio import async_sessionmaker
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 log = structlog.get_logger()
 
@@ -38,7 +38,7 @@ class PushService:
         self,
         vapid_private_key: str,
         vapid_public_key: str,
-        session_factory: async_sessionmaker | None = None,
+        session_factory: async_sessionmaker[AsyncSession] | None = None,
         vapid_mailto: str = "mailto:noreply@codeplane.dev",
     ) -> None:
         self._vapid_private_key = vapid_private_key

--- a/backend/services/sharing/push_service.py
+++ b/backend/services/sharing/push_service.py
@@ -139,9 +139,13 @@ class PushService:
         import json
 
         payload = json.dumps({"title": title, "body": body, "tag": tag, "url": url})
-        stale: list[str] = []
+        stale: list[tuple[str, PushSubscription]] = []
 
-        for endpoint, sub in list(self._subscriptions.items()):
+        # Snapshot subscriptions; track captured objects to avoid pruning a
+        # freshly-refreshed endpoint that replaced the stale one mid-delivery.
+        snapshot = list(self._subscriptions.items())
+
+        for endpoint, sub in snapshot:
             try:
                 await asyncio.get_running_loop().run_in_executor(
                     None,
@@ -151,13 +155,16 @@ class PushService:
                 )
             except Exception as exc:  # noqa: BLE001
                 if _is_gone_status(exc):
-                    stale.append(endpoint)
+                    stale.append((endpoint, sub))
                     log.debug("push_subscription_expired", endpoint=endpoint)
                 else:
                     log.warning("push_send_failed", endpoint=endpoint, error=str(exc))
 
-        for ep in stale:
-            self._subscriptions.pop(ep, None)
+        for ep, captured_sub in stale:
+            # Only remove if the cache still holds the same object we delivered to;
+            # a concurrent subscribe_async may have replaced it with a fresh entry.
+            if self._subscriptions.get(ep) is captured_sub:
+                del self._subscriptions[ep]
 
         # Prune stale endpoints from the database (best-effort)
         if stale and self._session_factory is not None:
@@ -165,9 +172,10 @@ class PushService:
                 from backend.persistence.database import serialized_write
                 from backend.persistence.push_subscription_repo import PushSubscriptionRepository
 
+                stale_endpoints = [ep for ep, _ in stale]
                 async with serialized_write(self._session_factory) as session:
                     repo = PushSubscriptionRepository(session)
-                    await repo.delete_many(stale)
+                    await repo.delete_many(stale_endpoints)
             except Exception:  # noqa: BLE001
                 log.warning("push_prune_db_failed", stale_count=len(stale))
 

--- a/backend/tests/unit/test_push_service.py
+++ b/backend/tests/unit/test_push_service.py
@@ -2,11 +2,18 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 
 from backend.services.sharing.push_service import PushService, PushSubscription
+
+
+def _gone_exc(status: int = 410) -> Exception:
+    exc = Exception(f"HTTP {status}")
+    exc.response = SimpleNamespace(status_code=status)  # type: ignore[attr-defined]
+    return exc
 
 
 @pytest.fixture
@@ -94,7 +101,7 @@ class TestPushServiceNotify:
     async def test_stale_410_subscription_removed(self, svc: PushService) -> None:
         ep = "https://push.example.com/sub1"
         svc.subscribe({"endpoint": ep, "keys": {"p256dh": "a", "auth": "b"}})
-        with patch.object(svc, "_send_one", side_effect=Exception("410 Gone")):
+        with patch.object(svc, "_send_one", side_effect=_gone_exc(410)):
             await svc.notify(title="Hi", body="World")
         assert ep not in svc._subscriptions
 
@@ -102,7 +109,7 @@ class TestPushServiceNotify:
     async def test_stale_404_subscription_removed(self, svc: PushService) -> None:
         ep = "https://push.example.com/sub1"
         svc.subscribe({"endpoint": ep, "keys": {"p256dh": "a", "auth": "b"}})
-        with patch.object(svc, "_send_one", side_effect=Exception("404 Not Found")):
+        with patch.object(svc, "_send_one", side_effect=_gone_exc(404)):
             await svc.notify(title="Hi", body="World")
         assert ep not in svc._subscriptions
 

--- a/backend/tests/unit/test_push_subscription_repo.py
+++ b/backend/tests/unit/test_push_subscription_repo.py
@@ -1,6 +1,9 @@
-"""Tests for PushSubscriptionRepository — persistence round-trips."""
+"""Tests for PushSubscriptionRepository and PushService persistence."""
 
 from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
@@ -23,6 +26,28 @@ async def session_factory():
 async def session(session_factory) -> AsyncSession:
     async with session_factory() as s:
         yield s
+
+
+def _make_svc(session_factory):
+    from backend.services.sharing.push_service import PushService
+
+    return PushService(
+        vapid_private_key="k1",
+        vapid_public_key="k2",
+        session_factory=session_factory,
+    )
+
+
+def _gone_exc(status: int = 410) -> Exception:
+    """Build an exception with a structured response.status_code."""
+    exc = Exception(f"HTTP {status}")
+    exc.response = SimpleNamespace(status_code=status)  # type: ignore[attr-defined]
+    return exc
+
+
+# ---------------------------------------------------------------------------
+# Repository round-trip tests
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -74,51 +99,124 @@ class TestPushSubscriptionRepo:
         assert rows[0]["endpoint"] == "https://ep.com/1"
 
 
+# ---------------------------------------------------------------------------
+# PushService integration tests
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.asyncio
 class TestPushServiceRestart:
     """Prove subscriptions survive a simulated server restart."""
 
     async def test_subscription_survives_new_service_instance(self, session_factory) -> None:
-        from backend.services.sharing.push_service import PushService
-
-        # First "server lifetime": subscribe
-        svc1 = PushService(
-            vapid_private_key="k1",
-            vapid_public_key="k2",
-            session_factory=session_factory,
-        )
+        svc1 = _make_svc(session_factory)
         await svc1.subscribe_async({"endpoint": "https://ep.com/persist", "keys": {"p256dh": "abc", "auth": "xyz"}})
 
-        # Second "server lifetime": new instance loads from DB
-        svc2 = PushService(
-            vapid_private_key="k1",
-            vapid_public_key="k2",
-            session_factory=session_factory,
-        )
+        # New instance (simulated restart) loads from DB
+        svc2 = _make_svc(session_factory)
         await svc2.load_from_db()
         assert "https://ep.com/persist" in svc2._subscriptions
 
-    async def test_410_prunes_from_db(self, session_factory) -> None:
-        from unittest.mock import patch
 
-        from backend.services.sharing.push_service import PushService
+@pytest.mark.asyncio
+class TestPushServiceDbFirst:
+    """Verify DB-first write ordering: cache reflects only committed state."""
 
-        svc = PushService(
-            vapid_private_key="k1",
-            vapid_public_key="k2",
-            session_factory=session_factory,
-        )
+    async def test_failed_db_write_does_not_update_cache(self, session_factory) -> None:
+        svc = _make_svc(session_factory)
+
+        with (
+            patch(
+                "backend.persistence.database.serialized_write",
+                side_effect=RuntimeError("DB write failed"),
+            ),
+            pytest.raises(RuntimeError, match="DB write failed"),
+        ):
+            await svc.subscribe_async({"endpoint": "https://ep.com/ghost", "keys": {"p256dh": "a", "auth": "b"}})
+
+        # Cache must NOT contain the subscription
+        assert "https://ep.com/ghost" not in svc._subscriptions
+
+    async def test_unsubscribe_deletes_row_even_when_cache_is_cold(self, session_factory) -> None:
+        """Unsubscribe must delete the DB row even if the cache has no entry."""
+        from backend.persistence.database import serialized_write
+
+        async with serialized_write(session_factory) as session:
+            repo = PushSubscriptionRepository(session)
+            await repo.upsert("https://ep.com/orphan", "p", "a")
+
+        # Fresh service with empty cache
+        svc = _make_svc(session_factory)
+        assert "https://ep.com/orphan" not in svc._subscriptions
+
+        await svc.unsubscribe_async("https://ep.com/orphan")
+
+        # DB row must be gone
+        async with session_factory() as session:
+            repo = PushSubscriptionRepository(session)
+            rows = await repo.list_all()
+            assert len(rows) == 0
+
+
+@pytest.mark.asyncio
+class TestPushServicePrune:
+    """Stale endpoint pruning uses structured status codes."""
+
+    async def test_410_response_prunes_from_cache_and_db(self, session_factory) -> None:
+        svc = _make_svc(session_factory)
         await svc.subscribe_async({"endpoint": "https://ep.com/stale", "keys": {"p256dh": "a", "auth": "b"}})
 
-        with patch.object(svc, "_send_one", side_effect=Exception("410 Gone")):
+        with patch.object(svc, "_send_one", side_effect=_gone_exc(410)):
             await svc.notify(title="Hi", body="World")
 
         assert "https://ep.com/stale" not in svc._subscriptions
 
-        # Verify also removed from DB
         async with session_factory() as session:
-            from backend.persistence.push_subscription_repo import PushSubscriptionRepository
-
             repo = PushSubscriptionRepository(session)
             rows = await repo.list_all()
             assert len(rows) == 0
+
+    async def test_404_response_prunes(self, session_factory) -> None:
+        svc = _make_svc(session_factory)
+        await svc.subscribe_async({"endpoint": "https://ep.com/stale", "keys": {"p256dh": "a", "auth": "b"}})
+
+        with patch.object(svc, "_send_one", side_effect=_gone_exc(404)):
+            await svc.notify(title="Hi", body="World")
+
+        assert "https://ep.com/stale" not in svc._subscriptions
+
+    async def test_exception_without_response_does_not_prune(self, session_factory) -> None:
+        """Non-WebPush exceptions (no response attr) must not trigger pruning."""
+        svc = _make_svc(session_factory)
+        await svc.subscribe_async({"endpoint": "https://ep.com/keep", "keys": {"p256dh": "a", "auth": "b"}})
+
+        with patch.object(svc, "_send_one", side_effect=Exception("network timeout")):
+            await svc.notify(title="Hi", body="World")
+
+        assert "https://ep.com/keep" in svc._subscriptions
+
+    async def test_500_response_does_not_prune(self, session_factory) -> None:
+        svc = _make_svc(session_factory)
+        await svc.subscribe_async({"endpoint": "https://ep.com/keep", "keys": {"p256dh": "a", "auth": "b"}})
+
+        with patch.object(svc, "_send_one", side_effect=_gone_exc(500)):
+            await svc.notify(title="Hi", body="World")
+
+        assert "https://ep.com/keep" in svc._subscriptions
+
+    async def test_prune_db_failure_is_best_effort(self, session_factory) -> None:
+        """A DB error during prune must not break the notification path."""
+        svc = _make_svc(session_factory)
+        await svc.subscribe_async({"endpoint": "https://ep.com/stale", "keys": {"p256dh": "a", "auth": "b"}})
+
+        with (
+            patch.object(svc, "_send_one", side_effect=_gone_exc(410)),
+            patch(
+                "backend.persistence.database.serialized_write",
+                side_effect=RuntimeError("DB down"),
+            ),
+        ):
+            await svc.notify(title="Hi", body="World")
+
+        # Cache was still pruned even though DB prune failed
+        assert "https://ep.com/stale" not in svc._subscriptions

--- a/backend/tests/unit/test_push_subscription_repo.py
+++ b/backend/tests/unit/test_push_subscription_repo.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
-from backend.models.db import Base, PushSubscriptionRow
+from backend.models.db import Base
 from backend.persistence.push_subscription_repo import PushSubscriptionRepository
 
 

--- a/backend/tests/unit/test_push_subscription_repo.py
+++ b/backend/tests/unit/test_push_subscription_repo.py
@@ -1,0 +1,128 @@
+"""Tests for PushSubscriptionRepository — persistence round-trips."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from backend.models.db import Base, PushSubscriptionRow
+from backend.persistence.push_subscription_repo import PushSubscriptionRepository
+
+
+@pytest.fixture
+async def session_factory():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    yield factory
+    await engine.dispose()
+
+
+@pytest.fixture
+async def session(session_factory) -> AsyncSession:
+    async with session_factory() as s:
+        yield s
+
+
+@pytest.mark.asyncio
+class TestPushSubscriptionRepo:
+    async def test_upsert_and_list(self, session: AsyncSession) -> None:
+        repo = PushSubscriptionRepository(session)
+        await repo.upsert("https://ep.com/1", "p256dh_val", "auth_val")
+        await session.commit()
+        rows = await repo.list_all()
+        assert len(rows) == 1
+        assert rows[0]["endpoint"] == "https://ep.com/1"
+        assert rows[0]["keys"] == {"p256dh": "p256dh_val", "auth": "auth_val"}
+
+    async def test_upsert_updates_existing(self, session: AsyncSession) -> None:
+        repo = PushSubscriptionRepository(session)
+        await repo.upsert("https://ep.com/1", "old_p256dh", "old_auth")
+        await session.commit()
+        await repo.upsert("https://ep.com/1", "new_p256dh", "new_auth")
+        await session.commit()
+        rows = await repo.list_all()
+        assert len(rows) == 1
+        assert rows[0]["keys"]["p256dh"] == "new_p256dh"
+
+    async def test_delete(self, session: AsyncSession) -> None:
+        repo = PushSubscriptionRepository(session)
+        await repo.upsert("https://ep.com/1", "a", "b")
+        await session.commit()
+        deleted = await repo.delete("https://ep.com/1")
+        await session.commit()
+        assert deleted is True
+        rows = await repo.list_all()
+        assert len(rows) == 0
+
+    async def test_delete_nonexistent(self, session: AsyncSession) -> None:
+        repo = PushSubscriptionRepository(session)
+        deleted = await repo.delete("https://no-such.com/x")
+        assert deleted is False
+
+    async def test_delete_many(self, session: AsyncSession) -> None:
+        repo = PushSubscriptionRepository(session)
+        for i in range(3):
+            await repo.upsert(f"https://ep.com/{i}", "p", "a")
+        await session.commit()
+        count = await repo.delete_many(["https://ep.com/0", "https://ep.com/2"])
+        await session.commit()
+        assert count == 2
+        rows = await repo.list_all()
+        assert len(rows) == 1
+        assert rows[0]["endpoint"] == "https://ep.com/1"
+
+
+@pytest.mark.asyncio
+class TestPushServiceRestart:
+    """Prove subscriptions survive a simulated server restart."""
+
+    async def test_subscription_survives_new_service_instance(self, session_factory) -> None:
+        from backend.services.sharing.push_service import PushService
+
+        # First "server lifetime": subscribe
+        svc1 = PushService(
+            vapid_private_key="k1",
+            vapid_public_key="k2",
+            session_factory=session_factory,
+        )
+        await svc1.subscribe_async(
+            {"endpoint": "https://ep.com/persist", "keys": {"p256dh": "abc", "auth": "xyz"}}
+        )
+
+        # Second "server lifetime": new instance loads from DB
+        svc2 = PushService(
+            vapid_private_key="k1",
+            vapid_public_key="k2",
+            session_factory=session_factory,
+        )
+        await svc2.load_from_db()
+        assert "https://ep.com/persist" in svc2._subscriptions
+
+    async def test_410_prunes_from_db(self, session_factory) -> None:
+        from unittest.mock import patch
+
+        from backend.services.sharing.push_service import PushService
+
+        svc = PushService(
+            vapid_private_key="k1",
+            vapid_public_key="k2",
+            session_factory=session_factory,
+        )
+        await svc.subscribe_async(
+            {"endpoint": "https://ep.com/stale", "keys": {"p256dh": "a", "auth": "b"}}
+        )
+
+        with patch.object(svc, "_send_one", side_effect=Exception("410 Gone")):
+            await svc.notify(title="Hi", body="World")
+
+        assert "https://ep.com/stale" not in svc._subscriptions
+
+        # Verify also removed from DB
+        async with session_factory() as session:
+            from backend.persistence.push_subscription_repo import PushSubscriptionRepository
+
+            repo = PushSubscriptionRepository(session)
+            rows = await repo.list_all()
+            assert len(rows) == 0

--- a/backend/tests/unit/test_push_subscription_repo.py
+++ b/backend/tests/unit/test_push_subscription_repo.py
@@ -87,9 +87,7 @@ class TestPushServiceRestart:
             vapid_public_key="k2",
             session_factory=session_factory,
         )
-        await svc1.subscribe_async(
-            {"endpoint": "https://ep.com/persist", "keys": {"p256dh": "abc", "auth": "xyz"}}
-        )
+        await svc1.subscribe_async({"endpoint": "https://ep.com/persist", "keys": {"p256dh": "abc", "auth": "xyz"}})
 
         # Second "server lifetime": new instance loads from DB
         svc2 = PushService(
@@ -110,9 +108,7 @@ class TestPushServiceRestart:
             vapid_public_key="k2",
             session_factory=session_factory,
         )
-        await svc.subscribe_async(
-            {"endpoint": "https://ep.com/stale", "keys": {"p256dh": "a", "auth": "b"}}
-        )
+        await svc.subscribe_async({"endpoint": "https://ep.com/stale", "keys": {"p256dh": "a", "auth": "b"}})
 
         with patch.object(svc, "_send_one", side_effect=Exception("410 Gone")):
             await svc.notify(title="Hi", body="World")

--- a/frontend/src/components/SettingsScreen.tsx
+++ b/frontend/src/components/SettingsScreen.tsx
@@ -104,8 +104,8 @@ export function SettingsScreen() {
 
   // Check whether a push subscription already exists and re-register with
   // the server (subscriptions survive in the browser but the server may have
-  // restarted and lost its in-memory registry). The endpoint URL is the
-  // idempotency key on the server side, so duplicate POSTs are harmless.
+  // restarted and lost its registry). The endpoint URL is the idempotency
+  // key on the server side, so duplicate POSTs are harmless.
   useEffect(() => {
     if (!pushSupported) return;
     navigator.serviceWorker.ready
@@ -113,7 +113,10 @@ export function SettingsScreen() {
       .then((sub) => {
         setPushEnabled(sub !== null);
         if (sub) {
-          subscribePush(sub.toJSON() as PushSubscriptionJSON).catch(() => {});
+          subscribePush(sub.toJSON() as PushSubscriptionJSON).catch((err) => {
+            console.warn("Push re-registration failed; notifications may not work until next visit", err);
+            toast.error("Push re-registration failed");
+          });
         }
       })
       .catch(() => {});

--- a/frontend/src/components/SettingsScreen.tsx
+++ b/frontend/src/components/SettingsScreen.tsx
@@ -102,12 +102,20 @@ export function SettingsScreen() {
       .finally(() => setLoading(false));
   }, []);
 
-  // Check whether a push subscription already exists
+  // Check whether a push subscription already exists and re-register with
+  // the server (subscriptions survive in the browser but the server may have
+  // restarted and lost its in-memory registry). The endpoint URL is the
+  // idempotency key on the server side, so duplicate POSTs are harmless.
   useEffect(() => {
     if (!pushSupported) return;
     navigator.serviceWorker.ready
       .then((reg) => reg.pushManager.getSubscription())
-      .then((sub) => setPushEnabled(sub !== null))
+      .then((sub) => {
+        setPushEnabled(sub !== null);
+        if (sub) {
+          subscribePush(sub.toJSON() as PushSubscriptionJSON).catch(() => {});
+        }
+      })
       .catch(() => {});
   }, [pushSupported]);
 

--- a/frontend/src/components/SettingsScreen.tsx
+++ b/frontend/src/components/SettingsScreen.tsx
@@ -111,13 +111,18 @@ export function SettingsScreen() {
     navigator.serviceWorker.ready
       .then((reg) => reg.pushManager.getSubscription())
       .then((sub) => {
-        setPushEnabled(sub !== null);
-        if (sub) {
-          subscribePush(sub.toJSON() as PushSubscriptionJSON).catch((err) => {
+        if (!sub) {
+          setPushEnabled(false);
+          return;
+        }
+        // Re-register with server; only mark enabled after server confirms.
+        subscribePush(sub.toJSON() as PushSubscriptionJSON)
+          .then(() => setPushEnabled(true))
+          .catch((err) => {
             console.warn("Push re-registration failed; notifications may not work until next visit", err);
             toast.error("Push re-registration failed");
+            setPushEnabled(false);
           });
-        }
       })
       .catch(() => {});
   }, [pushSupported]);


### PR DESCRIPTION
## Problem

Web Push notifications go silently dead after every server restart while the UI still displays "push enabled."

Two verified defects:

1. **Subscriptions stored in process memory only** (`push_service.py:39`). Server restart empties the dict; the browser still has a valid `PushSubscription`, so the toggle reads "enabled" but notifications are dead with zero user-visible signal.

2. **Incomplete event coverage** in `_push_subscriber`. Only `approval_requested`, `job_completed`, `job_failed` triggered push. Missing: `batch_approval_requested`, `merge_conflict`, `job_review`, `stall_detected`.

## Changes

### Persistence layer
- New `push_subscriptions` table (migration `0066`) with `endpoint` as PK, `p256dh`, `auth_key`, timestamps.
- New `PushSubscriptionRepository` following existing `BaseRepository` pattern.
- `PushService` gains `session_factory`, loads subscriptions from DB on startup, persists all subscribe/unsubscribe/prune operations.
- API routes made async to call the persistent `subscribe_async` / `unsubscribe_async`.

### Frontend re-subscription
- `SettingsScreen.tsx` `useEffect` now re-POSTs existing browser subscription on mount. The endpoint URL is the idempotency key (upsert), so duplicate POSTs are harmless.

### Corrected docstring
- Removed false claim that "clients re-subscribe automatically via the service worker."

### Missing push events
- Added `batch_approval_requested`, `merge_conflict`, `job_review`, `stall_detected` to the push subscriber in `lifespan.py`.

### Tests
- Repository round-trip, upsert-updates, delete, delete_many.
- Restart survival: new `PushService` instance reads persisted subscriptions.
- 410 response prunes from DB.
- All 24 push-related tests pass.

## Non-goals
- No VAPID key changes.
- No notification `actions` array (separate effort).
- No auth/device-identity model.