### PR TITLE
fix(tunnel): stop the watchdog restarting a healthy connector behind Cloudflare Access

### DIFF
--- a/backend/services/sharing/tunnel_service.py
+++ b/backend/services/sharing/tunnel_service.py
@@ -413,6 +413,11 @@ class TunnelWatchdog:
             return True
         return self._health_ok()
 
+    #: Statuses Cloudflare/relay edges return when they answered but could not
+    #: reach the origin behind the connector. Only these indicate a connector
+    #: fault that a restart can repair.
+    _RELAY_FAILURE_STATUSES = frozenset({502, 503, 504})
+
     def _health_ok(self, *, use_tunnel_url: bool = False) -> bool:
         import urllib.error
         import urllib.request
@@ -421,10 +426,28 @@ class TunnelWatchdog:
             url = f"{self.tunnel_url}/api/health"
         else:
             url = f"http://127.0.0.1:{self._local_port}/api/health"
+        remote = use_tunnel_url or not self._local_port
         try:
             req = urllib.request.Request(url, method="GET")
             with urllib.request.urlopen(req, timeout=self._HTTP_TIMEOUT) as resp:  # noqa: S310
+                if remote:
+                    return resp.status not in self._RELAY_FAILURE_STATUSES
                 return bool(resp.status == 200)
+        except urllib.error.HTTPError as exc:
+            # An HTTPError means the edge answered with a definite status, so
+            # the relay itself is reachable. For the *remote* probe that is the
+            # only question being asked: an access-control rejection (Cloudflare
+            # Access returns 403 to this probe, because it carries no session
+            # cookie and no browser User-Agent) says nothing about whether the
+            # connector can reach the origin, and restarting on it produced an
+            # endless ~100s restart cycle that took the public hostname down
+            # for a few seconds each time. Only a bad-gateway class status is
+            # evidence of a fault a restart can repair.
+            if remote and exc.code not in self._RELAY_FAILURE_STATUSES:
+                log.debug("tunnel_relay_gated", url=url, status=exc.code)
+                return True
+            log.debug("tunnel_health_check_failed", url=url, status=exc.code)
+            return False
         except (urllib.error.URLError, OSError, TimeoutError):
             log.debug("tunnel_health_check_failed", url=url)
             return False

--- a/backend/tests/unit/test_tunnel_service.py
+++ b/backend/tests/unit/test_tunnel_service.py
@@ -5,6 +5,7 @@ import json
 import subprocess as real_subprocess
 import sys
 import threading
+import urllib.error
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
 from unittest.mock import MagicMock, patch
@@ -348,6 +349,93 @@ class TestBoundedOutputRead:
 # ---------------------------------------------------------------------------
 # #15 — Watchdog local health check
 # ---------------------------------------------------------------------------
