### PR TITLE
fix: detect existing cloudflared connector via TUNNEL_TOKEN env var

### DIFF
--- a/backend/services/sharing/tunnel_service.py
+++ b/backend/services/sharing/tunnel_service.py
@@ -1059,10 +1059,22 @@ def _cloudflared_already_running(token: str) -> bool:
             if pid == our_pid or pid in our_descendants:
                 continue
             cmdline = " ".join(proc.info.get("cmdline") or ())
-            if not any(marker in cmdline for marker in markers):
-                log.debug("cloudflared_foreign_connector_ignored", pid=pid)
-                continue
-            return True
+            if any(marker in cmdline for marker in markers):
+                return True
+            # The token-run invocation we use (``cloudflared tunnel run``)
+            # carries the token via the ``TUNNEL_TOKEN`` env var, not argv —
+            # so a cmdline-only check never matches it and every restart
+            # spawns a duplicate connector, leaving the previous one
+            # orphaned (Cloudflare's edge then load-balances across both
+            # until the stale one's heartbeat lapses, causing intermittent
+            # 502s in the interim). Check the env var too.
+            try:
+                env_token = proc.environ().get("TUNNEL_TOKEN")
+            except (psutil.Error, OSError):
+                env_token = None
+            if env_token and any(marker in env_token for marker in markers):
+                return True
+            log.debug("cloudflared_foreign_connector_ignored", pid=pid)
         except (psutil.Error, OSError):
             continue
     return False

--- a/backend/tests/unit/test_tunnel_service.py
+++ b/backend/tests/unit/test_tunnel_service.py
@@ -1323,13 +1323,23 @@ class TestCloudflaredDetectionIsPortable:
     TOKEN = base64.b64encode(json.dumps({"a": "acct", "t": "tunnel-uuid", "s": "secret"}).encode()).decode()
 
     @classmethod
-    def _proc(cls, pid: int, name: str, cmdline: list[str] | None = None) -> object:
+    def _proc(
+        cls,
+        pid: int,
+        name: str,
+        cmdline: list[str] | None = None,
+        environ: dict[str, str] | None = None,
+    ) -> object:
         stub = MagicMock()
         stub.info = {
             "pid": pid,
             "name": name,
             "cmdline": cmdline if cmdline is not None else ["cloudflared", "tunnel", "run", "--token", cls.TOKEN],
         }
+        # Real connectors (``cloudflared tunnel run``) carry the token via the
+        # TUNNEL_TOKEN env var rather than argv; default to no env match so
+        # tests exercising cmdline-only matching stay unaffected.
+        stub.environ.return_value = environ if environ is not None else {}
         return stub
 
     def test_detects_windows_executable_name(self) -> None:
@@ -1410,6 +1420,56 @@ class TestCloudflaredDetectionIsPortable:
             patch.object(psutil, "process_iter", return_value=[self._proc(555, "cloudflared")]),
             patch.object(psutil, "Process", return_value=parent),
             patch.object(os, "getpid", return_value=111),
+        ):
+            assert _cloudflared_already_running(self.TOKEN) is False
+
+    def test_detects_a_token_run_connector_via_its_env_var(self) -> None:
+        """``_start_cloudflare`` spawns ``cloudflared tunnel run`` with the token
+        passed via the ``TUNNEL_TOKEN`` env var, not argv. Before this fix,
+        cmdline-only matching never recognized such a connector as ours, so
+        every ``cpl up --remote --provider cloudflare`` spawned a duplicate
+        connector alongside it. Cloudflare's edge then load-balanced across
+        both, causing intermittent 502s against the orphaned one until its
+        heartbeat lapsed.
+        """
+        import psutil
+
+        proc = self._proc(
+            999,
+            "cloudflared.exe",
+            cmdline=["cloudflared", "tunnel", "--no-autoupdate", "run"],
+            environ={"TUNNEL_TOKEN": self.TOKEN},
+        )
+        with (
+            patch.object(psutil, "process_iter", return_value=[proc]),
+            patch.object(psutil, "Process", side_effect=psutil.NoSuchProcess(1)),
+        ):
+            assert _cloudflared_already_running(self.TOKEN) is True
+
+    def test_ignores_a_token_run_connector_for_a_different_tunnel_via_env(self) -> None:
+        import psutil
+
+        other = base64.b64encode(json.dumps({"a": "b", "t": "someone-else", "s": "x"}).encode()).decode()
+        proc = self._proc(
+            999,
+            "cloudflared.exe",
+            cmdline=["cloudflared", "tunnel", "--no-autoupdate", "run"],
+            environ={"TUNNEL_TOKEN": other},
+        )
+        with (
+            patch.object(psutil, "process_iter", return_value=[proc]),
+            patch.object(psutil, "Process", side_effect=psutil.NoSuchProcess(1)),
+        ):
+            assert _cloudflared_already_running(self.TOKEN) is False
+
+    def test_ignores_a_connector_whose_environ_is_unreadable(self) -> None:
+        import psutil
+
+        proc = self._proc(999, "cloudflared.exe", cmdline=["cloudflared", "tunnel", "--no-autoupdate", "run"])
+        proc.environ.side_effect = psutil.AccessDenied(999)
+        with (
+            patch.object(psutil, "process_iter", return_value=[proc]),
+            patch.object(psutil, "Process", side_effect=psutil.NoSuchProcess(1)),
         ):
             assert _cloudflared_already_running(self.TOKEN) is False
 


### PR DESCRIPTION
## Problem
When restarting \cpl up --remote --provider cloudflare\, \_cloudflared_already_running\ failed to detect the already-running connector because \_start_cloudflare\ launches it as \cloudflared tunnel --no-autoupdate run\ with the tunnel token passed via the \TUNNEL_TOKEN\ **environment variable**, not argv/cmdline. Detection only ever inspected \cmdline\, so it always concluded no connector was running and spawned a duplicate on every restart.

Cloudflare's edge load-balances across every connector registered for a tunnel, so for roughly a minute after a restart, some requests routed to the orphaned/dying connector (502 Bad Gateway) while others hit the new healthy one (200) — until the stale connector's heartbeat lapsed and it dropped off the edge. This reproduced live: after several \cpl up\ restarts while debugging a hostname/Access config issue, \https://<tunnel-hostname>/...\ intermittently 502'd for about a minute, then became consistently healthy once the stale connector expired.

## Fix
\_cloudflared_already_running\ now also reads each candidate cloudflared process's \TUNNEL_TOKEN\ env var (via \psutil.Process.environ()\) and matches it against the same token/tunnel-UUID markers already used for cmdline matching, with a safe fallback to no-match if the environment can't be read (e.g. \AccessDenied\).

## Testing
- Added 3 new unit tests covering: detecting a token-run connector via env var, ignoring a token-run connector for a different tunnel via env var, and ignoring a connector whose environ is unreadable.
- \pytest backend/tests/unit/test_tunnel_service.py\: 90 passed.
- \uff check\, \uff format --check\, \mypy\: clean on both changed files.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>