### PR TITLE
fix: retire flat DashboardScreen route, make /repos the single entry point

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -6,9 +6,6 @@ import { App } from "./App";
 
 // Mock heavy child components to isolate App shell behavior
 vi.mock("./hooks/useSSE", () => ({ useSSE: () => ({ reconnect: vi.fn() }) }));
-vi.mock("./components/DashboardScreen", () => ({
-  DashboardScreen: () => <div data-testid="dashboard">Dashboard</div>,
-}));
 vi.mock("./components/JobDetailScreen", () => ({
   JobDetailScreen: () => <div data-testid="job-detail">JobDetail</div>,
 }));
@@ -82,9 +79,9 @@ describe("App", () => {
     expect(screen.getByText("Reconnecting\u2026")).toBeInTheDocument();
   });
 
-  it("routes / to DashboardScreen", async () => {
+  it("routes / to /repos (retired flat DashboardScreen)", async () => {
     await renderApp("/");
-    expect(screen.getByTestId("dashboard")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByTestId("repo-layout")).toBeInTheDocument());
   });
 
   it("routes /jobs/new to JobCreationScreen", async () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,13 +1,12 @@
 import { Component, type ReactNode, Suspense, useEffect } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
-import { Routes, Route, Link, useNavigate, useLocation } from "react-router-dom";
+import { Routes, Route, Navigate, Link, useNavigate, useLocation } from "react-router-dom";
 import { Search, ExternalLink } from "lucide-react";
 import { modKey } from "./lib/utils";
 import { CommandPalette } from "./components/CommandPalette";
 import { NavMenuSlideout } from "./components/NavMenuSlideout";
 import { useSSE } from "./hooks/useSSE";
 import { useStore } from "./store";
-import { DashboardScreen } from "./components/DashboardScreen";
 import { ConnectionStatusIndicator } from "./components/ConnectionStatusIndicator";
 import { Spinner } from "./components/ui/spinner";
 import { lazyRetry } from "./lib/lazyRetry";
@@ -204,7 +203,7 @@ export function App() {
         <ErrorBoundary>
           <Suspense fallback={<RouteFallback />}>
             <Routes>
-              <Route path="/" element={<DashboardScreen />} />
+              <Route path="/" element={<Navigate to="/repos" replace />} />
               <Route path="/jobs/new" element={<JobCreationScreen />} />
               <Route path="/jobs/:jobId" element={<JobDetailScreen />} />
               <Route path="/history" element={<HistoryScreen />} />


### PR DESCRIPTION
## Problem

`_bmad-output/planning-artifacts/epics.md` (line 251) explicitly requires:

> The existing flat `DashboardScreen`/`KanbanBoard` is retired outright; `/repos` (Overview + per-Project board) is the single entry point.

None of the 22 Epic 2-6 stories implemented this cutover. `ProjectsOverview.tsx` (Stories 2.2/2.4/2.5) is correctly wired as `/repos`'s index view via `RepoLayout.tsx`'s `{!repoPath ? <ProjectsOverview /> : <Outlet />}`, but `App.tsx`'s root route `"/"` still rendered the old `DashboardScreen`/`KanbanBoard` — the single-board UI the entire effort was meant to replace. Opening the app landed users on the retired design; the new multi-project boards experience was only reachable by manually navigating to `/repos`.

## Fix

- `App.tsx`: `"/"` now redirects to `/repos` (`<Navigate to="/repos" replace />`) instead of rendering `<DashboardScreen />`.
- `DashboardScreen.tsx`/`KanbanBoard.tsx` are left in place (untouched) — `KanbanBoard` is reused by `RepoBoard`, and `DashboardScreen`'s own unit tests still pass standalone — just no longer routed anywhere.
- Updated `App.test.tsx`: removed the now-unused `DashboardScreen` mock, replaced the `"routes / to DashboardScreen"` test with one asserting `/` routes to the `RepoLayout` shell.

## Validation

- `App.test.tsx`: 14/14 pass
- `tsc --noEmit`: clean
- `eslint` on changed files: clean

No backend/API/schema changes.