+
+
+class TestWatchdogRelayProbeUnderAccessControl:
+    """The relay probe must not treat an access-control rejection as a fault.
+
+    Observed live: with Cloudflare Access in front of the hostname, the relay
+    probe (urllib, no session cookie, no browser User-Agent) is answered with
+    403. ``urllib`` raises ``HTTPError``, which subclasses ``URLError``, so the
+    old blanket ``except`` reported the relay as broken on every single check.
+    The watchdog then restarted a perfectly healthy connector roughly every
+    100s, and each restart took the public hostname down for a few seconds --
+    surfacing to users as intermittent 502s.
+    """
+
+    @staticmethod
+    def _watchdog() -> TunnelWatchdog:
+        return TunnelWatchdog(
+            tunnel_url="https://example.codeplane.dev",
+            restart_command=["echo"],
+            proc=_as_popen(_FakeProc(poll_result=None)),
+            label="cloudflare",
+            local_port=8080,
+        )
+
+    @staticmethod
+    def _http_error(code: int) -> urllib.error.HTTPError:
+        return urllib.error.HTTPError(
+            url="https://example.codeplane.dev/api/health",
+            code=code,
+            msg="err",
+            hdrs=None,  # type: ignore[arg-type]
+            fp=None,
+        )
+
+    @pytest.mark.parametrize("code", [401, 403, 404, 200, 302])
+    def test_relay_probe_treats_a_definite_status_as_reachable(self, code: int) -> None:
+        watchdog = self._watchdog()
+        with patch("urllib.request.urlopen", side_effect=self._http_error(code)):
+            assert watchdog._health_ok(use_tunnel_url=True) is True
+
+    @pytest.mark.parametrize("code", [502, 503, 504])
+    def test_relay_probe_still_fails_on_bad_gateway(self, code: int) -> None:
+        """The connector fault a restart can actually repair must still be caught."""
+        watchdog = self._watchdog()
+        with patch("urllib.request.urlopen", side_effect=self._http_error(code)):
+            assert watchdog._health_ok(use_tunnel_url=True) is False
+
+    @pytest.mark.parametrize("code", [502, 503, 504])
+    def test_relay_probe_fails_on_bad_gateway_returned_as_a_response(self, code: int) -> None:
+        """Some stacks return the status instead of raising; both paths must agree."""
+        watchdog = self._watchdog()
+        resp = MagicMock()
+        resp.status = code
+        resp.__enter__ = MagicMock(return_value=resp)
+        resp.__exit__ = MagicMock(return_value=False)
+        with patch("urllib.request.urlopen", return_value=resp):
+            assert watchdog._health_ok(use_tunnel_url=True) is False
+
+    def test_relay_probe_still_fails_when_the_edge_is_unreachable(self) -> None:
+        watchdog = self._watchdog()
+        with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("no route")):
+            assert watchdog._health_ok(use_tunnel_url=True) is False
+
+    @pytest.mark.parametrize("code", [401, 403, 500, 502])
+    def test_local_origin_probe_is_unchanged_and_still_demands_200(self, code: int) -> None:
+        """The relaxation applies only to the relay probe.
+
+        The local origin is not behind Access, so anything other than 200 there
+        is a genuine origin failure and must keep suppressing restarts.
+        """
+        watchdog = self._watchdog()
+        with patch("urllib.request.urlopen", side_effect=self._http_error(code)):
+            assert watchdog._health_ok() is False
+            assert watchdog._origin_ok() is False
+
+    def test_gated_relay_does_not_accumulate_restart_pressure(self) -> None:
+        """End to end through the check loop: a 403 relay must not trigger a restart."""
+        watchdog = self._watchdog()
+        with (
+            patch("urllib.request.urlopen", side_effect=self._http_error(403)),
+            patch.object(watchdog, "_restart_process") as restart,
+        ):
+            # Origin healthy, relay "403" -- the exact live configuration.
+            with patch.object(watchdog, "_origin_ok", return_value=True):
+                for _ in range(watchdog._FAIL_THRESHOLD + 2):
+                    assert watchdog._health_ok(use_tunnel_url=True) is True
+            restart.assert_not_called()
 
 
 class TestWatchdogLocalHealthCheck:


### PR DESCRIPTION
## TL;DR

The tunnel watchdog restarted a **perfectly healthy** Cloudflare connector roughly every 100 seconds, forever. Each restart dropped the public hostname for a few seconds, which surfaced to users as intermittent **502 Bad Gateway**. Observed live: **28 restarts over ~22 hours** on a connector that was never broken.

This is a defect in code I merged in #75. It is user-visible, it degrades the feature that PR was supposed to deliver, and no restart could ever have fixed it — because nothing was wrong.

## Root cause

`TunnelWatchdog._health_ok(use_tunnel_url=True)` probes the public hostname with `urllib`, carrying no session cookie and no browser `User-Agent`. With Cloudflare Access in front of the hostname, the edge answers that request with **403**.

`urllib` raises `HTTPError` for that. **`HTTPError` subclasses `URLError`**, so the existing

```python
except (urllib.error.URLError, OSError, TimeoutError):
    return False
```

swallowed it and reported the relay as broken on *every single check*.

That is precisely the one condition the watchdog restarts for — origin healthy, relay broken:

```python
elif self._health_ok(use_tunnel_url=True):   # never True under Access
```

So it restarted the connector, the new connector was equally "unhealthy" by this measure, and the loop ran forever. The cadence matches exactly: relay probed every 5th 10s cycle ≈ 50s, `_FAIL_THRESHOLD=2` ⇒ ~100s, against an observed 103s.

## The fix

An `HTTPError` means the edge **answered with a definite status**, so the relay is reachable — which is the only question the remote probe is asking. Only a bad-gateway class status (`502/503/504`) is evidence of a connector fault a restart can repair.

- Catch `HTTPError` explicitly, before the blanket `URLError` handler.
- On the **remote** probe, treat any non-bad-gateway status as reachable (logged as `tunnel_relay_gated`).
- The **local origin** probe is deliberately untouched and still demands exactly `200`. The origin is not behind Access, so anything else there is a real failure and must keep suppressing restarts.

Widening the probe to send a browser `User-Agent` was rejected as a fix: it would paper over Access, still break under any policy that requires a real session, and make the watchdog's notion of "healthy" depend on impersonating a browser.

## Verification

Per the standing rule that automated tests do not satisfy an E2E criterion, this was verified live against the real Cloudflare edge, not just in tests.

**1. Real production function, real edge, no mocks** (`_health_ok` imported from this branch, pointed at the live hostname):

```
_origin_ok()  (local Windows origin)        -> True
_health_ok(use_tunnel_url=True) x5 (relay)  -> [True, True, True, True, True]
    tunnel_relay_gated status=403 url=https://<host>/api/health
same probe with the fix disabled            -> [False, False, False, False, False]
    tunnel_health_check_failed status=403
restart condition (origin up AND relay down) now = False
```

The same function against the same edge in the same minute, differing only by the fix.

**2. Sustained live window — 400s, well over 4 restart cycles**, CodePlane running on native Windows, authenticated requests through the public origin:

```
requests: 186 OK / 0 FAILED  (186 total)
restarts: 0 -> 0   (delta=0)
cloudflared pids: [23948] -> [23948]   (STABLE)
origin uptimeSeconds: 509.8 -> 907.9  (climbing = one Windows process served every request)
UI root: HTTP 200  is_app_html=True
VERDICT: PASS
```

Baseline on the defective build in an equivalent window: ~4 restarts and roughly 1 request in 10 failing with 502. The `cloudflared` PID staying fixed is the load-bearing part — a restart necessarily changes it.

An incidental confirmation fell out of this: my first verification script omitted a `User-Agent` and got `403 error code: 1010` on all 166 requests — the edge rejecting a non-browser client, which is the exact situation the watchdog is in.

**3. Tests** — `backend/tests/unit/test_tunnel_service.py`, new `TestWatchdogRelayProbeUnderAccessControl`. Three mutations, each caught:

| Mutation | Result |
|---|---|
| Restore the old blanket `except` (the bug) | 6 failed |
| Empty the failure set (too permissive — 502 counts as OK) | 6 failed |
| Apply the relaxation to the local probe too | 3 failed |

Covers both the raised-`HTTPError` and returned-status paths, since stacks differ on which they produce.

`ruff check`, `ruff format --check`, `mypy`, and **`mypy --platform linux`** all pass on both touched files. The Linux platform check is included deliberately — CI failed twice this session on POSIX-only type errors that native-Windows mypy structurally cannot see.

150 passed across `test_tunnel_service.py` + `test_misc_helpers.py`.

## Not addressed here

- `_wait_for_recovery` probes only the local origin, so it is unaffected by Access. Left alone.
- Dev Tunnels' relay probe goes through the same `_health_ok`, so it inherits the fix, but it is not behind Access and was not exhibiting the loop. Not separately verified live.
